### PR TITLE
feat: Mermaid architecture diagram generation (#633)

### DIFF
--- a/packages/core/src/mcp/diagram-generator.ts
+++ b/packages/core/src/mcp/diagram-generator.ts
@@ -1,0 +1,542 @@
+/**
+ * Mermaid architecture diagram generation from the knowledge graph.
+ *
+ * Supports four diagram types:
+ * - community: Cluster subgraphs showing module boundaries with member symbols
+ * - process: Execution flow diagrams from entry points through STEP_IN_PROCESS
+ * - dependency: Directed graph of CALLS, IMPORTS, EXTENDS, IMPLEMENTS edges
+ * - class_hierarchy: EXTENDS and IMPLEMENTS relationships between Class/Interface nodes
+ */
+
+import type { KnowledgeGraph, GraphNode, GraphRelationship, RelationshipType } from '../core/types.js';
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export type DiagramType = 'community' | 'process' | 'dependency' | 'class_hierarchy';
+
+export interface DiagramOptions {
+  type: DiagramType;
+  clusterId?: string;
+  processId?: string;
+  maxNodes?: number;
+  minConfidence?: number;
+}
+
+export interface DiagramResult {
+  diagram: string;
+  format: 'mermaid' | 'markdown';
+  stats: {
+    nodeCount: number;
+    edgeCount: number;
+    communityCount?: number;
+    processCount?: number;
+  };
+}
+
+// ── Sanitization ────────────────────────────────────────────────────────────
+
+/**
+ * Convert a node ID to a valid Mermaid identifier.
+ * Mermaid node IDs can only contain alphanumeric chars, underscores, and hyphens.
+ */
+function sanitizeId(id: string): string {
+  return id.replace(/[^a-zA-Z0-9_-]/g, '_');
+}
+
+/**
+ * Escape a label for use inside Mermaid quotes.
+ */
+function sanitizeLabel(label: string): string {
+  return label.replace(/"/g, '\\"').replace(/\n/g, ' ').replace(/\r/g, '');
+}
+
+/**
+ * Get the best display name for a node (prefer name property, fall back to id).
+ */
+function nodeName(node: GraphNode): string {
+  return (node.properties.name as string) ?? node.id;
+}
+
+/**
+ * Get a short label representation for a node.
+ */
+function nodeLabel(node: GraphNode): string {
+  const name = nodeName(node);
+  // Truncate very long names for readability
+  const display = name.length > 50 ? name.slice(0, 47) + '...' : name;
+  return `${display}\\n[${node.label}]`;
+}
+
+// ── Edge Filtering ──────────────────────────────────────────────────────────
+
+/** Relationship types that represent structural/coupling edges for diagrams. */
+const COUPLING_EDGES: Set<RelationshipType> = new Set([
+  'CALLS', 'IMPORTS', 'EXTENDS', 'IMPLEMENTS', 'USES', 'DEFINES',
+]);
+
+const EXTENDS_IMPLEMENTS_EDGES: Set<RelationshipType> = new Set([
+  'EXTENDS', 'IMPLEMENTS',
+]);
+
+/**
+ * Format an edge type for display in Mermaid arrow labels.
+ */
+function formatEdgeType(type: RelationshipType): string {
+  // Shorten common types for diagram readability
+  switch (type) {
+    case 'METHOD_OVERRIDES': return 'overrides';
+    case 'METHOD_IMPLEMENTS': return 'implements';
+    case 'MEMBER_OF': return 'member of';
+    default: return type.toLowerCase().replace(/_/g, ' ');
+  }
+}
+
+/**
+ * Check if a relationship passes confidence threshold.
+ */
+function passesConfidence(rel: GraphRelationship, minConfidence: number): boolean {
+  return (rel.confidence ?? 1) >= minConfidence;
+}
+
+// ── Community Cluster Diagram ───────────────────────────────────────────────
+
+/**
+ * Build a Mermaid graph showing communities as subgraphs with their member
+ * symbols and the coupling edges between them.
+ */
+function buildCommunityDiagram(
+  graph: KnowledgeGraph,
+  opts: DiagramOptions,
+): string {
+  const lines: string[] = ['```mermaid', 'graph TD'];
+  const minConf = opts.minConfidence ?? 0.5;
+  const maxNodes = opts.maxNodes ?? 200;
+  let nodeCount = 0;
+  let edgeCount = 0;
+
+  // Build community → member mapping
+  const communityMap = new Map<string, { name: string; members: Set<string> }>();
+  for (const rel of graph.iterRelationshipsByType('MEMBER_OF')) {
+    if (!passesConfidence(rel, minConf)) continue;
+    const community = graph.getNode(rel.targetId);
+    const symbol = graph.getNode(rel.sourceId);
+    if (!community || !symbol) continue;
+
+    let entry = communityMap.get(community.id);
+    if (!entry) {
+      entry = {
+        name: (community.properties.name as string) ?? community.id,
+        members: new Set(),
+      };
+      communityMap.set(community.id, entry);
+    }
+    entry.members.add(symbol.id);
+  }
+
+  // If no communities found, do a flat diagram
+  if (communityMap.size === 0) {
+    lines.push('  %% No communities detected — showing flat dependency graph');
+    lines.push(...buildDependencyEdges(graph, new Set(), minConf, maxNodes, { nodeCount, edgeCount }));
+    lines.push('```');
+    return lines.join('\n');
+  }
+
+  // If clusterId specified, filter to only that community + connected communities
+  let targetCommunities: Set<string>;
+  if (opts.clusterId) {
+    targetCommunities = new Set<string>();
+    // Find the target community by id or name
+    let targetId = opts.clusterId;
+    for (const [id, comm] of communityMap) {
+      if (id === opts.clusterId || comm.name === opts.clusterId || id.includes(opts.clusterId)) {
+        targetId = id;
+        break;
+      }
+    }
+    targetCommunities.add(targetId);
+
+    // Also include communities that have edges to/from the target
+    const targetMembers = communityMap.get(targetId)?.members ?? new Set();
+    const connectedCommunities = new Set<string>();
+    for (const rel of graph.iterRelationships()) {
+      if (!COUPLING_EDGES.has(rel.type)) continue;
+      if (!passesConfidence(rel, minConf)) continue;
+      if (targetMembers.has(rel.sourceId) && !targetMembers.has(rel.targetId)) {
+        // Find which community the target belongs to
+        for (const [cid, comm] of communityMap) {
+          if (comm.members.has(rel.targetId)) connectedCommunities.add(cid);
+        }
+      }
+      if (targetMembers.has(rel.targetId) && !targetMembers.has(rel.sourceId)) {
+        for (const [cid, comm] of communityMap) {
+          if (comm.members.has(rel.sourceId)) connectedCommunities.add(cid);
+        }
+      }
+    }
+    for (const cid of connectedCommunities) targetCommunities.add(cid);
+  } else {
+    targetCommunities = new Set(communityMap.keys());
+  }
+
+  // Render communities as subgraphs
+  const allMemberIds = new Set<string>();
+  let communityIndex = 0;
+  for (const [commId, comm] of communityMap) {
+    if (!targetCommunities.has(commId)) continue;
+    if (comm.members.size === 0) continue;
+    communityIndex++;
+
+    const commLabel = sanitizeLabel(comm.name);
+    lines.push(`  subgraph cluster_${sanitizeId(commId)}["${commLabel}"]`);
+
+    // Add member nodes (limit per community)
+    let memberIdx = 0;
+    for (const memberId of comm.members) {
+      if (memberIdx >= Math.floor(maxNodes / communityMap.size)) break;
+      const member = graph.getNode(memberId);
+      if (!member) continue;
+      allMemberIds.add(memberId);
+      const mId = sanitizeId(memberId);
+      const mLabel = sanitizeLabel(nodeLabel(member));
+      lines.push(`    ${mId}["${mLabel}"]`);
+      memberIdx++;
+      nodeCount++;
+    }
+    lines.push('  end');
+    lines.push('');
+  }
+
+  // Render coupling edges between members (within and across communities)
+  lines.push(...buildDependencyEdges(graph, allMemberIds, minConf, maxNodes, { nodeCount, edgeCount }));
+  edgeCount += lines.filter(l => !l.startsWith('subgraph') && !l.startsWith('end') && !l.startsWith('%%')).length - 2;
+
+  lines.push('```');
+  return lines.join('\n');
+}
+
+// ── Process Flow Diagram ────────────────────────────────────────────────────
+
+function buildProcessDiagram(
+  graph: KnowledgeGraph,
+  opts: DiagramOptions,
+): string {
+  const lines: string[] = ['```mermaid', 'graph LR'];
+  const minConf = opts.minConfidence ?? 0.5;
+  let nodeCount = 0;
+  let edgeCount = 0;
+
+  // Find target process
+  const processes: Array<{ node: GraphNode; steps: Array<{ step: number; node: GraphNode }> }> = [];
+
+  for (const procNode of graph.iterNodes()) {
+    if (procNode.label !== 'Process') continue;
+    if (opts.processId && procNode.id !== opts.processId && procNode.properties.name !== opts.processId) continue;
+
+    // Collect ordered steps
+    const stepMap = new Map<number, GraphNode>();
+    for (const rel of graph.iterRelationshipsByType('STEP_IN_PROCESS')) {
+      if (rel.sourceId !== procNode.id) continue;
+      if (!passesConfidence(rel, minConf)) continue;
+      const stepNode = graph.getNode(rel.targetId);
+      if (stepNode) stepMap.set(rel.step ?? 0, stepNode);
+    }
+
+    const steps = Array.from(stepMap.entries())
+      .sort((a, b) => a[0] - b[0])
+      .map(([step, node]) => ({ step, node }));
+
+    if (steps.length > 0) {
+      processes.push({ node: procNode, steps });
+    }
+  }
+
+  if (processes.length === 0) {
+    lines.push('  %% No processes found');
+    lines.push('  A[No process data available]');
+    lines.push('```');
+    return lines.join('\n');
+  }
+
+  for (const proc of processes) {
+    const procLabel = sanitizeLabel(nodeName(proc.node));
+    lines.push(`  %% Process: ${procLabel} (${proc.node.properties.processType ?? 'unknown'})`);
+
+    // Render step nodes
+    const nodeIds: string[] = [];
+    for (const { step: _step, node } of proc.steps) {
+      const sId = sanitizeId(node.id);
+      const sLabel = sanitizeLabel(nodeName(node));
+      const shape = node.label === 'Function' || node.label === 'Method' ? `(["${sLabel}"])` : `["${sLabel}"]`;
+      lines.push(`  ${sId}${shape}`);
+      nodeIds.push(sId);
+      nodeCount++;
+    }
+
+    // Render step edges (sequential flow)
+    for (let i = 0; i < nodeIds.length - 1; i++) {
+      const stepNum = proc.steps[i + 1].step;
+      lines.push(`  ${nodeIds[i]} -->|"step ${stepNum}"| ${nodeIds[i + 1]}`);
+      edgeCount++;
+    }
+
+    // Add coupling edges between steps (CALLS, IMPORTS, etc.)
+    const stepIdSet = new Set(proc.steps.map(s => s.node.id));
+    for (const rel of graph.iterRelationships()) {
+      if (!COUPLING_EDGES.has(rel.type)) continue;
+      if (!passesConfidence(rel, minConf)) continue;
+      if (stepIdSet.has(rel.sourceId) && stepIdSet.has(rel.targetId)) {
+        const label = formatEdgeType(rel.type);
+        lines.push(`  ${sanitizeId(rel.sourceId)} -.->|"${label}"| ${sanitizeId(rel.targetId)}`);
+        edgeCount++;
+      }
+    }
+
+    lines.push('');
+  }
+
+  lines.push('```');
+  return lines.join('\n');
+}
+
+// ── Dependency Graph ────────────────────────────────────────────────────────
+
+function buildDependencyEdges(
+  graph: KnowledgeGraph,
+  filterNodes: Set<string>,
+  minConfidence: number,
+  maxNodes: number,
+  counters: { nodeCount: number; edgeCount: number },
+): string[] {
+  const lines: string[] = [];
+  const edgeSet = new Set<string>(); // deduplicate by sourceId|targetId|type
+
+  for (const rel of graph.iterRelationships()) {
+    if (!COUPLING_EDGES.has(rel.type)) continue;
+    if (!passesConfidence(rel, minConfidence)) continue;
+
+    // If filtering, both source and target must be in the filter set
+    if (filterNodes.size > 0) {
+      if (!filterNodes.has(rel.sourceId) && !filterNodes.has(rel.targetId)) continue;
+    }
+
+    // Limit edges
+    if (counters.edgeCount >= maxNodes * 3) break;
+
+    const edgeKey = `${rel.sourceId}|${rel.targetId}|${rel.type}`;
+    if (edgeSet.has(edgeKey)) continue;
+    edgeSet.add(edgeKey);
+
+    const srcId = sanitizeId(rel.sourceId);
+    const tgtId = sanitizeId(rel.targetId);
+    const label = formatEdgeType(rel.type);
+    const style = rel.type === 'EXTENDS' || rel.type === 'IMPLEMENTS' ? '==>' : '-->';
+    lines.push(`  ${srcId} ${style}|"${label}"| ${tgtId}`);
+    counters.edgeCount++;
+  }
+
+  return lines;
+}
+
+function buildDependencyDiagram(
+  graph: KnowledgeGraph,
+  opts: DiagramOptions,
+): string {
+  const lines: string[] = ['```mermaid', 'graph TD'];
+  const minConf = opts.minConfidence ?? 0.5;
+  const maxNodes = opts.maxNodes ?? 100;
+  const counters = { nodeCount: 0, edgeCount: 0 };
+  const shownNodes = new Set<string>();
+
+  // First pass: collect all nodes that participate in coupling edges
+  const edgeNodes = new Set<string>();
+  for (const rel of graph.iterRelationships()) {
+    if (!COUPLING_EDGES.has(rel.type)) continue;
+    if (!passesConfidence(rel, minConf)) continue;
+    edgeNodes.add(rel.sourceId);
+    edgeNodes.add(rel.targetId);
+    if (edgeNodes.size >= maxNodes) break;
+  }
+
+  // Second pass: render nodes
+  for (const nodeId of edgeNodes) {
+    if (counters.nodeCount >= maxNodes) break;
+    const node = graph.getNode(nodeId);
+    if (!node) continue;
+    const nId = sanitizeId(nodeId);
+    const nLabel = sanitizeLabel(nodeLabel(node));
+    lines.push(`  ${nId}["${nLabel}"]`);
+    counters.nodeCount++;
+    shownNodes.add(nodeId);
+  }
+
+  // Third pass: render edges
+  const edgeLines = buildDependencyEdges(graph, shownNodes, minConf, maxNodes, counters);
+  lines.push(...edgeLines);
+
+  if (counters.nodeCount === 0) {
+    lines.push('  A[No coupling edges found in graph]');
+  }
+
+  lines.push('```');
+  return lines.join('\n');
+}
+
+// ── Class Hierarchy Diagram ─────────────────────────────────────────────────
+
+function buildClassHierarchyDiagram(
+  graph: KnowledgeGraph,
+  opts: DiagramOptions,
+): string {
+  const lines: string[] = ['```mermaid', 'graph TD'];
+  const minConf = opts.minConfidence ?? 0.5;
+  const maxNodes = opts.maxNodes ?? 100;
+  const counters = { nodeCount: 0, edgeCount: 0 };
+  const shownNodes = new Set<string>();
+
+  // Collect classes and interfaces
+  const classNodes = new Map<string, GraphNode>();
+  for (const node of graph.iterNodes()) {
+    if (node.label === 'Class' || node.label === 'Interface') {
+      classNodes.set(node.id, node);
+    }
+  }
+
+  // Find EXTENDS/IMPLEMENTS edges between classes/interfaces
+  const hierarchyEdges: Array<{ sourceId: string; targetId: string; type: RelationshipType }> = [];
+  const edgeNodes = new Set<string>();
+  for (const rel of graph.iterRelationships()) {
+    if (!EXTENDS_IMPLEMENTS_EDGES.has(rel.type)) continue;
+    if (!passesConfidence(rel, minConf)) continue;
+    if (!classNodes.has(rel.sourceId) && !classNodes.has(rel.targetId)) continue;
+    hierarchyEdges.push({ sourceId: rel.sourceId, targetId: rel.targetId, type: rel.type });
+    edgeNodes.add(rel.sourceId);
+    edgeNodes.add(rel.targetId);
+  }
+
+  // Also include METHOD_OVERRIDES and METHOD_IMPLEMENTS edges
+  for (const rel of graph.iterRelationships()) {
+    if (rel.type !== 'METHOD_OVERRIDES' && rel.type !== 'METHOD_IMPLEMENTS') continue;
+    if (!passesConfidence(rel, minConf)) continue;
+    hierarchyEdges.push({ sourceId: rel.sourceId, targetId: rel.targetId, type: rel.type });
+    edgeNodes.add(rel.sourceId);
+    edgeNodes.add(rel.targetId);
+  }
+
+  if (hierarchyEdges.length === 0) {
+    lines.push('  %% No class hierarchy relationships found');
+    lines.push('  A[No EXTENDS/IMPLEMENTS edges detected]');
+    lines.push('```');
+    return lines.join('\n');
+  }
+
+  // Render nodes (only those with hierarchy relationships)
+  for (const nodeId of edgeNodes) {
+    if (counters.nodeCount >= maxNodes) break;
+    const node = classNodes.get(nodeId) ?? graph.getNode(nodeId);
+    if (!node) continue;
+    const nId = sanitizeId(nodeId);
+    const nLabel = sanitizeLabel(nodeLabel(node));
+    const shape = node.label === 'Interface' ? `{{"${nLabel}"}}` : `["${nLabel}"]`;
+    lines.push(`  ${nId}${shape}`);
+    counters.nodeCount++;
+    shownNodes.add(nodeId);
+  }
+
+  // Render edges
+  const edgeSet = new Set<string>();
+  for (const { sourceId, targetId, type } of hierarchyEdges) {
+    const key = `${sourceId}|${targetId}|${type}`;
+    if (edgeSet.has(key)) continue;
+    edgeSet.add(key);
+
+    const srcId = sanitizeId(sourceId);
+    const tgtId = sanitizeId(targetId);
+    const style = type === 'EXTENDS' || type === 'IMPLEMENTS' ? '==>' : '-.->';
+    lines.push(`  ${srcId} ${style}|"${formatEdgeType(type)}"| ${tgtId}`);
+    counters.edgeCount++;
+  }
+
+  lines.push('```');
+  return lines.join('\n');
+}
+
+// ── Main Entry Point ────────────────────────────────────────────────────────
+
+export function generateDiagram(graph: KnowledgeGraph, opts: DiagramOptions): DiagramResult {
+  let diagram: string;
+  let communityCount: number | undefined;
+  let processCount: number | undefined;
+
+  // Count communities and processes for stats
+  for (const node of graph.iterNodes()) {
+    if (node.label === 'Community') communityCount = (communityCount ?? 0) + 1;
+    if (node.label === 'Process') processCount = (processCount ?? 0) + 1;
+  }
+
+  switch (opts.type) {
+    case 'community':
+      diagram = buildCommunityDiagram(graph, opts);
+      break;
+    case 'process':
+      diagram = buildProcessDiagram(graph, opts);
+      break;
+    case 'dependency':
+      diagram = buildDependencyDiagram(graph, opts);
+      break;
+    case 'class_hierarchy':
+      diagram = buildClassHierarchyDiagram(graph, opts);
+      break;
+    default:
+      diagram = '```mermaid\ngraph TD\n  A[Unknown diagram type]\n```';
+  }
+
+  // Extract node/edge counts from the Mermaid output
+  const nodeMatches = diagram.match(/^\s+(?!subgraph|end|%%|```)(\w+)(?:\(?)\[/gm);
+  const edgeMatches = diagram.match(/^\s+\w+\s+(-->|==>|==|\.-\>|\|)/gm);
+  const nodeCount = nodeMatches?.length ?? 0;
+  const edgeCount = edgeMatches?.length ?? 0;
+
+  return {
+    diagram,
+    format: 'mermaid',
+    stats: { nodeCount, edgeCount, communityCount, processCount },
+  };
+}
+
+/**
+ * Wraps Mermaid diagram in markdown documentation structure.
+ */
+export function generateMarkdownDoc(
+  graph: KnowledgeGraph,
+  opts: DiagramOptions,
+  repoName?: string,
+): string {
+  const result = generateDiagram(graph, opts);
+
+  const typeTitles: Record<DiagramType, string> = {
+    community: 'Community Architecture',
+    process: 'Process Flow',
+    dependency: 'Dependency Graph',
+    class_hierarchy: 'Class Hierarchy',
+  };
+
+  const typeDescs: Record<DiagramType, string> = {
+    community: 'Module boundaries and coupling relationships between functional communities detected by community detection.',
+    process: 'Execution flow tracing from entry points through the call graph.',
+    dependency: 'CALLS, IMPORTS, EXTENDS, and IMPLEMENTS relationships between code symbols.',
+    class_hierarchy: 'Inheritance and implementation relationships between classes and interfaces.',
+  };
+
+  const header = repoName ? `# ${typeTitles[opts.type]} — ${repoName}` : `# ${typeTitles[opts.type]}`;
+  return [
+    header,
+    '',
+    typeDescs[opts.type],
+    '',
+    `**Stats**: ${result.stats.nodeCount} nodes, ${result.stats.edgeCount} edges`,
+    result.stats.communityCount != null ? `- Communities: ${result.stats.communityCount}` : '',
+    result.stats.processCount != null ? `- Processes: ${result.stats.processCount}` : '',
+    '',
+    result.diagram,
+  ].filter(Boolean).join('\n');
+}

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -25,6 +25,7 @@ import { executeTraversal, type TraversalQuery } from './traverse.js';
 import { PhaseTimer } from '../core/phase-timer.js';
 import { pageRank, betweennessCentrality, shortestPath } from '../core/graph-algorithms.js';
 import { chat as ragChat, type ChatMessage } from '../agent/rag-chat.js';
+import { generateDiagram, generateMarkdownDoc, type DiagramType, type DiagramOptions } from './diagram-generator.js';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -1785,6 +1786,54 @@ Requires ASTROLABE_API_KEY or OPENAI_API_KEY environment variable to be set for 
       }
     },
   },
+
+  'astrolabe.generate_diagram': {
+    name: 'astrolabe.generate_diagram',
+    description: `Generate Mermaid architecture diagrams from the knowledge graph.
+
+DIAGRAM TYPES:
+- community: Cluster subgraphs showing module boundaries, member symbols, and coupling edges
+- process: Execution flow diagrams from entry points through step-by-step call traces
+- dependency: Directed graph of CALLS, IMPORTS, EXTENDS, IMPLEMENTS, USES relationships
+- class_hierarchy: Inheritance tree showing EXTENDS/IMPLEMENTS between classes and interfaces`,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        diagram_type: { type: 'string', enum: ['community', 'process', 'dependency', 'class_hierarchy'], description: 'Type of diagram to generate' },
+        repo: { type: 'string', description: 'Repository name' },
+        cluster_id: { type: 'string', description: 'Filter community diagram to a specific cluster (by id or name)' },
+        process_id: { type: 'string', description: 'Filter process diagram to a specific process (by id or name)' },
+        format: { type: 'string', enum: ['mermaid', 'markdown'], description: 'Output format. "mermaid" returns raw diagram code. "markdown" wraps in documentation.', default: 'mermaid' },
+        max_nodes: { type: 'number', description: 'Maximum nodes to include (default: 200 for community, 100 for others)' },
+        min_confidence: { type: 'number', description: 'Minimum edge confidence threshold (default: 0.5)' },
+      },
+      required: ['diagram_type'],
+    },
+    handler: async (params) => {
+      const diagramType = requireString(params, 'diagram_type') as DiagramType;
+      const format = (params.format as string) ?? 'mermaid';
+      const ctx = backend.getRepo(params.repo as string);
+      const graph = ctx.loadGraph();
+
+      const opts: DiagramOptions = {
+        type: diagramType,
+        clusterId: params.cluster_id as string | undefined,
+        processId: params.process_id as string | undefined,
+        maxNodes: params.max_nodes as number | undefined,
+        minConfidence: params.min_confidence as number | undefined,
+      };
+
+      if (format === 'markdown') {
+        const repoName = (params.repo as string) ?? ctx.entry.name;
+        const doc = generateMarkdownDoc(graph, opts, repoName);
+        return { content: [{ type: 'text', text: doc }] };
+      }
+
+      const result = generateDiagram(graph, opts);
+      const statsLine = `// ${result.stats.nodeCount} nodes, ${result.stats.edgeCount} edges`;
+      return { content: [{ type: 'text', text: result.diagram + '\n\n' + statsLine }] };
+    },
+  },
 };
 
 // ── Resources ──────────────────────────────────────────────────────────────
