### PR TITLE
feat: CI failure notifications and Node version matrix (#490, #491)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - run: npm run build --workspace packages/shared
       - run: npm test -- --coverage
       - name: Upload coverage
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '20'
         uses: actions/upload-artifact@v4
         with:
           name: coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,17 +40,18 @@ jobs:
         run: npm audit --audit-level=critical --omit=dev
 
   unit-test:
-    name: Unit Tests (${{ matrix.os }})
+    name: Unit Tests (${{ matrix.os }}, Node ${{ matrix.node-version }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
+        node-version: ['18', '20', '22']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - run: npm ci
       - run: npm run build --workspace packages/shared
@@ -125,4 +126,33 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: `## Coverage Report\n\n${coverageText}\n\nTests: ${context.payload.pull_request ? 'PR checks passed' : 'N/A'}`,
+            });
+
+  notify-failure:
+    name: Notify on Failure
+    runs-on: ubuntu-latest
+    needs: [unit-test, integration-test, coverage-report]
+    if: failure() && always()
+    permissions:
+      issues: write
+    steps:
+      - name: Create issue on CI failure
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const branch = context.ref.replace('refs/heads/', '');
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `CI failed: ${context.workflow} #${context.runNumber}`,
+              body: [
+                `**Workflow**: ${context.workflow}`,
+                `**Branch**: ${branch}`,
+                `**Run**: ${runUrl}`,
+                `**Trigger**: ${context.eventName}`,
+                '',
+                `@${context.actor} — please investigate.`,
+              ].join('\n'),
+              labels: ['bug'],
             });

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -152,3 +152,31 @@ jobs:
           **Contributors**: ${CONTRIBUTORS}
           NOTESEOF
           )"
+
+  # ── Notify on failure ──────────────────────────────────────────────────
+  notify-failure:
+    name: Notify on Failure
+    runs-on: ubuntu-latest
+    needs: [test, release-candidate]
+    if: failure() && always()
+    permissions:
+      issues: write
+    steps:
+      - name: Create issue on RC failure
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `RC pipeline failed: ${context.workflow} #${context.runNumber}`,
+              body: [
+                `**Workflow**: ${context.workflow}`,
+                `**Branch**: staging`,
+                `**Run**: ${runUrl}`,
+                '',
+                `@${context.actor} — RC pipeline failure blocks deployment.`,
+              ].join('\n'),
+              labels: ['bug'],
+            });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,3 +231,31 @@ jobs:
           gh release create "$TAG" \
             --title "Release ${TAG}" \
             --notes-file "$NOTES_FILE"
+
+  # ── Notify on failure ──────────────────────────────────────────────────
+  notify-failure:
+    name: Notify on Failure
+    runs-on: ubuntu-latest
+    needs: [check, integration-test, release]
+    if: failure() && always()
+    permissions:
+      issues: write
+    steps:
+      - name: Create issue on release failure
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Release pipeline failed: ${context.workflow} #${context.runNumber}`,
+              body: [
+                `**Workflow**: ${context.workflow}`,
+                `**Branch**: main`,
+                `**Run**: ${runUrl}`,
+                '',
+                `@${context.actor} — Release pipeline failure requires immediate attention.`,
+              ].join('\n'),
+              labels: ['bug'],
+            });

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "clean": "npm run clean --workspaces --if-present",
     "postinstall": "node scripts/postinstall.mjs"
   },
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "license": "MIT",
   "keywords": [
     "code-analysis",


### PR DESCRIPTION
## Summary

- Add Node 18/20/22 version matrix to CI unit tests (6 parallel runs: 2 OS x 3 Node)
- Add auto-issue creation on CI/RC/Release pipeline failures with workflow name, branch, run link
- Add engines field to root package.json enforcing Node >= 18.0.0

## Changes

- .github/workflows/ci.yml � Node matrix + notify-failure job
- .github/workflows/rc.yml � notify-failure job
- .github/workflows/release.yml � notify-failure job
- package.json � engines field

Closes #490
Closes #491
