### PR TITLE
chore: promote staging to main (CHANGELOG v1.0.3 + release pipeline fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - id: check
         run: |
           MSG="${{ github.event.head_commit.message }}"
-          if echo "$MSG" | grep -qE "chore: release v|docs: update CHANGELOG for v"; then
+          if echo "$MSG" | head -1 | grep -qE "chore: release v|docs: update CHANGELOG for v"; then
             echo "should_release=false" >> "$GITHUB_OUTPUT"
             echo "Skipping — version bump or CHANGELOG commit."
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,9 @@ jobs:
       - id: check
         run: |
           MSG="${{ github.event.head_commit.message }}"
-          if echo "$MSG" | grep -q "chore: release v"; then
+          if echo "$MSG" | grep -qE "chore: release v|docs: update CHANGELOG for v"; then
             echo "should_release=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping — version bump commit."
+            echo "Skipping — version bump or CHANGELOG commit."
           else
             echo "should_release=true" >> "$GITHUB_OUTPUT"
             echo "Proceeding with release."
@@ -199,6 +199,9 @@ jobs:
       # ── Update CHANGELOG.md ───────────────────────────────────────────────
       - name: Update CHANGELOG.md
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
           VERSION="${{ steps.version.outputs.version }}"
           TAG="v${VERSION}"
           NOTES=$(node scripts/release-notes.mjs)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,7 +224,7 @@ jobs:
           git add CHANGELOG.md
           git diff --cached --quiet && echo "No CHANGELOG changes" || {
             git commit -m "docs: update CHANGELOG for ${TAG}"
-            git push origin main
+            echo "CHANGELOG updated locally — main is branch-protected; push manually via PR."
           }
 
       # ── GitHub release ──────────────────────────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.3] — 2026-05-07
+
+### 🐛 Bug Fixes
+
+- release check trigger only inspects first line of commit message (6c740f4)
+- configure git identity and filter CHANGELOG commits in release pipeline (6474b22)
+
 ## [1.0.1] — 2026-05-07
 
 ### 🐛 Bug Fixes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ feature/fix-xxx ──PR──▶ staging (auto RC) ──PR──▶ main (stab
 ### Rules
 
 - **NEVER push directly to `main` or `staging`. Always go through PRs.** See [Release Flow is MANDATORY](#release-flow-is-mandatory-absolute--no-exceptions) above.
-- **Admin bypass does not exist.** Even if you can force-push as admin, you must not. The release flow is the only path.
+- **Admin bypass does not exist.** Even if you can force-push as admin, you must not. The release flow is the only path. **Never use `--admin` flag on `gh pr merge`.** PRs that lack approval MUST wait for the reviewer — do not self-approve or bypass.
 - All PRs require passing status checks: unit tests (ubuntu + windows), integration tests (main only), Docker build validation.
 - All PRs require at least 1 approval. Stale reviews are auto-dismissed on new pushes.
 - Use linear history (no merge commits). Rebase or squash-merge.
@@ -157,6 +157,7 @@ A reviewer agent works in 10-minute rounds: reviews open PRs, pushes back with c
 - Reviewer marks PRs as ready for review after implementation is complete and tests pass.
 - The implementer and reviewer coordinate via GitHub issues AND PR reviews — no direct push to protected branches.
 - **Always check PR reviews**: `gh pr view <number> --repo danielperezr88/astrolabe --json reviews,comments` — fix any reviewer feedback before merging.
+- **When waiting for review**: Set a 10-minute deferred check (`gh pr view <N> --json reviewDecision`) to poll for reviewer approval. Never admin-merge to bypass the review requirement.
 
 ## Repository
 


### PR DESCRIPTION
## Summary

Promote staging to main. Includes CHANGELOG v1.0.3 entry and release pipeline fix (remove push to protected main).

## Changes

- **fix**: Remove CHANGELOG push from release pipeline — main is branch-protected, can't push directly
- **docs**: Add v1.0.3 entry to CHANGELOG.md
- **fix**: Release check trigger only inspects first line (prevents false-positive skips)
- **chore**: Merge main into staging (sync)
- **docs**: Strengthen admin bypass prohibition and reviewer workflow in CLAUDE.md
