### PR TITLE
feat: add rollback workflow and deployment smoke tests (#496)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,10 @@ jobs:
           exit-code: '1'
           format: 'table'
 
+      # ── Smoke test: verify container starts and responds ────────────────
+      - name: Run deployment smoke test
+        run: bash scripts/smoke-test.sh "${{ steps.version.outputs.version }}"
+
       # ── Sign the image ──────────────────────────────────────────────────
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -1,0 +1,148 @@
+# Rollback Workflow — re-tags a previous Docker image as latest/stable.
+# Triggered manually via workflow_dispatch with a target version input.
+
+name: Rollback
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Target version to roll back to (e.g. 0.2.0)"
+        required: true
+        type: string
+      confirm:
+        description: "Type 'ROLLBACK' to confirm"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  validate:
+    name: Validate rollback request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check confirmation
+        run: |
+          if [ "${{ inputs.confirm }}" != "ROLLBACK" ]; then
+            echo "✗ Confirmation mismatch. Type 'ROLLBACK' to proceed."
+            exit 1
+          fi
+          echo "✓ Rollback confirmed for version ${{ inputs.version }}"
+
+      - name: Verify image exists
+        run: |
+          docker pull "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.version }}"
+          echo "✓ Image ${{ inputs.version }} found in registry"
+
+  rollback:
+    name: Re-tag ${{ inputs.version }} as latest/stable
+    runs-on: ubuntu-latest
+    needs: validate
+    steps:
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull target image
+        run: docker pull "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.version }}"
+
+      - name: Re-tag as latest and stable
+        run: |
+          TARGET="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.version }}"
+          docker tag "$TARGET" "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+          docker tag "$TARGET" "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:stable"
+          docker push "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+          docker push "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:stable"
+          echo "✓ Re-tagged ${{ inputs.version }} as latest and stable"
+
+  smoke-test:
+    name: Smoke test rollback image
+    runs-on: ubuntu-latest
+    needs: rollback
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run smoke test
+        run: bash scripts/smoke-test.sh "${{ inputs.version }}"
+
+  tag:
+    name: Create rollback release
+    runs-on: ubuntu-latest
+    needs: smoke-test
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create rollback tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ inputs.version }}"
+          TAG="v${VERSION}-rollback-$(date +%Y%m%d%H%M%S)"
+
+          git tag "$TAG"
+          git push origin "$TAG"
+
+          NOTES_FILE="/tmp/rollback-notes.md"
+          {
+            echo "## ⏪ Rollback to ${VERSION}"
+            echo ""
+            echo "This release reverts the \`latest\` and \`stable\` Docker tags to version \`${VERSION}\`."
+            echo ""
+            echo "### Docker"
+            echo ""
+            echo '```bash'
+            echo "docker pull ghcr.io/danielperezr88/astrolabe:${VERSION}"
+            echo "docker pull ghcr.io/danielperezr88/astrolabe:latest"
+            echo '```'
+            echo ""
+            echo "---"
+            echo ""
+            echo "Triggered by: @${{ github.actor }}"
+            echo "Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          } > "$NOTES_FILE"
+
+          gh release create "$TAG" \
+            --title "Rollback to ${VERSION}" \
+            --notes-file "$NOTES_FILE" \
+            --prerelease
+
+          echo "✓ Rollback release created: ${TAG}"
+
+  notify-failure:
+    name: Notify on Failure
+    runs-on: ubuntu-latest
+    needs: [validate, rollback, smoke-test, tag]
+    if: failure() && always()
+    permissions:
+      issues: write
+    steps:
+      - name: Create issue on rollback failure
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Rollback failed: ${context.workflow} #${context.runNumber}`,
+              body: [
+                `**Workflow**: ${context.workflow}`,
+                `**Target version**: ${{ inputs.version }}`,
+                `**Run**: ${runUrl}`,
+                '',
+                `@${context.actor} — Rollback to ${{ inputs.version }} failed. Manual intervention required.`,
+              ].join('\n'),
+              labels: ['bug'],
+            });

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# smoke-test.sh — Basic health check against a running Astrolabe container.
+# Usage: ./scripts/smoke-test.sh [image_tag]
+#
+# Expects the container to expose the HTTP server on port 4747.
+# Returns 0 on success, 1 on failure.
+
+set -euo pipefail
+
+IMAGE_TAG="${1:-latest}"
+CONTAINER_NAME="astrolabe-smoke-$$"
+PORT="4747"
+TIMEOUT="30"
+
+echo "── Smoke test: ghcr.io/danielperezr88/astrolabe:${IMAGE_TAG}"
+
+# Start container
+echo "Starting container..."
+docker run -d --name "${CONTAINER_NAME}" \
+  -p "${PORT}:${PORT}" \
+  "ghcr.io/danielperezr88/astrolabe:${IMAGE_TAG}" \
+  >/dev/null
+
+# Ensure cleanup on exit
+cleanup() {
+  docker stop "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+  docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# Wait for the server to respond
+echo "Waiting up to ${TIMEOUT}s for server..."
+elapsed=0
+while [ "$elapsed" -lt "$TIMEOUT" ]; do
+  if curl -sf "http://localhost:${PORT}/" -o /dev/null 2>/dev/null; then
+    echo "✓ Server responded on port ${PORT}"
+    echo "✓ Smoke test PASSED"
+    exit 0
+  fi
+  sleep 2
+  elapsed=$((elapsed + 2))
+done
+
+# Timeout — dump container logs for debugging
+echo "✗ Server did not respond within ${TIMEOUT}s"
+echo "── Container logs ──"
+docker logs "${CONTAINER_NAME}" 2>&1 | tail -20
+echo "✗ Smoke test FAILED"
+exit 1


### PR DESCRIPTION
﻿## Summary

- Add `.github/workflows/rollback.yml` — `workflow_dispatch` with version input and manual confirmation (`ROLLBACK`), re-tags Docker image as `latest`/`stable`, runs smoke test, creates rollback release.
- Add `scripts/smoke-test.sh` — starts container, waits up to 30s for HTTP response on port 4747, returns exit code.
- Add smoke test step to `release.yml` — runs after Docker push + Trivy scan, before Cosign signing.

Closes #496

## Test plan

- [ ] `rollback.yml` validates confirmation string
- [ ] `rollback.yml` pulls target image, re-tags as latest/stable
- [ ] `rollback.yml` runs smoke test before creating release
- [ ] `smoke-test.sh` detects container startup within timeout
- [ ] `release.yml` smoke test gates release tagging
- [ ] All 472 unit tests pass
