### PR TITLE
fix: release pipeline — git identity for CHANGELOG + prevent infinite loop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,9 @@ jobs:
       - id: check
         run: |
           MSG="${{ github.event.head_commit.message }}"
-          if echo "$MSG" | grep -q "chore: release v"; then
+          if echo "$MSG" | grep -qE "chore: release v|docs: update CHANGELOG for v"; then
             echo "should_release=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping — version bump commit."
+            echo "Skipping — version bump or CHANGELOG commit."
           else
             echo "should_release=true" >> "$GITHUB_OUTPUT"
             echo "Proceeding with release."
@@ -199,6 +199,9 @@ jobs:
       # ── Update CHANGELOG.md ───────────────────────────────────────────────
       - name: Update CHANGELOG.md
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
           VERSION="${{ steps.version.outputs.version }}"
           TAG="v${VERSION}"
           NOTES=$(node scripts/release-notes.mjs)


### PR DESCRIPTION
## Summary

Merges the staging fix for the release pipeline:

1. **Git identity**: `git config user.name/email` added before CHANGELOG commit (fixes "Author identity unknown" in `release.yml`)
2. **Infinite loop prevention**: Check trigger now also filters `docs: update CHANGELOG for v*` commits

**Note**: This merge will trigger the release pipeline (v1.0.3). The pipeline should now complete successfully including CHANGELOG update and GitHub release creation.

## Accompanying changes
- CHANGELOG.md updated with v1.0.1 entry (manual completion of failed release)
- GitHub release v1.0.1 created (manual completion of failed release)