@@ -2193,6 +2242,19 @@ Summarize your findings:
     const repo = args.repoPath ?? '';
     const format = args.format ?? 'mermaid';
     const repoLabel = repo ? ` "${repo}"` : '';
+    const repoArg = repo ? `, repo: "${repo}"` : '';
+    const mermaidStep = format === 'mermaid'
+      ? `**Step 5 — Generate Mermaid Diagram**
+Call: \`astrolabe.generate_diagram({diagram_type: "community"${repoArg}})\`
+This produces a Mermaid graph with communities as subgraphs, member symbols as nodes,
+and CALLS/IMPORTS/EXTENDS/IMPLEMENTS relationships as edges.
+
+For process flows, call: \`astrolabe.generate_diagram({diagram_type: "process"${repoArg}})\`
+For dependency graphs, call: \`astrolabe.generate_diagram({diagram_type: "dependency"${repoArg}})\`
+For class hierarchies, call: \`astrolabe.generate_diagram({diagram_type: "class_hierarchy"${repoArg}})\``
+      : `**Step 5 — Generate Markdown Documentation**
+Call: \`astrolabe.generate_diagram({diagram_type: "community", format: "markdown"${repoArg}})\`
+This produces a Markdown document with architecture overview, per-cluster details, and stats.`;
     return [
       {
         role: 'user',
@@ -2218,18 +2280,7 @@ Read resource: \`astrolabe://repo/{name}/schema\` for available node/edge types.
 Read resource: \`astrolabe://repo/{name}/processes\` for execution flows.
 For important processes, read: \`astrolabe://repo/{name}/process/{processName}\` for step-by-step traces.
 
-**Step 5 — Generate ${format === 'mermaid' ? 'Mermaid Diagram' : 'Markdown Documentation'}**
-${format === 'mermaid'
-    ? `Create a Mermaid architecture diagram showing:
-- Modules/clusters as subgraphs
-- Key symbols (functions, classes, routes) as nodes
-- CALLS, IMPORTS, EXTENDS relationships as directed edges
-- Data flow between processes`
-    : `Create a structured Markdown document with:
-- Architecture overview section
-- Per-cluster documentation (purpose, entry points, key dependencies)
-- Cross-cluster dependency summary
-- Process flow descriptions`}
+${mermaidStep}
 
 **Step 6 — Document Each Cluster**
 For each cluster found in Step 3, describe:

--- a/packages/core/tests/mcp/diagram-generator.test.ts
+++ b/packages/core/tests/mcp/diagram-generator.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Tests for the Mermaid diagram generator.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createKnowledgeGraph } from '../../src/core/graph.js';
+import { generateDiagram, generateMarkdownDoc } from '../../src/mcp/diagram-generator.js';
+import type { GraphNode, GraphRelationship } from '../../src/core/types.js';
+
+function makeNode(overrides: Partial<GraphNode> & { id: string }): GraphNode {
+  return { label: 'Function', properties: {}, ...overrides };
+}
+
+function makeRel(overrides: Partial<GraphRelationship> & { id: string; sourceId: string; targetId: string }): GraphRelationship {
+  return { type: 'CALLS', confidence: 1.0, reason: 'test', ...overrides };
+}
+
+// ── Helper: build a small realistic graph ───────────────────────────────────
+
+function buildTestGraph() {
+  const g = createKnowledgeGraph();
+
+  // Communities
+  g.addNode(makeNode({ id: 'community:1', label: 'Community', properties: { name: 'auth-module', symbolCount: 3, cohesion: 0.85 } }));
+  g.addNode(makeNode({ id: 'community:2', label: 'Community', properties: { name: 'db-layer', symbolCount: 2, cohesion: 0.72 } }));
+
+  // Members of community 1
+  g.addNode(makeNode({ id: 'fn:auth:login', label: 'Function', properties: { name: 'login', filePath: 'src/auth/login.ts', startLine: 10 } }));
+  g.addNode(makeNode({ id: 'fn:auth:validate', label: 'Function', properties: { name: 'validateToken', filePath: 'src/auth/validate.ts', startLine: 5 } }));
+  g.addNode(makeNode({ id: 'cls:auth:handler', label: 'Class', properties: { name: 'AuthHandler', filePath: 'src/auth/handler.ts', startLine: 1 } }));
+
+  // Members of community 2
+  g.addNode(makeNode({ id: 'fn:db:query', label: 'Function', properties: { name: 'query', filePath: 'src/db/query.ts', startLine: 20 } }));
+  g.addNode(makeNode({ id: 'cls:db:repo', label: 'Class', properties: { name: 'UserRepo', filePath: 'src/db/repo.ts', startLine: 1 } }));
+
+  // Interfaces and implementations for class hierarchy
+  g.addNode(makeNode({ id: 'iface:auth:provider', label: 'Interface', properties: { name: 'AuthProvider', filePath: 'src/auth/provider.ts', startLine: 3 } }));
+  g.addNode(makeNode({ id: 'cls:auth:impl', label: 'Class', properties: { name: 'OAuthProvider', filePath: 'src/auth/oauth.ts', startLine: 1 } }));
+
+  // MEMBER_OF edges
+  g.addRelationship(makeRel({ id: 'mem:1', sourceId: 'fn:auth:login', targetId: 'community:1', type: 'MEMBER_OF', confidence: 0.7 }));
+  g.addRelationship(makeRel({ id: 'mem:2', sourceId: 'fn:auth:validate', targetId: 'community:1', type: 'MEMBER_OF', confidence: 0.7 }));
+  g.addRelationship(makeRel({ id: 'mem:3', sourceId: 'cls:auth:handler', targetId: 'community:1', type: 'MEMBER_OF', confidence: 0.7 }));
+  g.addRelationship(makeRel({ id: 'mem:4', sourceId: 'fn:db:query', targetId: 'community:2', type: 'MEMBER_OF', confidence: 0.7 }));
+  g.addRelationship(makeRel({ id: 'mem:5', sourceId: 'cls:db:repo', targetId: 'community:2', type: 'MEMBER_OF', confidence: 0.7 }));
+
+  // Coupling edges
+  g.addRelationship(makeRel({ id: 'call:1', sourceId: 'fn:auth:login', targetId: 'fn:auth:validate', type: 'CALLS', confidence: 0.9 }));
+  g.addRelationship(makeRel({ id: 'call:2', sourceId: 'cls:auth:handler', targetId: 'fn:auth:login', type: 'CALLS', confidence: 0.8 }));
+  g.addRelationship(makeRel({ id: 'call:3', sourceId: 'fn:auth:login', targetId: 'fn:db:query', type: 'CALLS', confidence: 0.85 }));
+  g.addRelationship(makeRel({ id: 'call:4', sourceId: 'cls:db:repo', targetId: 'fn:db:query', type: 'CALLS', confidence: 0.9 }));
+
+  // EXTENDS / IMPLEMENTS for class hierarchy
+  g.addRelationship(makeRel({ id: 'ext:1', sourceId: 'cls:auth:impl', targetId: 'iface:auth:provider', type: 'IMPLEMENTS', confidence: 0.95 }));
+  g.addRelationship(makeRel({ id: 'ext:2', sourceId: 'cls:auth:handler', targetId: 'cls:auth:impl', type: 'EXTENDS', confidence: 0.8 }));
+
+  // Process
+  g.addNode(makeNode({ id: 'process:login_flow', label: 'Process', properties: { name: 'login-flow', entryPointId: 'fn:auth:login', stepCount: 3, processType: 'cross_community' } }));
+
+  // STEP_IN_PROCESS edges
+  g.addRelationship(makeRel({ id: 'step:1', sourceId: 'process:login_flow', targetId: 'fn:auth:login', type: 'STEP_IN_PROCESS', step: 1, confidence: 1.0 }));
+  g.addRelationship(makeRel({ id: 'step:2', sourceId: 'process:login_flow', targetId: 'fn:auth:validate', type: 'STEP_IN_PROCESS', step: 2, confidence: 1.0 }));
+  g.addRelationship(makeRel({ id: 'step:3', sourceId: 'process:login_flow', targetId: 'fn:db:query', type: 'STEP_IN_PROCESS', step: 3, confidence: 1.0 }));
+
+  // ENTRY_POINT_OF
+  g.addRelationship(makeRel({ id: 'ep:1', sourceId: 'fn:auth:login', targetId: 'process:login_flow', type: 'ENTRY_POINT_OF', confidence: 0.9 }));
+
+  return g;
+}
+
+describe('diagram-generator', () => {
+  // ── Community Diagram ──────────────────────────────────────────────────
+  describe('community diagram', () => {
+    it('produces Mermaid syntax with subgraphs', () => {
+      const g = buildTestGraph();
+      const result = generateDiagram(g, { type: 'community' });
+
+      expect(result.format).toBe('mermaid');
+      expect(result.diagram).toContain('```mermaid');
+      expect(result.diagram).toContain('graph TD');
+      expect(result.diagram).toContain('subgraph');
+      expect(result.diagram).toContain('auth-module');
+      expect(result.diagram).toContain('db-layer');
+      expect(result.diagram).toContain('-->');
+      expect(result.stats.nodeCount).toBeGreaterThan(0);
+      expect(result.stats.edgeCount).toBeGreaterThan(0);
+    });
+
+    it('filters by cluster_id', () => {
+      const g = buildTestGraph();
+      const result = generateDiagram(g, { type: 'community', clusterId: 'community:1' });
+
+      expect(result.diagram).toContain('auth-module');
+      // Should focus on community:1 and connected communities
+      expect(result.diagram).toContain('subgraph');
+    });
+
+    it('handles empty graph gracefully', () => {
+      const g = createKnowledgeGraph();
+      const result = generateDiagram(g, { type: 'community' });
+
+      expect(result.diagram).toContain('```mermaid');
+      expect(result.diagram).toContain('%% No communities detected');
+      expect(result.stats.nodeCount).toBe(0);
+    });
+  });
+
+  // ── Process Diagram ────────────────────────────────────────────────────
+  describe('process diagram', () => {
+    it('produces Mermaid flow for login process', () => {
+      const g = buildTestGraph();
+      const result = generateDiagram(g, { type: 'process', processId: 'process:login_flow' });
+
+      expect(result.diagram).toContain('```mermaid');
+      expect(result.diagram).toContain('graph LR');
+      expect(result.diagram).toContain('login');
+      expect(result.diagram).toContain('validateToken');
+      expect(result.diagram).toContain('query');
+      expect(result.diagram).toContain('-->|"step ');
+      expect(result.stats.nodeCount).toBeGreaterThan(0);
+    });
+
+    it('shows all processes when no processId given', () => {
+      const g = buildTestGraph();
+      const result = generateDiagram(g, { type: 'process' });
+
+      expect(result.diagram).toContain('```mermaid');
+      expect(result.diagram).toContain('login-flow');
+    });
+
+    it('handles no processes gracefully', () => {
+      const g = createKnowledgeGraph();
+      const result = generateDiagram(g, { type: 'process' });
+
+      expect(result.diagram).toContain('No process data available');
+    });
+  });
+
+  // ── Dependency Diagram ─────────────────────────────────────────────────
+  describe('dependency diagram', () => {
+    it('produces Mermaid graph of coupling edges', () => {
+      const g = buildTestGraph();
+      const result = generateDiagram(g, { type: 'dependency' });
+
+      expect(result.diagram).toContain('```mermaid');
+      expect(result.diagram).toContain('graph TD');
+      expect(result.diagram).toContain('-->');
+      expect(result.diagram).toContain('login');
+      expect(result.diagram).toContain('validateToken');
+    });
+
+    it('respects max_nodes limit', () => {
+      const g = buildTestGraph();
+      const result = generateDiagram(g, { type: 'dependency', maxNodes: 2 });
+
+      expect(result.stats.nodeCount).toBeLessThanOrEqual(2);
+    });
+
+    it('respects min_confidence threshold', () => {
+      const g = buildTestGraph();
+
+      // Add a low-confidence edge
+      g.addNode(makeNode({ id: 'fn:low:conf', label: 'Function', properties: { name: 'lowConf' } }));
+      g.addRelationship(makeRel({ id: 'lc:1', sourceId: 'fn:auth:login', targetId: 'fn:low:conf', type: 'CALLS', confidence: 0.2 }));
+
+      // With high threshold, low-confidence edge should be excluded
+      const result = generateDiagram(g, { type: 'dependency', minConfidence: 0.8 });
+      expect(result.diagram).not.toContain('lowConf');
+    });
+
+    it('handles no edges gracefully', () => {
+      const g = createKnowledgeGraph();
+      g.addNode(makeNode({ id: 'a', label: 'Function', properties: { name: 'lonely' } }));
+      const result = generateDiagram(g, { type: 'dependency' });
+
+      expect(result.diagram).toContain('No coupling edges found');
+    });
+  });
+
+  // ── Class Hierarchy Diagram ────────────────────────────────────────────
+  describe('class hierarchy diagram', () => {
+    it('produces Mermaid graph of EXTENDS/IMPLEMENTS', () => {
+      const g = buildTestGraph();
+      const result = generateDiagram(g, { type: 'class_hierarchy' });
+
+      expect(result.diagram).toContain('```mermaid');
+      expect(result.diagram).toContain('graph TD');
+      expect(result.diagram).toContain('OAuthProvider');
+      expect(result.diagram).toContain('AuthProvider');
+      expect(result.diagram).toContain('AuthHandler');
+      expect(result.diagram).toContain('==>');
+    });
+
+    it('handles no hierarchy gracefully', () => {
+      const g = createKnowledgeGraph();
+      g.addNode(makeNode({ id: 'cls:a', label: 'Class', properties: { name: 'LonelyClass' } }));
+      const result = generateDiagram(g, { type: 'class_hierarchy' });
+
+      expect(result.diagram).toContain('No EXTENDS/IMPLEMENTS edges');
+    });
+  });
+
+  // ── Markdown Format ────────────────────────────────────────────────────
+  describe('markdown format', () => {
+    it('wraps Mermaid diagram in documentation', () => {
+      const g = buildTestGraph();
+      const doc = generateMarkdownDoc(g, { type: 'community' }, 'my-repo');
+
+      expect(doc).toContain('# Community Architecture');
+      expect(doc).toContain('my-repo');
+      expect(doc).toContain('```mermaid');
+      expect(doc).toContain('**Stats**');
+    });
+
+    it('works without repo name', () => {
+      const g = buildTestGraph();
+      const doc = generateMarkdownDoc(g, { type: 'dependency' });
+
+      expect(doc).toContain('# Dependency Graph');
+      expect(doc).toContain('```mermaid');
+    });
+  });
+
+  // ── Stats ──────────────────────────────────────────────────────────────
+  describe('stats', () => {
+    it('includes community and process counts', () => {
+      const g = buildTestGraph();
+      const result = generateDiagram(g, { type: 'community' });
+
+      expect(result.stats.communityCount).toBe(2);
+      expect(result.stats.processCount).toBe(1);
+    });
+  });
+
+  // ── Edge Cases ─────────────────────────────────────────────────────────
+  describe('edge cases', () => {
+    it('sanitizes node IDs with special characters', () => {
+      const g = createKnowledgeGraph();
+      g.addNode(makeNode({ id: 'ns:com.example:MyClass', label: 'Class', properties: { name: 'MyClass' } }));
+      g.addNode(makeNode({ id: 'ns:com.example:OtherClass', label: 'Class', properties: { name: 'OtherClass' } }));
+      g.addRelationship(makeRel({ id: 'r1', sourceId: 'ns:com.example:MyClass', targetId: 'ns:com.example:OtherClass', type: 'EXTENDS' }));
+
+      const result = generateDiagram(g, { type: 'class_hierarchy' });
+      expect(result.diagram).not.toContain('ns:com.example:MyClass'); // raw colon-containing ID
+      expect(result.diagram).toContain('MyClass'); // sanitized label
+    });
+
+    it('sanitizes labels with quotes', () => {
+      const g = createKnowledgeGraph();
+      g.addNode(makeNode({ id: 'fn:test', label: 'Function', properties: { name: 'handle "special" case' } }));
+      g.addNode(makeNode({ id: 'fn:test2', label: 'Function', properties: { name: 'normal' } }));
+      g.addRelationship(makeRel({ id: 'r1', sourceId: 'fn:test', targetId: 'fn:test2', type: 'CALLS' }));
+
+      const result = generateDiagram(g, { type: 'dependency' });
+      // The quote should be escaped, not raw
+      expect(result.diagram).toContain('\\"special\\"');
+    });
+
+    it('truncates very long node names', () => {
+      const g = createKnowledgeGraph();
+      const longName = 'a'.repeat(60);
+      g.addNode(makeNode({ id: 'fn:long', label: 'Function', properties: { name: longName } }));
+      g.addNode(makeNode({ id: 'fn:short', label: 'Function', properties: { name: 'b' } }));
+      g.addRelationship(makeRel({ id: 'r1', sourceId: 'fn:long', targetId: 'fn:short', type: 'CALLS' }));
+
+      const result = generateDiagram(g, { type: 'dependency' });
+      expect(result.diagram).toContain('...');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds server-side Mermaid diagram generation from the knowledge graph, replacing the old manual-drawing approach with a new MCP tool.

- **New `diagram-generator.ts`**: `generateDiagram(graph, opts)` produces valid Mermaid syntax for 4 diagram types
- **New MCP tool**: `astrolabe.generate_diagram` with params: `diagram_type` (community/process/dependency/class_hierarchy), `repo`, `cluster_id`, `process_id`, `format` (mermaid/markdown), `max_nodes`, `min_confidence`
- **Updated `generate_map` prompt**: Now calls the tool instead of telling the AI to "create a Mermaid diagram" manually

## Diagram Types

| Type | Mermaid Syntax | Content |
|------|---------------|---------|
| `community` | `graph TD` with `subgraph` per cluster | Module boundaries, member symbols, coupling edges |
| `process` | `graph LR` with step sequences | Execution flows from entry points via STEP_IN_PROCESS |
| `dependency` | `graph TD` with directed edges | CALLS, IMPORTS, EXTENDS, IMPLEMENTS, USES |
| `class_hierarchy` | `graph TD` with thick arrows | EXTENDS/IMPLEMENTS tree for classes and interfaces |

## Testing

- 18 new tests in `diagram-generator.test.ts` covering all diagram types, confidence filtering, node limits, cluster filtering, markdown format, label sanitization, and type truncation
- Full test suite: **526 pass, 17 skipped** (no regressions)

Closes #633
