### PR TITLE
feat: custom error type hierarchy for API responses (#487)

### DIFF
--- a/packages/core/src/server/http-server.ts
+++ b/packages/core/src/server/http-server.ts
@@ -19,6 +19,7 @@ import { loadRegistry } from '../mcp/registry.js';
 import { loadMeta } from '../analysis/meta.js';
 import { JobManager, type AnalyzeJob, type AnalyzeJobProgress } from './analyze-job.js';
 import { chat as ragChat, type ChatMessage } from '../agent/rag-chat.js';
+import { isAstrolabeError } from '@astrolabe/shared';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -147,6 +148,15 @@ function error(res: ServerResponse, message: string, status = 400) {
   json(res, { error: message }, status);
 }
 
+/** Handle thrown errors — AstrolabeError produces structured response, others return 500 */
+function handleError(res: ServerResponse, err: unknown) {
+  if (isAstrolabeError(err)) {
+    json(res, err.toJSON(), err.statusCode);
+  } else {
+    json(res, { error: err instanceof Error ? err.message : String(err), code: 'INTERNAL_ERROR' }, 500);
+  }
+}
+
 // #471: Body size limit to prevent DoS (10 MB, same as MCP transport)
 const MAX_BODY_SIZE = 10 * 1024 * 1024;
 
@@ -209,7 +219,7 @@ async function handleContext(res: ServerResponse, repoName: string) {
       metaStale: meta ? meta.lastCommit !== entry.lastCommit : null,
     });
   } catch (err) {
-    error(res, `Failed to read repo: ${(err as Error).message}`, 500);
+    handleError(res, err);
   }
 }
 
@@ -233,7 +243,7 @@ async function handleClusters(res: ServerResponse, repoName: string) {
     }
     json(res, { clusters });
   } catch (err) {
-    error(res, String(err), 500);
+    handleError(res, err);
   }
 }
 
@@ -292,7 +302,7 @@ async function handleGraph(res: ServerResponse, repoName: string, clusterId?: st
 
     json(res, { nodes, edges, nodeCount: nodes.length, edgeCount: edges.length });
   } catch (err) {
-    error(res, String(err), 500);
+    handleError(res, err);
   }
 }
 
@@ -310,7 +320,7 @@ async function handleQuery(res: ServerResponse, repoName: string, params: Record
     const results = ctx.fts.search(query, limit);
     json(res, { results: results.map((r) => ({ label: r.label, name: r.name, filePath: r.filePath, rank: r.score })) });
   } catch (err) {
-    error(res, String(err), 500);
+    handleError(res, err);
   }
 }
 
@@ -358,7 +368,7 @@ async function handleImpact(res: ServerResponse, repoName: string, params: Recor
 
     json(res, { results });
   } catch (err) {
-    error(res, String(err), 500);
+    handleError(res, err);
   }
 }
 
@@ -422,7 +432,7 @@ async function handleGrep(res: ServerResponse, repoName: string, pattern: string
 
     json(res, { matches: results.length, results });
   } catch (err) {
-    error(res, String(err), 500);
+    handleError(res, err);
   }
 }
 
@@ -617,7 +627,7 @@ async function handleGraphStream(res: ServerResponse, repoName: string) {
     res.end();
   } catch (err) {
     if (!res.headersSent) {
-      error(res, String(err), 500);
+      handleError(res, err);
     } else {
       try { res.write(JSON.stringify({ type: 'error', error: String(err) }) + '\n'); } catch { /* best effort */ }
       res.end();
@@ -645,7 +655,7 @@ async function handleChat(res: ServerResponse, params: Record<string, unknown>) 
     const result = await ragChat(messages, { repo });
     json(res, result);
   } catch (err: any) {
-    error(res, err.message, 500);
+    handleError(res, err);
   }
 }
 
@@ -792,7 +802,7 @@ export function startHttpServer(opts: ServeOptions = {}): Server {
       // 404
       error(res, `Not found: ${req.method} ${path}`, 404);
     } catch (err) {
-      error(res, String(err), 500);
+      handleError(res, err);
     }
   });
 

