### PR TITLE
fix: restore platform-specific rollup native modules in CI (#674)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - run: npm ci
+      - run: npm install --no-save --package-lock=false --legacy-peer-deps
       - run: npm run build --workspace packages/shared
       - run: npm run build --workspace packages/core
       - run: npm test -- --coverage
@@ -76,6 +77,7 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
+      - run: npm install --no-save --package-lock=false --legacy-peer-deps
       - run: npm run build --workspace packages/shared
       - run: npm run build --workspace packages/core
       - run: npm test

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -31,6 +31,7 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
+      - run: npm install --no-save --package-lock=false --legacy-peer-deps
       - run: npm run build --workspace packages/shared
       - run: npm run build --workspace packages/core
       - run: npm test


### PR DESCRIPTION
## Summary

Fix the recurring CI failures caused by `npm ci` stripping platform-specific optional dependencies (npm/cli#4828).

All recent CI failures (#674, #673, #672, #670, #668, #666, #664, #662, #660, #658, #655, #653, #651) share the same root cause: `npm ci` removes platform-specific `@rollup/rollup-*` native modules, causing vitest to fail at startup with `Cannot find module '@rollup/rollup-linux-x64-gnu'`.

### Fix

Add `npm install --no-save --package-lock=false --legacy-peer-deps` after each `npm ci` step in:
- **ci.yml**: unit-test job, integration-test job
- **rc.yml**: test job

This matches the pattern already used successfully in **release.yml** (lines 60-61 and 190-192).

### Why this works

`npm ci` does a clean install from the lockfile but has a known bug where it doesn't install the correct platform-specific optional dependencies. Running `npm install` afterward lets npm resolve and download the missing native modules (`@rollup/rollup-linux-x64-gnu`, `@rollup/rollup-darwin-arm64`, etc.) without modifying the lockfile or package.json (`--no-save --package-lock=false`).

Closes #674, #673, #672, #670, #668, #666, #664, #662, #660, #658, #655, #653, #651