### PR TITLE
feat: add npm publish step to release pipeline (#489)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,6 +175,18 @@ jobs:
             git push origin main
           }
 
+      # ── Publish to npm ────────────────────────────────────────────────────
+      - name: Build CLI package
+        run: |
+          npm run build --workspace packages/shared
+          npm run build --workspace packages/core
+          npm run build --workspace packages/cli
+
+      - name: Publish @astrolabe/cli to npm
+        run: npm publish --workspace packages/cli --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       # ── GitHub release ──────────────────────────────────────────────────
       - name: Generate release notes
         id: notes

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,6 +12,9 @@
     "dist",
     "!dist/**/*.test.*"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch",


### PR DESCRIPTION
## Summary

Adds npm publishing to the release pipeline so 
pm install -g @astrolabe/cli works after releases.

## Changes

### .github/workflows/release.yml`n- New Publish @astrolabe/cli to npm step after version bump
- Builds shared + core + cli workspaces before publish
- Uses NPM_TOKEN secret for authentication

### .npmrc (new)
- Configures npm auth via NODE_AUTH_TOKEN env var

### packages/cli/package.json`n- Added publishConfig.access: 'public' (scoped packages default to restricted)

## Prerequisites

Before merging, the repository owner needs to:
1. Create an npm automation access token
2. Add it as NPM_TOKEN secret in GitHub repo settings

Closes #489
