### PR TITLE
docs: add CHANGELOG.md with auto-update in release pipeline (#493)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# Stable Release Pipeline — fires on every push to main.
+﻿# Stable Release Pipeline — fires on every push to main.
 # Calculates the stable version from the latest RC, builds Docker image
 # with stable + latest tags, publishes to GHCR, signs with Cosign,
 # creates a GitHub release with auto-generated release notes.
@@ -186,6 +186,34 @@ jobs:
         run: npm publish --workspace packages/cli --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # ── Update CHANGELOG.md ───────────────────────────────────────────────
+      - name: Update CHANGELOG.md
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="v${VERSION}"
+          NOTES=$(node scripts/release-notes.mjs)
+
+          # Prepend new entry to CHANGELOG.md
+          HEADER="## [${VERSION}] — $(date +%Y-%m-%d)"
+          TEMP=$(mktemp)
+          {
+            echo "# Changelog"
+            echo ""
+            echo "${HEADER}"
+            echo ""
+            echo "${NOTES}"
+            echo ""
+            # Skip the first 2 lines (title + blank) of existing changelog
+            tail -n +3 CHANGELOG.md
+          } > "${TEMP}"
+          mv "${TEMP}" CHANGELOG.md
+
+          git add CHANGELOG.md
+          git diff --cached --quiet && echo "No CHANGELOG changes" || {
+            git commit -m "docs: update CHANGELOG for ${TAG}"
+            git push origin main
+          }
 
       # ── GitHub release ──────────────────────────────────────────────────
       - name: Generate release notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
+
+Releases are auto-generated from conventional commits. See [GitHub Releases](https://github.com/danielperezr88/astrolabe/releases) for detailed release notes.
+
+## [0.2.0] — Unreleased
+
+### Added
+
+- **Security scanning**: CodeQL SAST, npm audit, Trivy Docker image scanning in CI (#484)
+- **Rate limiting**: Token-bucket rate limiter on HTTP server (100 req/min/IP, configurable) (#485)
+- **Request tracing**: `X-Request-Id` header on every response, preserved from upstream (#483)
+- **Structured logger**: JSON logger with `createLogger()`, migrated operational `console.*` calls (#486)
+- **Error hierarchy**: `AstrolabeError` base class with domain-specific subclasses for API responses (#487)
+- **CI failure notifications**: Auto-create GitHub issue on pipeline failure (#490)
+- **Node version matrix**: CI tests on Node 18, 20, and 22 (#491)
+- **npm publish**: `@astrolabe/cli` auto-published to npm on release (#489)
+- **Environment docs**: `.env.example` documenting all 13 environment variables (#494)
+
+### Fixed
+
+- **Command injection**: `execSync` → `execFileSync` in release/version scripts (#481)
+- **CI coverage report**: Artifact upload fix, moved coverage provider to correct workspace (#498, #499)
+- **Silent catch blocks**: 19 catch blocks now log at debug level with error context (#488)
+
+### Changed
+
+- **CONTRIBUTING.md**: Added full development workflow and issue templates (#492)
+- **Removed**: Non-functional `packages/web` workspace and temp debug artifacts (#497)


### PR DESCRIPTION
## Summary

Adds CHANGELOG.md and auto-update step in the release pipeline.

## Changes

- CHANGELOG.md � Initial file with 0.2.0 entries for all enterprise readiness work
- .github/workflows/release.yml � New step after version bump that prepends generated release notes to CHANGELOG.md

The release pipeline uses scripts/release-notes.mjs (already exists) to group conventional commits, then prepends the entry under a version+date header.

Closes #493
