### PR TITLE
feat: response shape extraction and consumer mismatch detection (#641)

### DIFF
--- a/packages/core/src/mcp/api-tools.ts
+++ b/packages/core/src/mcp/api-tools.ts
@@ -185,7 +185,7 @@ export function toolMap(graph: KnowledgeGraph): ToolMapEntry[] {
 
 // ── api_impact ─────────────────────────────────────────────────────────────
 
-export function apiImpact(graph: KnowledgeGraph, symbolName: string): ApiImpactResult[] {
+export async function apiImpact(graph: KnowledgeGraph, symbolName: string, repoPath?: string): Promise<ApiImpactResult[]> {
   // #335: Find ALL matching symbols, not just the first
   const targetIds: string[] = [];
   for (const node of graph.iterNodes()) {
@@ -275,21 +275,134 @@ export function apiImpact(graph: KnowledgeGraph, symbolName: string): ApiImpactR
       tools.push(t);
     }
 
+    // Collect shape drift from route response shape analysis
+    const shapeDrift: ApiImpactResult['shapeDrift'] = [];
+    for (const r of matchedRoutes) {
+      const mismatches = await shapeCheck(graph, r.path, repoPath);
+      for (const m of mismatches) {
+        shapeDrift.push({
+          field: `${r.method} ${r.path}: ${m.field}`,
+          severity: m.severity,
+        });
+      }
+    }
+
     results.push({
       symbol: `${symbolName} (${targetId})`,
       routes,
       tools,
-      shapeDrift: [],
+      shapeDrift,
     });
   }
 
   return results;
 }
 
+// ── Consumer field access extraction ────────────────────────────────────────
+
+// Lazy imports for file I/O (only loaded when repoPath is provided)
+let _readFileFn: ((path: string, encoding: string) => Promise<string>) | undefined;
+let _joinPathFn: ((...parts: string[]) => string) | undefined;
+
+function getReadFile(): (path: string, encoding: string) => Promise<string> {
+  if (!_readFileFn) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    _readFileFn = require('node:fs/promises').readFile;
+  }
+  return _readFileFn!;
+}
+function getJoinPath(): (...parts: string[]) => string {
+  if (!_joinPathFn) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    _joinPathFn = require('node:path').join;
+  }
+  return _joinPathFn!;
+}
+
+/**
+ * Variable names commonly used to hold HTTP response data after fetch/axios calls.
+ * We scan for member access on these identifiers to detect what fields consumers read.
+ */
+const RESPONSE_VAR_NAMES = new Set([
+  'data', 'response', 'json', 'result', 'body', 'res', 'resp',
+  'apiResponse', 'responseData', 'r', 'd',
+]);
+
+/**
+ * Extract field names accessed on HTTP response variables in consumer code.
+ *
+ * Detects patterns like `data.field`, `response['field']`, `result?.field`,
+ * `data.field.subfield` (captures top-level: `field`), destructuring
+ * like `const { id, name } = data`, and `data?.field`.
+ *
+ * Returns deduplicated list of top-level field names.
+ */
+export function extractConsumerAccessedFields(code: string): string[] {
+  const fields = new Set<string>();
+
+  // Pattern 1: dot access or optional chaining on response vars — data.field, response?.field
+  const dotPattern = /([$\w]+)\?\.(\w+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = dotPattern.exec(code)) !== null) {
+    if (RESPONSE_VAR_NAMES.has(m[1]!)) {
+      fields.add(m[2]!);
+    }
+  }
+
+  // Pattern 2: plain dot access — data.field (not optional chaining)
+  // We need to avoid re-matching optional chaining, so use a lookbehind-free approach
+  // Match identifier.field where identifier is not preceded by ?.
+  const plainDotPattern = /([$\w]+)\.(\w+)/g;
+  while ((m = plainDotPattern.exec(code)) !== null) {
+    // Avoid optional chaining (already handled above)
+    if (code[m.index - 1] === '?') continue;
+    // Avoid matching numbers (e.g., 3.14)
+    if (/^\d/.test(m[1]!)) continue;
+    if (RESPONSE_VAR_NAMES.has(m[1]!)) {
+      fields.add(m[2]!);
+    }
+  }
+
+  // Pattern 3: bracket access — data['field'] or data["field"]
+  const bracketPattern = /([$\w]+)\s*\[(['"])([^'"]+)\2\]/g;
+  while ((m = bracketPattern.exec(code)) !== null) {
+    if (RESPONSE_VAR_NAMES.has(m[1]!)) {
+      fields.add(m[3]!);
+    }
+  }
+
+  // Pattern 4: destructuring — const { id, name } = data or const { id, name } = await data
+  const destructPattern = /(?:const|let|var)\s*\{([^}]+)\}\s*=\s*(?:await\s+)?(\w+)/g;
+  while ((m = destructPattern.exec(code)) !== null) {
+    const varName = m[2];
+    if (!varName || !RESPONSE_VAR_NAMES.has(varName)) continue;
+    const fieldsText = m[1]!;
+    const parts = fieldsText.split(',');
+    for (const part of parts) {
+      const fieldName = part.trim().split(':')[0]?.trim();
+      if (fieldName && /^\w+$/.test(fieldName) && !RESPONSE_VAR_NAMES.has(fieldName)) {
+        fields.add(fieldName);
+      }
+    }
+  }
+
+  return Array.from(fields);
+}
+
 // ── shape_check ────────────────────────────────────────────────────────────
 
-export function shapeCheck(graph: KnowledgeGraph, routePath: string): Array<{ field: string; severity: string }> {
-  // Find the route
+export interface ShapeMismatch {
+  field: string;
+  severity: 'missing' | 'unused' | 'warning';
+  reason: string;
+}
+
+export async function shapeCheck(
+  graph: KnowledgeGraph,
+  routePath: string,
+  repoPath?: string,
+): Promise<ShapeMismatch[]> {
+  // Find the route node by path
   let routeNode = null;
   for (const node of graph.iterNodes()) {
     if (node.label === 'Route' && (node.properties.path as string) === routePath) {
@@ -299,41 +412,121 @@ export function shapeCheck(graph: KnowledgeGraph, routePath: string): Array<{ fi
   }
   if (!routeNode) return [];
 
-  const mismatches: Array<{ field: string; severity: string }> = [];
+  // Provider response keys: what the API actually returns
+  const providerKeys = (nodeProperties(routeNode, 'responseKeys') as string[]) ?? [];
+  const providerErrorKeys = (nodeProperties(routeNode, 'errorKeys') as string[]) ?? [];
+  const allProviderKeys = [...providerKeys, ...providerErrorKeys];
 
-  // Check consumers of this route
-  const handlesRel = graph.iterRelationshipsByType('HANDLES_ROUTE');
-  const handlerIds: string[] = []; // #413: collect all handlers, not just the last one
-  for (const hr of handlesRel) {
-    if (hr.targetId === routeNode!.id) {
-      handlerIds.push(hr.sourceId);
+  // Find consumers via FETCHES edges (source = consumer, target = route)
+  const consumerFns = new Map<string, { filePath: string; startLine: number; endLine: number; name: string }>();
+  for (const rel of graph.iterRelationships()) {
+    if (rel.type === 'FETCHES' && rel.targetId === routeNode.id) {
+      const consumer = graph.getNode(rel.sourceId);
+      if (consumer && (consumer.label === 'Function' || consumer.label === 'Method')) {
+        consumerFns.set(consumer.id, {
+          filePath: (consumer.properties.filePath as string) ?? '',
+          startLine: (consumer.properties.startLine as number) ?? 0,
+          endLine: (consumer.properties.endLine as number) ?? Infinity,
+          name: (consumer.properties.name as string) ?? consumer.id,
+        });
+      }
     }
   }
 
-  if (handlerIds.length === 0) return mismatches;
+  const mismatches: ShapeMismatch[] = [];
 
-  // Find callers of all handlers
-  for (const handlerId of handlerIds) {
-    for (const rel of graph.iterRelationships()) {
-      if (rel.type === 'CALLS' && rel.targetId === handlerId) {
-        const caller = graph.getNode(rel.sourceId);
-        if (!caller) continue;
+  // Extract consumer-accessed fields from source code
+  const allAccessedFields = new Set<string>();
+  const consumerFieldMap = new Map<string, Set<string>>();
 
-        // Check for USES edges from caller to types/imports that indicate field access
-        for (const rel2 of graph.iterRelationships()) {
-          if (rel2.type === 'USES' && rel2.sourceId === caller.id) {
-            const usedNode = graph.getNode(rel2.targetId);
-            if (usedNode && usedNode.label === 'Variable') {
-              mismatches.push({
-                field: (usedNode.properties.name as string) ?? usedNode.id,
-                severity: 'warning',
-              });
-            }
-          }
+  if (repoPath && consumerFns.size > 0) {
+    // Group consumers by file for batched reads
+    const consumersByFile = new Map<string, Array<{ filePath: string; startLine: number; endLine: number; name: string }>>();
+    for (const [, fn] of consumerFns) {
+      const fns = consumersByFile.get(fn.filePath) ?? [];
+      fns.push(fn);
+      consumersByFile.set(fn.filePath, fns);
+    }
+
+    const readFile = getReadFile();
+    const joinPath = getJoinPath();
+
+    for (const [fp, fns] of consumersByFile) {
+      let content: string;
+      try {
+        content = await readFile(joinPath(repoPath, fp), 'utf-8');
+      } catch {
+        continue;
+      }
+      const lines = content.split('\n');
+
+      for (const fn of fns) {
+        const start = Math.max(0, fn.startLine - 1);
+        const end = fn.endLine === Infinity ? lines.length : Math.min(lines.length, fn.endLine);
+        const body = lines.slice(start, end).join('\n');
+        const accessedFields = extractConsumerAccessedFields(body);
+        consumerFieldMap.set(fn.name, new Set(accessedFields));
+        for (const f of accessedFields) {
+          allAccessedFields.add(f);
         }
       }
     }
   }
 
-  return mismatches.slice(0, 20);
+  // Comparison 1: Fields consumer accesses but provider doesn't return → missing
+  if (allProviderKeys.length > 0) {
+    for (const field of allAccessedFields) {
+      if (!allProviderKeys.includes(field)) {
+        const consumerNames = Array.from(consumerFieldMap.entries())
+          .filter(([, fields]) => fields.has(field))
+          .map(([name]) => name);
+        mismatches.push({
+          field,
+          severity: 'missing',
+          reason: consumerNames.length > 0
+            ? `Consumer(s) ${consumerNames.join(', ')} read "${field}" but route does not return it`
+            : `Consumer reads "${field}" but route does not return it`,
+        });
+      }
+    }
+  }
+
+  // Comparison 2: Fields provider returns but no consumer accesses → unused
+  if (allAccessedFields.size > 0) {
+    for (const field of providerKeys) {
+      if (!allAccessedFields.has(field)) {
+        mismatches.push({
+          field,
+          severity: 'unused',
+          reason: `Route returns "${field}" but no consumer reads it`,
+        });
+      }
+    }
+  } else if (providerKeys.length > 0 && consumerFns.size > 0 && !repoPath) {
+    // Can't extract consumer fields (no repoPath) but there are consumers
+    for (const field of providerKeys) {
+      mismatches.push({
+        field,
+        severity: 'warning',
+        reason: `Route returns "${field}" — unable to verify consumer access (needs repo path)`,
+      });
+    }
+  }
+
+  // Also flag error-only response fields when there are consumers
+  if (providerKeys.length === 0 && providerErrorKeys.length > 0 && consumerFns.size > 0) {
+    for (const field of providerErrorKeys) {
+      mismatches.push({
+        field,
+        severity: 'warning',
+        reason: `Error response field "${field}" returned by route`,
+      });
+    }
+  }
+
+  return mismatches.slice(0, 30);
+}
+
+function nodeProperties(node: { properties: Record<string, unknown> }, key: string): unknown {
+  return node.properties[key];
 }

--- a/packages/core/src/mcp/api-tools.ts
+++ b/packages/core/src/mcp/api-tools.ts
@@ -5,6 +5,9 @@
  * provide API-level analysis beyond basic symbol queries.
  */
 
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
 import type { KnowledgeGraph } from '../core/types.js';
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -300,25 +303,6 @@ export async function apiImpact(graph: KnowledgeGraph, symbolName: string, repoP
 
 // ── Consumer field access extraction ────────────────────────────────────────
 
-// Lazy imports for file I/O (only loaded when repoPath is provided)
-let _readFileFn: ((path: string, encoding: string) => Promise<string>) | undefined;
-let _joinPathFn: ((...parts: string[]) => string) | undefined;
-
-function getReadFile(): (path: string, encoding: string) => Promise<string> {
-  if (!_readFileFn) {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    _readFileFn = require('node:fs/promises').readFile;
-  }
-  return _readFileFn!;
-}
-function getJoinPath(): (...parts: string[]) => string {
-  if (!_joinPathFn) {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    _joinPathFn = require('node:path').join;
-  }
-  return _joinPathFn!;
-}
-
 /**
  * Variable names commonly used to hold HTTP response data after fetch/axios calls.
  * We scan for member access on these identifiers to detect what fields consumers read.
@@ -448,13 +432,10 @@ export async function shapeCheck(
       consumersByFile.set(fn.filePath, fns);
     }
 
-    const readFile = getReadFile();
-    const joinPath = getJoinPath();
-
     for (const [fp, fns] of consumersByFile) {
       let content: string;
       try {
-        content = await readFile(joinPath(repoPath, fp), 'utf-8');
+        content = await readFile(join(repoPath, fp), 'utf-8');
       } catch {
         continue;
       }

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -1357,7 +1357,7 @@ Returns JSON with providers (method/path/handler), consumers (urlPattern/functio
       const name = requireString(params, 'name');
       const ctx = backend.getRepo(params.repo as string);
       const graph = ctx.loadGraph();
-      const impact = apiImpact(graph, name);
+      const impact = await apiImpact(graph, name, ctx.entry.path);
       if (impact.length === 0) return { content: [{ type: 'text', text: `Symbol "${name}" not found.` }] };
       const lines: string[] = [];
       for (const imp of impact) {
@@ -1372,6 +1372,10 @@ Returns JSON with providers (method/path/handler), consumers (urlPattern/functio
         if (imp.tools.length > 0) {
           lines.push('Tools:');
           for (const t of imp.tools) lines.push(`  ${t.type}: ${t.name}`);
+        }
+        if (imp.shapeDrift.length > 0) {
+          lines.push('Shape Drift:');
+          for (const sd of imp.shapeDrift) lines.push(`  ${sd.severity}: ${sd.field}`);
         }
       }
       return { content: [{ type: 'text', text: lines.join('\n') }] };
@@ -1393,9 +1397,9 @@ Returns JSON with providers (method/path/handler), consumers (urlPattern/functio
       const path = requireString(params, 'path');
       const ctx = backend.getRepo(params.repo as string);
       const graph = ctx.loadGraph();
-      const mismatches = shapeCheck(graph, path);
+      const mismatches = await shapeCheck(graph, path, ctx.entry.path);
       if (mismatches.length === 0) return { content: [{ type: 'text', text: `No shape mismatches detected for route "${path}".` }] };
-      const lines = mismatches.map((m) => `  ${m.severity.toUpperCase()}: ${m.field}`);
+      const lines = mismatches.map((m) => `  ${m.severity.toUpperCase()}: ${m.field} — ${m.reason}`);
       return { content: [{ type: 'text', text: `Shape Check for "${path}" (${mismatches.length} issues):\n${lines.join('\n')}` }] };
     },
   },

--- a/packages/core/tests/mcp/api-tools.test.ts
+++ b/packages/core/tests/mcp/api-tools.test.ts
@@ -3,7 +3,14 @@
  */
 import { describe, it, expect } from 'vitest';
 import { createKnowledgeGraph } from '../../src/core/graph.js';
-import { routeMap, toolMap, apiImpact, shapeCheck } from '../../src/mcp/api-tools.js';
+import {
+  routeMap,
+  toolMap,
+  apiImpact,
+  shapeCheck,
+  extractConsumerAccessedFields,
+} from '../../src/mcp/api-tools.js';
+import type { ShapeMismatch } from '../../src/mcp/api-tools.js';
 
 function makeTestGraph() {
   const g = createKnowledgeGraph();
@@ -39,6 +46,85 @@ function makeTestGraph() {
   return g;
 }
 
+/** Graph with responseKeys and FETCHES edges for testing shape_check with real data */
+function makeShapeTestGraph() {
+  const g = createKnowledgeGraph();
+
+  // Route with response keys
+  g.addNode({
+    id: 'route:users:GET:/api/users',
+    label: 'Route',
+    properties: {
+      name: 'GET /api/users',
+      method: 'GET',
+      path: '/api/users',
+      filePath: 'routes/users.ts',
+      responseKeys: ['id', 'name', 'email'],
+      errorKeys: ['error', 'message'],
+    },
+  });
+
+  // Route without response keys
+  g.addNode({
+    id: 'route:auth:POST:/api/login',
+    label: 'Route',
+    properties: {
+      name: 'POST /api/login',
+      method: 'POST',
+      path: '/api/login',
+      filePath: 'routes/auth.ts',
+      responseKeys: ['token', 'user'],
+    },
+  });
+
+  // Consumer function that fetches /api/users
+  g.addNode({
+    id: 'Function:src/app.ts:consumeUsers:L1',
+    label: 'Function',
+    properties: {
+      name: 'consumeUsers',
+      filePath: 'src/app.ts',
+      startLine: 1,
+      endLine: 10,
+    },
+  });
+
+  // Consumer that fetches /api/login
+  g.addNode({
+    id: 'Function:src/app.ts:consumeLogin:L15',
+    label: 'Function',
+    properties: {
+      name: 'consumeLogin',
+      filePath: 'src/app.ts',
+      startLine: 15,
+      endLine: 25,
+    },
+  });
+
+  // FETCHES edges: consumers → routes
+  g.addRelationship({
+    id: 'fetch:1',
+    sourceId: 'Function:src/app.ts:consumeUsers:L1',
+    targetId: 'route:users:GET:/api/users',
+    type: 'FETCHES',
+    confidence: 0.7,
+    reason: 'fetch to /api/users',
+  });
+
+  g.addRelationship({
+    id: 'fetch:2',
+    sourceId: 'Function:src/app.ts:consumeLogin:L15',
+    targetId: 'route:auth:POST:/api/login',
+    type: 'FETCHES',
+    confidence: 0.7,
+    reason: 'axios to /api/login',
+  });
+
+  return g;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
 describe('API Tools (#270)', () => {
   describe('routeMap', () => {
     it('returns all routes with handlers', () => {
@@ -51,7 +137,6 @@ describe('API Tools (#270)', () => {
     it('marks route as orphaned when handler not found', () => {
       const g = createKnowledgeGraph();
       g.addNode({ id: 'route:orphan', label: 'Route', properties: { name: 'GET /orphan', method: 'GET', path: '/orphan' } });
-      // No HANDLES_ROUTE edge for orphan route
       const map = routeMap(g);
       const orphan = map.find((r) => r.path === '/orphan');
       expect(orphan).toBeDefined();
@@ -75,12 +160,11 @@ describe('API Tools (#270)', () => {
 
     it('marks tool as unused when no callers', () => {
       const map = toolMap(makeTestGraph());
-      expect(map[0].isUnused).toBe(true); // no CALLS to queryDb
+      expect(map[0].isUnused).toBe(true);
     });
 
     it('finds callers for a tool', () => {
       const g = makeTestGraph();
-      // Add a caller for the tool handler
       g.addNode({ id: 'Function:src/caller.ts:useDb:L1', label: 'Function', properties: { name: 'useDb', filePath: 'src/caller.ts', startLine: 1 } });
       g.addRelationship({ id: 'call:2', sourceId: 'Function:src/caller.ts:useDb:L1', targetId: 'Function:tools/db.ts:queryDb:L5', type: 'CALLS', confidence: 0.8, reason: 'calls' });
       const map = toolMap(g);
@@ -96,53 +180,140 @@ describe('API Tools (#270)', () => {
   });
 
   describe('apiImpact', () => {
-    it('finds routes connected to a symbol', () => {
-      const impact = apiImpact(makeTestGraph(), 'getUsers');
+    it('finds routes connected to a symbol', async () => {
+      const impact = await apiImpact(makeTestGraph(), 'getUsers');
       expect(impact.length).toBe(1);
       expect(impact[0].routes.length).toBe(1);
       expect(impact[0].routes[0].path).toBe('/api/users');
     });
 
-    it('returns empty array for unknown symbol', () => {
-      const impact = apiImpact(makeTestGraph(), 'nonexistent');
+    it('returns empty array for unknown symbol', async () => {
+      const impact = await apiImpact(makeTestGraph(), 'nonexistent');
       expect(impact).toEqual([]);
     });
 
-    it('#335: returns results for all matching symbols with same name', () => {
+    it('#335: returns results for all matching symbols with same name', async () => {
       const g = makeTestGraph();
-      // Add a second function with same name in different file
       g.addNode({ id: 'Function:routes/v2/users.ts:getUsers:L5', label: 'Function', properties: { name: 'getUsers', filePath: 'routes/v2/users.ts', startLine: 5 } });
       g.addNode({ id: 'route:v2:GET:/api/v2/users', label: 'Route', properties: { name: 'GET /api/v2/users', method: 'GET', path: '/api/v2/users', filePath: 'routes/v2/users.ts' } });
       g.addRelationship({ id: 'hr:3', sourceId: 'Function:routes/v2/users.ts:getUsers:L5', targetId: 'route:v2:GET:/api/v2/users', type: 'HANDLES_ROUTE', confidence: 1, reason: 'handler' });
 
-      const impact = apiImpact(g, 'getUsers');
-      expect(impact.length).toBe(2); // both getUsers functions found
+      const impact = await apiImpact(g, 'getUsers');
+      expect(impact.length).toBe(2);
     });
 
-    it('detects breaking risk when symbol has consumers', () => {
-      const impact = apiImpact(makeTestGraph(), 'getUsers');
+    it('detects breaking risk when symbol has consumers', async () => {
+      const impact = await apiImpact(makeTestGraph(), 'getUsers');
       expect(impact[0].routes[0].risk).toBe('BREAKING: has consumers');
       expect(impact[0].routes[0].consumers).toContain('consumeUsers');
     });
 
-    it('handles empty graph', () => {
+    it('handles empty graph', async () => {
       const g = createKnowledgeGraph();
-      const impact = apiImpact(g, 'anything');
+      const impact = await apiImpact(g, 'anything');
       expect(impact).toEqual([]);
     });
   });
 
   describe('shapeCheck', () => {
-    it('returns empty when no routes or tools match', () => {
+    it('returns empty when route not found', async () => {
       const g = createKnowledgeGraph();
-      const shape = shapeCheck(g, 'nonexistent');
+      const shape = await shapeCheck(g, 'nonexistent');
       expect(shape).toEqual([]);
     });
 
-    it('returns shape drift for a known route', () => {
-      const shape = shapeCheck(makeTestGraph(), 'getUsers');
-      // shapeCheck currently is a stub (requires type annotation analysis)
-      expect(Array.isArray(shape)).toBe(true);
+    it('returns empty when route has no responseKeys', async () => {
+      const g = createKnowledgeGraph();
+      g.addNode({ id: 'route:test', label: 'Route', properties: { path: '/test', method: 'GET' } });
+      const shape = await shapeCheck(g, '/test');
+      expect(shape).toEqual([]);
+    });
+
+    it('detects unused fields when route has responseKeys but no consumer access extracted', async () => {
+      const g = makeShapeTestGraph();
+      // No repoPath → can't read consumer source files → all provider keys flagged as warnings
+      const shape = await shapeCheck(g, '/api/users');
+      // Without repoPath, provider keys are flagged as warnings
+      expect(shape.length).toBeGreaterThan(0);
+      for (const m of shape) {
+        expect(m).toHaveProperty('field');
+        expect(m).toHaveProperty('severity');
+        expect(m).toHaveProperty('reason');
+      }
+    });
+
+    it('returns mismatches with proper ShapeMismatch shape', async () => {
+      const g = makeShapeTestGraph();
+      const shape = await shapeCheck(g, '/api/login');
+      for (const m of shape) {
+        expect(typeof m.field).toBe('string');
+        expect(['missing', 'unused', 'warning']).toContain(m.severity);
+        expect(typeof m.reason).toBe('string');
+      }
+    });
+
+    it('handles FETCHES consumers with no repoPath gracefully', async () => {
+      const g = makeShapeTestGraph();
+      const shape = await shapeCheck(g, '/api/users');
+      // Should have warnings for provider keys since consumers exist but can't verify access
+      const warnings = shape.filter((m: ShapeMismatch) => m.severity === 'warning');
+      expect(warnings.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('extractConsumerAccessedFields', () => {
+    it('extracts dot-access fields on response vars', () => {
+      const code = 'const users = data.users; const name = data.name;';
+      const fields = extractConsumerAccessedFields(code);
+      expect(fields).toContain('users');
+      expect(fields).toContain('name');
+    });
+
+    it('extracts optional chaining fields', () => {
+      const code = 'const id = data?.id; const email = response?.user?.email;';
+      const fields = extractConsumerAccessedFields(code);
+      expect(fields).toContain('id');
+      expect(fields).toContain('user');
+    });
+
+    it('extracts bracket-access fields', () => {
+      const code = "const role = data['role']; const token = response['access_token'];";
+      const fields = extractConsumerAccessedFields(code);
+      expect(fields).toContain('role');
+      expect(fields).toContain('access_token');
+    });
+
+    it('extracts destructured fields', () => {
+      const code = 'const { id, name, email } = data;';
+      const fields = extractConsumerAccessedFields(code);
+      expect(fields).toContain('id');
+      expect(fields).toContain('name');
+      expect(fields).toContain('email');
+    });
+
+    it('extracts destructured fields from await response', () => {
+      const code = 'const { token } = await response;';
+      const fields = extractConsumerAccessedFields(code);
+      expect(fields).toContain('token');
+    });
+
+    it('deduplicates fields', () => {
+      const code = 'data.name; data.name; data.email;';
+      const fields = extractConsumerAccessedFields(code);
+      expect(fields.filter((f) => f === 'name').length).toBe(1);
+    });
+
+    it('ignores non-response var dot access', () => {
+      const code = 'user.name; config.host; foo.bar;';
+      const fields = extractConsumerAccessedFields(code);
+      expect(fields).not.toContain('name');
+      expect(fields).not.toContain('host');
+      expect(fields).not.toContain('bar');
+    });
+
+    it('handles empty code', () => {
+      const fields = extractConsumerAccessedFields('');
+      expect(fields).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Route nodes now leverage existing `responseKeys`/`errorKeys` extraction from handler code analysis for consumer mismatch detection
- `shape_check` MCP tool compares API producer response shapes against what consumers actually access
- `api_impact` now includes `shapeDrift` results, flagging missing fields (consumer needs but provider doesn't return) and unused fields (provider returns but no consumer accesses)
- Consumer field access detection handles dot-access, optional chaining, bracket-access, and destructuring patterns

Closes #641
