### PR TITLE
fix: remove --package-lock=false from CI/RC npm install to preserve workspace hoisting (#647)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - run: npm ci
-      - run: npm install --no-save --package-lock=false --legacy-peer-deps
+      - run: npm install --no-save --legacy-peer-deps
       - run: npm run build --workspace packages/shared
       - run: npm run build --workspace packages/core
       - run: npm test -- --coverage
@@ -77,7 +77,7 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
-      - run: npm install --no-save --package-lock=false --legacy-peer-deps
+      - run: npm install --no-save --legacy-peer-deps
       - run: npm run build --workspace packages/shared
       - run: npm run build --workspace packages/core
       - run: npm test

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -31,7 +31,7 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
-      - run: npm install --no-save --package-lock=false --legacy-peer-deps
+      - run: npm install --no-save --legacy-peer-deps
       - run: npm run build --workspace packages/shared
       - run: npm run build --workspace packages/core
       - run: npm test


### PR DESCRIPTION
## Summary
Removes `--package-lock=false` from the CI and RC pipeline `npm install` step to prevent workspace dependency resolution issues that cause `tsc` build failures.

## Root Cause
The `npm install --no-save --package-lock=false --legacy-peer-deps` step (added in #556 for platform-specific native dep resolution) was re-resolving the entire dependency tree without the lockfile. This caused npm to make different hoisting decisions than `npm ci`, stripping workspace dependencies like `@huggingface/transformers` from the root `node_modules`. TypeScript then failed with `TS2307: Cannot find module '@huggingface/transformers'`.

## Fix
Dropped `--package-lock=false` from both:
- `.github/workflows/ci.yml` (unit-test + integration-test jobs)
- `.github/workflows/rc.yml` (test job)

This preserves lockfile-based hoisting for existing packages while still allowing platform-specific native dependency resolution.

Closes #647
