### PR TITLE
refactor: migrate operational console.* calls to structured logger (#486)

### DIFF
--- a/packages/core/src/server/eval-server.ts
+++ b/packages/core/src/server/eval-server.ts
@@ -12,6 +12,9 @@ import { createSqliteStore } from '../persist/sqlite.js';
 import { createFtsSearch } from '../search/fts.js';
 import { loadRegistry } from '../mcp/registry.js';
 import { execFileSync } from 'node:child_process';
+import { createLogger } from '../logging/logger.js';
+
+const log = createLogger({ level: 'info' });
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -341,7 +344,7 @@ export function startEvalServer(opts: EvalServerOptions = {}): Server {
       idleTimer = setTimeout(() => {
         const elapsed = (Date.now() - lastRequestTime) / 1000;
         if (elapsed >= idleTimeout) {
-          console.error(`Eval server: idle timeout (${idleTimeout}s) reached, shutting down.`);
+          log.info('Eval server idle timeout reached, shutting down', { idleTimeout, elapsed: Math.round(elapsed) });
           shutdownEvalServer();
           server.close();
         }
@@ -406,8 +409,7 @@ export function startEvalServer(opts: EvalServerOptions = {}): Server {
   });
 
   server.listen(port, host, () => {
-    console.error(`Astrolabe eval server listening on http://${host}:${port}`);
-    console.error(`Idle timeout: ${idleTimeout}s`);
+    log.info('Eval server started', { host, port, idleTimeout });
   });
 
   // Start idle timer

--- a/packages/core/src/wiki/index.ts
+++ b/packages/core/src/wiki/index.ts
@@ -11,6 +11,9 @@ import { join } from 'node:path';
 import { execSync, execFileSync } from 'node:child_process';
 import type { KnowledgeGraph } from '../core/types.js';
 import { generateHtmlViewer } from './html-viewer.js';
+import { createLogger } from '../logging/logger.js';
+
+const log = createLogger({ level: 'info' });
 export { generateHtmlViewer } from './html-viewer.js';
 
 export interface WikiMeta {
@@ -133,7 +136,7 @@ function callLlm(prompt: string, opts: WikiOptions, moduleName: string): Promise
     .catch((e) => {
       clearTimeout(timeout);
       if ((e as Error).name === 'AbortError') {
-        console.warn(`[wiki] LLM call timed out for "${moduleName}"`);
+        log.warn('LLM call timed out', { moduleName });
       }
       return '';
     });
@@ -359,7 +362,7 @@ export async function generateWiki(opts: WikiOptions): Promise<WikiResult> {
       }
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
-      console.warn(`[wiki] Gist publishing failed: ${msg}`);
+      log.warn('Gist publishing failed', { error: msg });
     }
   }
 


### PR DESCRIPTION
Closes #486

## Changes

- eval-server.ts: 3 console.error calls migrated to structured log.info/warn
- wiki/index.ts: 2 console.warn calls migrated to structured log.warn  
- Both modules now use scoped logger via createLogger({ level: 'info' })
- Log entries include structured data (host, port, idleTimeout, moduleName, error)

## Preserved (not migrated)
- wiki/index.ts: console.log calls are user-facing status messages (review mode, incremental, Gist URL)
- hooks/index.ts: all console.error calls are in hook script templates (run in Claude Code terminal)
- cli/index.ts: console.log calls are user-facing CLI output (separate concern)

## Testing
- 472 pass, 12 skip (unchanged)