### PR TITLE
chore: promote staging to main (release pipeline fix for v1.0.3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - id: check
         run: |
           MSG="${{ github.event.head_commit.message }}"
-          if echo "$MSG" | grep -qE "chore: release v|docs: update CHANGELOG for v"; then
+          if echo "$MSG" | head -1 | grep -qE "chore: release v|docs: update CHANGELOG for v"; then
             echo "should_release=false" >> "$GITHUB_OUTPUT"
             echo "Skipping — version bump or CHANGELOG commit."
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,9 @@ jobs:
       - id: check
         run: |
           MSG="${{ github.event.head_commit.message }}"
-          if echo "$MSG" | grep -q "chore: release v"; then
+          if echo "$MSG" | grep -qE "chore: release v|docs: update CHANGELOG for v"; then
             echo "should_release=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping — version bump commit."
+            echo "Skipping — version bump or CHANGELOG commit."
           else
             echo "should_release=true" >> "$GITHUB_OUTPUT"
             echo "Proceeding with release."
@@ -199,6 +199,9 @@ jobs:
       # ── Update CHANGELOG.md ───────────────────────────────────────────────
       - name: Update CHANGELOG.md
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
           VERSION="${{ steps.version.outputs.version }}"
           TAG="v${VERSION}"
           NOTES=$(node scripts/release-notes.mjs)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ feature/fix-xxx ──PR──▶ staging (auto RC) ──PR──▶ main (stab
 ### Rules
 
 - **NEVER push directly to `main` or `staging`. Always go through PRs.** See [Release Flow is MANDATORY](#release-flow-is-mandatory-absolute--no-exceptions) above.
-- **Admin bypass does not exist.** Even if you can force-push as admin, you must not. The release flow is the only path.
+- **Admin bypass does not exist.** Even if you can force-push as admin, you must not. The release flow is the only path. **Never use `--admin` flag on `gh pr merge`.** PRs that lack approval MUST wait for the reviewer — do not self-approve or bypass.
 - All PRs require passing status checks: unit tests (ubuntu + windows), integration tests (main only), Docker build validation.
 - All PRs require at least 1 approval. Stale reviews are auto-dismissed on new pushes.
 - Use linear history (no merge commits). Rebase or squash-merge.
@@ -157,6 +157,7 @@ A reviewer agent works in 10-minute rounds: reviews open PRs, pushes back with c
 - Reviewer marks PRs as ready for review after implementation is complete and tests pass.
 - The implementer and reviewer coordinate via GitHub issues AND PR reviews — no direct push to protected branches.
 - **Always check PR reviews**: `gh pr view <number> --repo danielperezr88/astrolabe --json reviews,comments` — fix any reviewer feedback before merging.
+- **When waiting for review**: Set a 10-minute deferred check (`gh pr view <N> --json reviewDecision`) to poll for reviewer approval. Never admin-merge to bypass the review requirement.
 
 ## Repository
 


### PR DESCRIPTION
## Summary

Promote staging to main for v1.0.3 release. Includes critical release pipeline fix.

## Changes

- **fix**: Release check trigger now only inspects first line of commit message — prevents false-positive skips from PR body text leaking into squash merge commits
- **docs**: Strengthen admin bypass prohibition and reviewer workflow documentation
- **chore**: Sync staging with main (CHANGELOG v1.0.1)
- **fix**: Configure git identity and filter CHANGELOG commits in release pipeline

## Why this needs to go to main

The release pipeline's check trigger has been falsely skipping releases when PR body text (containing "CHANGELOG") leaks into the squash merge commit message. This fix ensures only the commit title is checked against the filter pattern, unblocking the v1.0.3 release.