--- a/packages/shared/src/errors.ts
+++ b/packages/shared/src/errors.ts
@@ -1,0 +1,121 @@
+/**
+ * Astrolabe Error Hierarchy — structured error types for API responses.
+ *
+ * Base class `AstrolabeError` carries a machine-readable code, HTTP status,
+ * and optional details. Domain-specific subclasses provide semantic meaning
+ * so API consumers can handle specific failure modes programmatically.
+ *
+ * @module errors
+ */
+
+// ── Base Error ──────────────────────────────────────────────────────────────
+
+export class AstrolabeError extends Error {
+  /** Machine-readable error code (e.g. 'PARSE_001') */
+  readonly code: string;
+  /** HTTP status code */
+  readonly statusCode: number;
+  /** Arbitrary structured details for debugging */
+  readonly details?: Record<string, unknown>;
+
+  constructor(
+    message: string,
+    code: string,
+    statusCode: number = 500,
+    details?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = 'AstrolabeError';
+    this.code = code;
+    this.statusCode = statusCode;
+    if (details) this.details = details;
+  }
+
+  /** Serialize for JSON API responses */
+  toJSON(): Record<string, unknown> {
+    return {
+      error: this.message,
+      code: this.code,
+      ...(this.details ? { details: this.details } : {}),
+    };
+  }
+}
+
+// ── Domain-Specific Errors ─────────────────────────────────────────────────
+
+/** Tree-sitter parsing failures */
+export class ParseError extends AstrolabeError {
+  constructor(
+    message: string,
+    code: string = 'PARSE_001',
+    details?: Record<string, unknown>,
+  ) {
+    super(message, code, 422, details);
+    this.name = 'ParseError';
+  }
+}
+
+/** Graph construction / query failures */
+export class GraphError extends AstrolabeError {
+  constructor(
+    message: string,
+    code: string = 'GRAPH_001',
+    details?: Record<string, unknown>,
+  ) {
+    super(message, code, 500, details);
+    this.name = 'GraphError';
+  }
+}
+
+/** Invalid search queries or bad user input */
+export class QueryError extends AstrolabeError {
+  constructor(
+    message: string,
+    code: string = 'QUERY_001',
+    details?: Record<string, unknown>,
+  ) {
+    super(message, code, 400, details);
+    this.name = 'QueryError';
+  }
+}
+
+/** Repo / symbol not found */
+export class NotFoundError extends AstrolabeError {
+  constructor(
+    message: string,
+    code: string = 'NOT_FOUND',
+    details?: Record<string, unknown>,
+  ) {
+    super(message, code, 404, details);
+    this.name = 'NotFoundError';
+  }
+}
+
+/** Analysis pipeline failures */
+export class AnalysisError extends AstrolabeError {
+  constructor(
+    message: string,
+    code: string = 'ANALYSIS_001',
+    details?: Record<string, unknown>,
+  ) {
+    super(message, code, 500, details);
+    this.name = 'AnalysisError';
+  }
+}
+
+/** Configuration issues (invalid env vars, missing config) */
+export class ConfigError extends AstrolabeError {
+  constructor(
+    message: string,
+    code: string = 'CONFIG_001',
+    details?: Record<string, unknown>,
+  ) {
+    super(message, code, 400, details);
+    this.name = 'ConfigError';
+  }
+}
+
+/** Type guard — checks if an error is an AstrolabeError */
+export function isAstrolabeError(err: unknown): err is AstrolabeError {
+  return err instanceof AstrolabeError;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -23,3 +23,14 @@ export {
   isRelativeImport,
   appDataDir,
 } from './path-utils.js';
+
+export {
+  AstrolabeError,
+  ParseError,
+  GraphError,
+  QueryError,
+  NotFoundError,
+  AnalysisError,
+  ConfigError,
+  isAstrolabeError,
+} from './errors.js';


### PR DESCRIPTION
## Summary

Creates a structured error type hierarchy in @astrolabe/shared for use across all packages, and updates the HTTP server to return structured error responses with machine-readable codes.

## Changes

### New: packages/shared/src/errors.ts`n- AstrolabeError base class with code, statusCode, details, 	oJSON()`n- Domain-specific subclasses: ParseError (422), GraphError (500), QueryError (400), NotFoundError (404), AnalysisError (500), ConfigError (400)
- isAstrolabeError() type guard

### Updated: packages/core/src/server/http-server.ts`n- New handleError() function checks instanceof AstrolabeError for structured responses
- All 9 catch blocks that returned generic 500 now use handleError()`n- Non-AstrolabeError throws still return {error, code: 'INTERNAL_ERROR'} with status 500

### Updated: packages/shared/src/index.ts`n- Re-exports all error types and isAstrolabeError`n
Closes #487
