### PR TITLE
fix: remove redundant npm install step causing optional dep stripping (#651, #652, #653)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - run: npm ci
-      - run: npm install --no-save --legacy-peer-deps
       - run: npm run build --workspace packages/shared
       - run: npm run build --workspace packages/core
       - run: npm test -- --coverage
@@ -77,7 +76,6 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
-      - run: npm install --no-save --legacy-peer-deps
       - run: npm run build --workspace packages/shared
       - run: npm run build --workspace packages/core
       - run: npm test

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -31,7 +31,6 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
-      - run: npm install --no-save --legacy-peer-deps
       - run: npm run build --workspace packages/shared
       - run: npm run build --workspace packages/core
       - run: npm test


### PR DESCRIPTION

## Summary

Removed the redundant 
pm install --no-save --legacy-peer-deps step from CI and RC workflows. This step was running AFTER 
pm ci and causing npm to strip platform-specific optional dependencies (specifically @rollup/rollup-linux-x64-gnu), breaking vitest on Linux/macOS runners. 

npm CLI bug #4828 � running 
pm install after 
pm ci re-resolves the dependency tree and can drop optional dependencies that are platform-specific.

## Root Cause

RC #43 failure log:
`
Cannot find module @rollup/rollup-linux-x64-gnu. 
npm has a bug related to optional dependencies 
(https://github.com/npm/cli/issues/4828).
`

The 
pm ci step correctly installs all dependencies including platform-specific optional deps from the lockfile. The subsequent 
pm install --no-save --legacy-peer-deps re-resolves without lockfile guidance and strips them.

## Fix

- **ci.yml**: Removed 
pm install --no-save --legacy-peer-deps from both unit-test and integration-test jobs
- **rc.yml**: Removed 
pm install --no-save --legacy-peer-deps from 	est job


pm ci alone is sufficient � it installs exactly what's in the lockfile.

## Files Changed

- .github/workflows/ci.yml � remove 2 lines
- .github/workflows/rc.yml � remove 1 line

Closes #651, closes #652, closes #653
