### PR TITLE
fix: narrow CI notify-failure to real test failures only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
     name: Notify on Failure
     runs-on: ubuntu-latest
     needs: [unit-test, integration-test, coverage-report]
-    if: failure() && always()
+    if: always() && (needs.unit-test.result == 'failure' || needs.integration-test.result == 'failure')
     permissions:
       issues: write
     steps:


### PR DESCRIPTION
## Summary
- Changes \
otify-failure\ job condition from \ailure() && always()\ to \lways() && (needs.unit-test.result == 'failure' || needs.integration-test.result == 'failure')\
- Prevents auto-filing bug issues for pre-existing non-blocking failures (Dependency Review, Coverage Report #498)
- Only files CI failure issues when unit tests or integration tests genuinely fail

## Before
\
otify-failure\ fired whenever ANY job in the workflow failed, including Dependency Review (always fails, pre-existing) and Coverage Report (fails due to #498). This resulted in false positive issues for every merged PR.

## After
\
otify-failure\ only fires when unit tests or integration tests fail — actual testing issues that need investigation.