### PR TITLE
fix: remove CHANGELOG push from release pipeline + update CHANGELOG for v1.0.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - id: check
         run: |
           MSG="${{ github.event.head_commit.message }}"
-          if echo "$MSG" | grep -qE "chore: release v|docs: update CHANGELOG for v"; then
+          if echo "$MSG" | head -1 | grep -qE "chore: release v|docs: update CHANGELOG for v"; then
             echo "should_release=false" >> "$GITHUB_OUTPUT"
             echo "Skipping — version bump or CHANGELOG commit."
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,7 +224,7 @@ jobs:
           git add CHANGELOG.md
           git diff --cached --quiet && echo "No CHANGELOG changes" || {
             git commit -m "docs: update CHANGELOG for ${TAG}"
-            git push origin main
+            echo "CHANGELOG updated locally — main is branch-protected; push manually via PR."
           }
 
       # ── GitHub release ──────────────────────────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.3] — 2026-05-07
+
+### 🐛 Bug Fixes
+
+- release check trigger only inspects first line of commit message (6c740f4)
+- configure git identity and filter CHANGELOG commits in release pipeline (6474b22)
+
 ## [1.0.1] — 2026-05-07
 
 ### 🐛 Bug Fixes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ feature/fix-xxx ──PR──▶ staging (auto RC) ──PR──▶ main (stab
 ### Rules
 
 - **NEVER push directly to `main` or `staging`. Always go through PRs.** See [Release Flow is MANDATORY](#release-flow-is-mandatory-absolute--no-exceptions) above.
-- **Admin bypass does not exist.** Even if you can force-push as admin, you must not. The release flow is the only path.
+- **Admin bypass does not exist.** Even if you can force-push as admin, you must not. The release flow is the only path. **Never use `--admin` flag on `gh pr merge`.** PRs that lack approval MUST wait for the reviewer — do not self-approve or bypass.
 - All PRs require passing status checks: unit tests (ubuntu + windows), integration tests (main only), Docker build validation.
 - All PRs require at least 1 approval. Stale reviews are auto-dismissed on new pushes.
 - Use linear history (no merge commits). Rebase or squash-merge.
@@ -157,6 +157,7 @@ A reviewer agent works in 10-minute rounds: reviews open PRs, pushes back with c
 - Reviewer marks PRs as ready for review after implementation is complete and tests pass.
 - The implementer and reviewer coordinate via GitHub issues AND PR reviews — no direct push to protected branches.
 - **Always check PR reviews**: `gh pr view <number> --repo danielperezr88/astrolabe --json reviews,comments` — fix any reviewer feedback before merging.
+- **When waiting for review**: Set a 10-minute deferred check (`gh pr view <N> --json reviewDecision`) to poll for reviewer approval. Never admin-merge to bypass the review requirement.
 
 ## Repository
 


### PR DESCRIPTION
## Summary

Two related fixes for the release pipeline's CHANGELOG step:

1. **Remove `git push origin main`** — main is now branch-protected and requires PRs. Direct pushes from the pipeline are rejected. The GitHub release already serves as the canonical changelog.

2. **Add v1.0.3 entry to CHANGELOG.md** — was missing because the push failed in run #25506459874. GitHub release v1.0.3 already exists (manually created).

## Root Cause

When we tightened branch protection on `main` (require PR, linear history), the release pipeline's CHANGELOG push step broke. The pipeline creates a local commit but can't push to the protected branch:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
```

## Fix

Instead of trying to push directly, the pipeline now commits the CHANGELOG locally and prints a reminder. CHANGELOG.md updates should be done via PR after each release.
