### PR TITLE
fix: configure git identity before CHANGELOG commit in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,9 @@ jobs:
       - id: check
         run: |
           MSG="${{ github.event.head_commit.message }}"
-          if echo "$MSG" | grep -q "chore: release v"; then
+          if echo "$MSG" | grep -qE "chore: release v|docs: update CHANGELOG for v"; then
             echo "should_release=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping — version bump commit."
+            echo "Skipping — version bump or CHANGELOG commit."
           else
             echo "should_release=true" >> "$GITHUB_OUTPUT"
             echo "Proceeding with release."
@@ -199,6 +199,9 @@ jobs:
       # ── Update CHANGELOG.md ───────────────────────────────────────────────
       - name: Update CHANGELOG.md
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
           VERSION="${{ steps.version.outputs.version }}"
           TAG="v${VERSION}"
           NOTES=$(node scripts/release-notes.mjs)


### PR DESCRIPTION
## Summary

Two fixes to the release pipeline:

1. **Git identity for CHANGELOG commit**: Adds `git config user.name` and `git config user.email` before the CHANGELOG commit step — resolves "Author identity unknown" failure.

2. **Filter CHANGELOG commits in check trigger**: The check step now also skips `docs: update CHANGELOG for v*` messages to prevent infinite release loops (CHANGELOG commit → pipeline trigger → new version → CHANGELOG commit → ...).

## Root Cause (Issue 1)

Run #25491699441 Publish Release job: step "Update CHANGELOG.md" failed with:
```
Author identity unknown
fatal: empty ident name (for <runner@...>) not allowed
```

This prevented the CHANGELOG update, release notes generation, and GitHub release creation.

## Root Cause (Issue 2)

Pushing the CHANGELOG commit to main triggered the release pipeline again (commit message "docs: update CHANGELOG for v1.0.1" didn't match the "chore: release v" filter), creating an unintended v1.0.2 release.

## Changes

1. Added `git config` at the start of "Update CHANGELOG.md" step:
   ```bash
   git config user.name "github-actions[bot]"
   git config user.email "github-actions[bot]@users.noreply.github.com"
   ```

2. Extended check trigger filter from `grep -q "chore: release v"` to `grep -qE "chore: release v|docs: update CHANGELOG for v"`
