### PR TITLE
feat: add request tracing and correlation IDs (#483)

### DIFF
--- a/packages/core/src/server/http-server.ts
+++ b/packages/core/src/server/http-server.ts
@@ -8,6 +8,7 @@
  */
 
 import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';
+import { randomUUID } from 'node:crypto';
 import { existsSync, readFileSync } from 'node:fs';
 import { join as pathJoin, resolve as pathResolve, dirname, basename, normalize, isAbsolute } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -621,6 +622,10 @@ export function startHttpServer(opts: ServeOptions = {}): Server {
   }
 
   const server = createServer(async (req, res) => {
+    // #483: Request tracing — generate or preserve request ID
+    const requestId = (req.headers['x-request-id'] as string) || randomUUID();
+    res.setHeader('X-Request-Id', requestId);
+
     // CORS preflight
     if (req.method === 'OPTIONS') {
       res.writeHead(204, {


### PR DESCRIPTION
Closes #483

## Changes

- Generate UUID v4 for each incoming request (via crypto.randomUUID)
- Preserve incoming x-request-id header if present (not overwritten)
- Return x-request-id in every response for client-side debugging
- Uses Node.js crypto module — no external dependencies
- Enables correlation of logs and client reports to specific requests

## Future work
- Full structured logger integration (pass requestId into log entries) will be done as part of #486 (structured logger migration)

## Testing
- 472 pass, 12 skip (unchanged)