### PR TITLE
fix: use deterministic author check instead of regex for release skip (#625)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,8 @@ on:
   push:
     branches: [main]
 
-# Prevent infinite loop: the check job detects version-bump commits
-# (messages starting with "chore: release v") and skips the pipeline.
+# Prevent infinite loop: the check job skips the pipeline for commits
+# authored by github-actions[bot] (CHANGELOG edits, version bumps).
 concurrency:
   group: release-${{ github.sha }}
   cancel-in-progress: false
@@ -34,10 +34,10 @@ jobs:
     steps:
       - id: check
         run: |
-          MSG="${{ github.event.head_commit.message }}"
-          if echo "$MSG" | head -1 | grep -qE "chore: release v|docs: update CHANGELOG for v"; then
+          AUTHOR="${{ github.event.head_commit.author.username }}"
+          if [ "$AUTHOR" = "github-actions[bot]" ]; then
             echo "should_release=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping — version bump or CHANGELOG commit."
+            echo "Skipping — automated commit (author: github-actions[bot])."
           else
             echo "should_release=true" >> "$GITHUB_OUTPUT"
             echo "Proceeding with release."


### PR DESCRIPTION
## Summary
Closes #625

Replaces the fragile regex-based release skip check with a deterministic author check.

## Before
```bash
MSG="${{ github.event.head_commit.message }}"
if echo "$MSG" | head -1 | grep -qE "chore: release v|docs: update CHANGELOG for v"
```

Problems:
- **False positive**: PR body text leaked into squash merge commit, matching the regex pattern
- **False negative**: Format changes in commit messages could bypass the check
- Required `head -1` hack to work around the false positive

## After
```bash
AUTHOR="${{ github.event.head_commit.author.username }}"
if [ "$AUTHOR" = "github-actions[bot]" ]
```

The CHANGELOG step already sets the commit author to `github-actions[bot]`, so checking the author is a deterministic and reliable way to identify automated commits.
