### PR TITLE
fix: release check trigger only inspects first line of commit message

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - id: check
         run: |
           MSG="${{ github.event.head_commit.message }}"
-          if echo "$MSG" | grep -qE "chore: release v|docs: update CHANGELOG for v"; then
+          if echo "$MSG" | head -1 | grep -qE "chore: release v|docs: update CHANGELOG for v"; then
             echo "should_release=false" >> "$GITHUB_OUTPUT"
             echo "Skipping — version bump or CHANGELOG commit."
           else


### PR DESCRIPTION
## Summary

Fixes a false-positive skip in the release pipeline's check trigger. The `grep` pattern was matching against the full multi-line commit message (which includes squashed PR body text), causing releases to be skipped when the PR description mentioned "CHANGELOG" in prose.

## Root Cause

When merging a PR via squash, the PR body text becomes part of the commit message body. If that body contains `docs: update CHANGELOG for v*` (as many PRs about the release pipeline do), the grep pattern matches and the release is skipped — even though the commit title is something completely different like `fix: release pipeline — git identity`.

## Fix

Added `head -1` to only check the **first line** (commit title) against the filter patterns:

```diff
- if echo "$MSG" | grep -qE "chore: release v|docs: update CHANGELOG for v"; then
+ if echo "$MSG" | head -1 | grep -qE "chore: release v|docs: update CHANGELOG for v"; then
```

Only commit titles matching `chore: release v*` or `docs: update CHANGELOG for v*` will now trigger a skip — exactly what was intended.
