### PR TITLE
test: add MCP server end-to-end integration tests (#536)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build --workspace packages/shared
+      - run: npm run build --workspace packages/core
       - run: npm test -- --coverage
       - name: Upload coverage
         if: matrix.os == 'ubuntu-latest' && matrix.node-version == '20'
@@ -76,6 +77,7 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build --workspace packages/shared
+      - run: npm run build --workspace packages/core
       - run: npm test
         env:
           ASTROLABE_INTEGRATION: '1'

--- a/packages/core/tests/mcp/mcp-server-helper.mjs
+++ b/packages/core/tests/mcp/mcp-server-helper.mjs
@@ -1,11 +1,22 @@
 /**
  * Helper subprocess for MCP server e2e integration tests (#536).
  * Imports and starts the MCP server from dist/.
+ * Writes "READY" to stderr when the server is listening, so the test
+ * knows it's safe to send JSON-RPC requests.
  */
 
-import { startMcpServer } from '../../dist/mcp/server.js';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
-startMcpServer().catch((err) => {
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const serverPath = pathToFileURL(resolve(__dirname, '../../dist/mcp/server.js')).href;
+
+try {
+  const { startMcpServer } = await import(serverPath);
+  await startMcpServer();
+  // Signal readiness — the test waits for this before sending requests
+  process.stderr.write('READY\n');
+} catch (err) {
   console.error('MCP server failed to start:', err);
   process.exit(1);
-});
+}

--- a/packages/core/tests/mcp/mcp-server-helper.mjs
+++ b/packages/core/tests/mcp/mcp-server-helper.mjs
@@ -1,0 +1,11 @@
+/**
+ * Helper subprocess for MCP server e2e integration tests (#536).
+ * Imports and starts the MCP server from dist/.
+ */
+
+import { startMcpServer } from '../../dist/mcp/server.js';
+
+startMcpServer().catch((err) => {
+  console.error('MCP server failed to start:', err);
+  process.exit(1);
+});

--- a/packages/core/tests/mcp/mcp-server.test.ts
+++ b/packages/core/tests/mcp/mcp-server.test.ts
@@ -10,20 +10,18 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { spawn, type ChildProcess } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { createSqliteStore } from '../../src/persist/sqlite.js';
 import { createFtsSearch } from '../../src/search/fts.js';
 import { createKnowledgeGraph } from '../../src/core/graph.js';
-import { loadRegistry, saveRegistry, type RegistryEntry } from '../../src/mcp/registry.js';
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 
 let testDir: string;
 let dbPath: string;
 let child: ChildProcess;
-let originalRegistry: RegistryEntry[];
 let msgId = 0;
 let responseBuffer = '';
 let stderrBuffer = '';
@@ -70,9 +68,7 @@ function sendRpc(method: string, params?: Record<string, unknown>): Promise<unkn
 // ── Setup ────────────────────────────────────────────────────────────────
 
 beforeAll(async () => {
-  originalRegistry = loadRegistry();
-
-  // Create test database with graph data
+  // Use isolated temp directory for DB, registry, and subprocess home
   testDir = mkdtempSync(resolve(tmpdir(), 'astrolabe-mcp-e2e-'));
   dbPath = resolve(testDir, 'mcp-e2e.db');
 
@@ -101,20 +97,28 @@ beforeAll(async () => {
   fts.close();
   store.close();
 
-  // Register in global registry
-  saveRegistry([{
+  // Register in subprocess-isolated registry (separate home dir)
+  const astrolabeDir = resolve(testDir, '.astrolabe');
+  mkdirSync(astrolabeDir);
+  writeFileSync(resolve(astrolabeDir, 'registry.json'), JSON.stringify([{
     name: 'mcp-e2e-repo',
     path: testDir,
     dbPath,
     lastCommit: 'abc123',
     indexedAt: Date.now(),
-  }]);
+  }]));
 
   // Spawn MCP server via helper (which calls startMcpServer())
   const helperPath = resolve(__dirname, 'mcp-server-helper.mjs');
   child = spawn(process.execPath, [helperPath], {
     stdio: ['pipe', 'pipe', 'pipe'],
-    env: { ...process.env, NODE_ENV: 'test' },
+    env: {
+      ...process.env,
+      NODE_ENV: 'test',
+      // Isolate subprocess home dir so registry.json is from testDir
+      HOME: testDir,
+      USERPROFILE: testDir,
+    },
   });
 
   // Wait for READY signal on stderr before sending requests
@@ -147,7 +151,6 @@ beforeAll(async () => {
 
 afterAll(() => {
   child?.kill();
-  saveRegistry(originalRegistry);
   // Log stderr for debugging (helps diagnose subprocess startup failures)
   if (stderrBuffer) console.warn(`[MCP server stderr]:\n${stderrBuffer}`);
   // Temp dir may be locked by subprocess SQLite — best-effort cleanup

--- a/packages/core/tests/mcp/mcp-server.test.ts
+++ b/packages/core/tests/mcp/mcp-server.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { spawn, type ChildProcess } from 'node:child_process';
-import { join } from 'node:path';
+import { resolve } from 'node:path';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { createSqliteStore } from '../../src/persist/sqlite.js';
@@ -26,6 +26,7 @@ let child: ChildProcess;
 let originalRegistry: RegistryEntry[];
 let msgId = 0;
 let responseBuffer = '';
+let stderrBuffer = '';
 let pendingResolvers = new Map<number, { resolve: (value: unknown) => void; reject: (err: Error) => void; timer: ReturnType<typeof setTimeout> }>();
 
 /** Handle incoming data — parse newline-delimited JSON and dispatch to waiting callers. */
@@ -72,8 +73,8 @@ beforeAll(async () => {
   originalRegistry = loadRegistry();
 
   // Create test database with graph data
-  testDir = mkdtempSync(join(tmpdir(), 'astrolabe-mcp-e2e-'));
-  dbPath = join(testDir, 'mcp-e2e.db');
+  testDir = mkdtempSync(resolve(tmpdir(), 'astrolabe-mcp-e2e-'));
+  dbPath = resolve(testDir, 'mcp-e2e.db');
 
   const store = createSqliteStore(dbPath);
   const graph = createKnowledgeGraph();
@@ -110,14 +111,24 @@ beforeAll(async () => {
   }]);
 
   // Spawn MCP server via helper (which calls startMcpServer())
-  const helperPath = join(__dirname, 'mcp-server-helper.mjs');
+  const helperPath = resolve(__dirname, 'mcp-server-helper.mjs');
   child = spawn(process.execPath, [helperPath], {
     stdio: ['pipe', 'pipe', 'pipe'],
-    env: { ...process.env },
+    env: { ...process.env, NODE_ENV: 'test' },
   });
 
-  child.stderr!.on('data', () => { /* drain stderr */ });
+  // Wait for READY signal on stderr before sending requests
+  const ready = new Promise<void>((resolveReady, rejectReady) => {
+    child.stderr!.on('data', (d: Buffer) => {
+      stderrBuffer += d.toString();
+      if (stderrBuffer.includes('READY\n')) resolveReady();
+    });
+    setTimeout(() => rejectReady(new Error(`MCP server not ready after 25s. stderr: ${stderrBuffer}`)), 25000);
+  });
+
   child.stdout!.on('data', handleStdoutData);
+
+  await ready;
 
   // Send initialize request to start the server
   const initResponse = await sendRpc('initialize', {
@@ -132,11 +143,13 @@ beforeAll(async () => {
   child.stdin!.write(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n');
   // Small delay for the notification to be processed
   await new Promise((r) => setTimeout(r, 100));
-}, 15000);
+}, 30000);
 
 afterAll(() => {
   child?.kill();
   saveRegistry(originalRegistry);
+  // Log stderr for debugging (helps diagnose subprocess startup failures)
+  if (stderrBuffer) console.warn(`[MCP server stderr]:\n${stderrBuffer}`);
   // Temp dir may be locked by subprocess SQLite — best-effort cleanup
   try { if (testDir) rmSync(testDir, { recursive: true, force: true }); } catch { /* locked */ }
 });

--- a/packages/core/tests/mcp/mcp-server.test.ts
+++ b/packages/core/tests/mcp/mcp-server.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Integration tests for the MCP server — end-to-end via JSON-RPC over stdio (#536).
+ *
+ * Spawns the MCP server as a subprocess, sends JSON-RPC requests via stdin
+ * (newline-delimited JSON framing), and reads responses from stdout.
+ *
+ * Tests the full tool dispatch pipeline: transport → JSON-RPC parse →
+ * tool handler → backend → result formatting.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { join } from 'node:path';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { createSqliteStore } from '../../src/persist/sqlite.js';
+import { createFtsSearch } from '../../src/search/fts.js';
+import { createKnowledgeGraph } from '../../src/core/graph.js';
+import { loadRegistry, saveRegistry, type RegistryEntry } from '../../src/mcp/registry.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+let testDir: string;
+let dbPath: string;
+let child: ChildProcess;
+let originalRegistry: RegistryEntry[];
+let msgId = 0;
+let responseBuffer = '';
+let pendingResolvers = new Map<number, { resolve: (value: unknown) => void; reject: (err: Error) => void; timer: ReturnType<typeof setTimeout> }>();
+
+/** Handle incoming data — parse newline-delimited JSON and dispatch to waiting callers. */
+function handleStdoutData(data: Buffer) {
+  responseBuffer += data.toString();
+  const lines = responseBuffer.split('\n');
+  responseBuffer = lines.pop() ?? ''; // Keep incomplete line in buffer
+
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    try {
+      const msg = JSON.parse(line);
+      if (msg.id !== undefined && pendingResolvers.has(msg.id)) {
+        const { resolve, timer } = pendingResolvers.get(msg.id)!;
+        clearTimeout(timer);
+        pendingResolvers.delete(msg.id);
+        resolve(msg);
+      }
+    } catch {
+      // Incomplete JSON — ignore
+    }
+  }
+}
+
+/** Send a JSON-RPC request and return the response promise. */
+function sendRpc(method: string, params?: Record<string, unknown>): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const id = ++msgId;
+    const req = JSON.stringify({ jsonrpc: '2.0', id, method, params: params ?? {} }) + '\n';
+
+    const timer = setTimeout(() => {
+      pendingResolvers.delete(id);
+      reject(new Error(`Timeout waiting for response to ${method} (id=${id})`));
+    }, 15000);
+
+    pendingResolvers.set(id, { resolve, reject, timer });
+    child.stdin!.write(req);
+  });
+}
+
+// ── Setup ────────────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  originalRegistry = loadRegistry();
+
+  // Create test database with graph data
+  testDir = mkdtempSync(join(tmpdir(), 'astrolabe-mcp-e2e-'));
+  dbPath = join(testDir, 'mcp-e2e.db');
+
+  const store = createSqliteStore(dbPath);
+  const graph = createKnowledgeGraph();
+  graph.addNode({ id: 'fn:app:authenticate', label: 'Function', properties: { name: 'authenticate', filePath: 'src/auth.ts' } });
+  graph.addNode({ id: 'fn:app:login', label: 'Function', properties: { name: 'login', filePath: 'src/login.ts' } });
+  graph.addNode({ id: 'fn:app:hashPassword', label: 'Function', properties: { name: 'hashPassword', filePath: 'src/auth.ts' } });
+  graph.addNode({ id: 'fn:app:validateToken', label: 'Function', properties: { name: 'validateToken', filePath: 'src/auth.ts' } });
+  graph.addRelationship({
+    id: 'rel:call1', sourceId: 'fn:app:login', targetId: 'fn:app:authenticate',
+    type: 'CALLS', confidence: 0.95, reason: 'login calls authenticate',
+  });
+  graph.addRelationship({
+    id: 'rel:call2', sourceId: 'fn:app:hashPassword', targetId: 'fn:app:authenticate',
+    type: 'CALLS', confidence: 0.90, reason: 'hashing related to auth',
+  });
+  graph.addRelationship({
+    id: 'rel:call3', sourceId: 'fn:app:login', targetId: 'fn:app:validateToken',
+    type: 'CALLS', confidence: 0.85, reason: 'login validates token',
+  });
+  store.saveGraph(graph);
+
+  const fts = createFtsSearch(dbPath);
+  fts.indexGraph(store);
+  fts.close();
+  store.close();
+
+  // Register in global registry
+  saveRegistry([{
+    name: 'mcp-e2e-repo',
+    path: testDir,
+    dbPath,
+    lastCommit: 'abc123',
+    indexedAt: Date.now(),
+  }]);
+
+  // Spawn MCP server via helper (which calls startMcpServer())
+  const helperPath = join(__dirname, 'mcp-server-helper.mjs');
+  child = spawn(process.execPath, [helperPath], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env },
+  });
+
+  child.stderr!.on('data', () => { /* drain stderr */ });
+  child.stdout!.on('data', handleStdoutData);
+
+  // Send initialize request to start the server
+  const initResponse = await sendRpc('initialize', {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'test-client', version: '1.0.0' },
+  });
+  const init = initResponse as { result?: { capabilities?: unknown } };
+  expect(init.result?.capabilities).toBeDefined();
+
+  // Send initialized notification
+  child.stdin!.write(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n');
+  // Small delay for the notification to be processed
+  await new Promise((r) => setTimeout(r, 100));
+}, 15000);
+
+afterAll(() => {
+  child?.kill();
+  saveRegistry(originalRegistry);
+  // Temp dir may be locked by subprocess SQLite — best-effort cleanup
+  try { if (testDir) rmSync(testDir, { recursive: true, force: true }); } catch { /* locked */ }
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe('MCP Server E2E (#536)', () => {
+  // ── Protocol ──────────────────────────────────────────────────────────
+
+  describe('protocol', () => {
+    it('responds to tools/list with available tools', async () => {
+      const msg = await sendRpc('tools/list') as { result?: { tools?: Array<{ name: string }> } };
+      expect(msg.result?.tools).toBeDefined();
+      const tools = msg.result!.tools!;
+      const toolNames = tools.map((t) => t.name);
+      expect(toolNames).toContain('astrolabe.list_repos');
+      expect(toolNames).toContain('astrolabe.query');
+      expect(toolNames).toContain('astrolabe.context');
+      expect(toolNames).toContain('astrolabe.impact');
+      expect(toolNames.length).toBeGreaterThanOrEqual(7);
+    });
+
+    it('returns error for unknown method', async () => {
+      const msg = await sendRpc('nonexistent/method') as { error?: { code: number; message: string } };
+      expect(msg.error).toBeDefined();
+      expect(msg.error!.code).toBe(-32601);
+    });
+  });
+
+  // ── Tools ─────────────────────────────────────────────────────────────
+
+  describe('tools', () => {
+    it('list_repos returns indexed repos', async () => {
+      const msg = await sendRpc('tools/call', {
+        name: 'astrolabe.list_repos',
+        arguments: {},
+      }) as { result?: { content?: Array<{ type: string; text: string }> } };
+      expect(msg.result?.content).toBeDefined();
+      const text = msg.result!.content![0].text;
+      expect(text).toContain('mcp-e2e-repo');
+    });
+
+    it('query returns search results', async () => {
+      const msg = await sendRpc('tools/call', {
+        name: 'astrolabe.query',
+        arguments: { query: 'authenticate' },
+      }) as { result?: { content?: Array<{ type: string; text: string }> } };
+      expect(msg.result?.content).toBeDefined();
+      const text = msg.result!.content![0].text;
+      expect(text).toContain('authenticate');
+    });
+
+    it('query requires query parameter', async () => {
+      const msg = await sendRpc('tools/call', {
+        name: 'astrolabe.query',
+        arguments: {},
+      }) as { error?: { code: number; message: string } };
+      expect(msg.error).toBeDefined();
+      expect(msg.error!.message).toContain('query');
+    });
+
+    it('context returns symbol context', async () => {
+      const msg = await sendRpc('tools/call', {
+        name: 'astrolabe.context',
+        arguments: { name: 'authenticate' },
+      }) as { result?: { content?: Array<{ type: string; text: string }> } };
+      expect(msg.result?.content).toBeDefined();
+      const text = msg.result!.content![0].text;
+      expect(text).toContain('authenticate');
+    });
+
+    it('context requires name parameter', async () => {
+      const msg = await sendRpc('tools/call', {
+        name: 'astrolabe.context',
+        arguments: {},
+      }) as { error?: { code: number; message: string } };
+      expect(msg.error).toBeDefined();
+      expect(msg.error!.message).toContain('name');
+    });
+
+    it('impact returns blast radius', async () => {
+      const msg = await sendRpc('tools/call', {
+        name: 'astrolabe.impact',
+        arguments: { target: 'authenticate' },
+      }) as { result?: { content?: Array<{ type: string; text: string }> } };
+      expect(msg.result?.content).toBeDefined();
+      const text = msg.result!.content![0].text;
+      expect(text).toContain('login');
+    });
+
+    it('unknown tool returns error', async () => {
+      const msg = await sendRpc('tools/call', {
+        name: 'astrolabe.nonexistent',
+        arguments: {},
+      }) as { error?: { code: number; message: string } };
+      expect(msg.error).toBeDefined();
+      expect(msg.error!.code).toBe(-32601);
+      expect(msg.error!.message).toContain('Unknown tool');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds 9 end-to-end integration tests for the MCP server (JSON-RPC over stdio)
- Tests the full dispatch pipeline: transport → JSON-RPC parse → tool handler → backend → response
- Uses subprocess with newline-delimited JSON framing (real MCP transport)

## Test Coverage

### Protocol
- `tools/list` returns available tools (7+)
- Unknown method returns -32601 error

### Tool Dispatch
- `astrolabe.list_repos` returns indexed repos
- `astrolabe.query` returns search results
- `astrolabe.query` requires `query` parameter
- `astrolabe.context` returns symbol context
- `astrolabe.context` requires `name` parameter
- `astrolabe.impact` returns blast radius
- Unknown tool returns -32601 error

## Test Results

```
481 passed, 12 skipped (was 472 + 9 new)
```

Closes #536
