### PR TITLE
feat: middleware chain detection with WRAPS edges (#637)

### DIFF
--- a/packages/core/src/analysis/phases/routes.ts
+++ b/packages/core/src/analysis/phases/routes.ts
@@ -17,6 +17,7 @@ export interface RoutesOutput {
   fetchesCount: number;
   responseShapeCount: number;
   middlewareCount: number;
+  wrapsCount: number;
 }
 
 // ── HTTP client detection patterns ─────────────────────────────────────────
@@ -278,6 +279,10 @@ const BUILTIN_IDENTS = new Set(['require', 'import', 'Promise', 'setTimeout', 's
  *
  * 1. Express: `app.get(path, mw1, mw2, handler)` — identifier args are middleware
  * 2. Higher-order: `withAuth(handler)`, `withRateLimit(handler)`
+ * 3. Express/Koa: `app.use(middleware)`, `router.use(middleware)` (#637)
+ * 4. FastAPI: `Depends(middleware)` (#637)
+ * 5. Django: `@login_required`, `@permission_required(...)`, etc. (#637)
+ * 6. Laravel: `->middleware('name')` (#637)
  */
 export function extractMiddlewareNames(code: string): string[] {
   const middleware: string[] = [];
@@ -308,6 +313,37 @@ export function extractMiddlewareNames(code: string): string[] {
     if (name && !BUILTIN_IDENTS.has(name) && !PARAM_IDENTS.has(name)) {
       if (!middleware.includes(name)) middleware.push(name);
     }
+  }
+
+  // Express/Koa app.use() / router.use() — middleware registration (#637)
+  const usePattern = /\b(?:app|router|koa)\.use\s*\(\s*([$\w]+)/g;
+  while ((match = usePattern.exec(code)) !== null) {
+    const name = match[1];
+    if (name && !PARAM_IDENTS.has(name) && !BUILTIN_IDENTS.has(name)) {
+      if (!middleware.includes(name)) middleware.push(name);
+    }
+  }
+
+  // FastAPI Depends() injection (#637)
+  const dependsPattern = /Depends\s*\(\s*([$\w]+)/g;
+  while ((match = dependsPattern.exec(code)) !== null) {
+    const name = match[1];
+    if (name && !middleware.includes(name)) middleware.push(name);
+  }
+
+  // Django view decorators (#637): @login_required, @permission_required, @csrf_exempt, etc.
+  const djangoDecoratorPattern = /@(login_required|permission_required|csrf_exempt|csrf_protect|require_http_methods|require_GET|require_POST|require_safe|staff_member_required|user_passes_test)/g;
+  while ((match = djangoDecoratorPattern.exec(code)) !== null) {
+    const name = match[1];
+    if (name && !middleware.includes(name)) middleware.push(name);
+  }
+
+  // Laravel middleware() chain (#637): ->middleware('auth'), ->middleware('throttle:60')
+  const laravelMiddlewarePattern = /->middleware\s*\(\s*['"]([^'"]+)['"]/g;
+  while ((match = laravelMiddlewarePattern.exec(code)) !== null) {
+    // Laravel middleware names may have colon-separated params like 'throttle:60'
+    const name = match[1]!.split(':')[0]!;
+    if (!middleware.includes(name)) middleware.push(name);
   }
 
   return middleware;
@@ -437,6 +473,70 @@ export const routesPhase: PhaseDefinition<RoutesOutput> = {
           }
         }
       } catch { /* skip unreadable */ }
+    }
+
+    // ── WRAPS edge creation (#637) ────────────────────────────────────────
+
+    // Create WRAPS edges from middleware names to Route nodes.
+    // Resolve middleware names to Function/Method nodes by name in the graph.
+    const nameToFnNodes = new Map<string, string[]>();
+    for (const fn of graph.iterNodes()) {
+      if (fn.label !== 'Function' && fn.label !== 'Method') continue;
+      const fnName = fn.properties.name as string | undefined;
+      if (!fnName) continue;
+      const ids = nameToFnNodes.get(fnName);
+      if (ids) ids.push(fn.id);
+      else nameToFnNodes.set(fnName, [fn.id]);
+    }
+
+    for (const routeNode of graph.iterNodes()) {
+      if (routeNode.label !== 'Route') continue;
+      const mwNames = routeNode.properties.middleware as string[] | undefined;
+      if (!mwNames || mwNames.length === 0) continue;
+
+      for (const mwName of mwNames) {
+        // Try to resolve the middleware name to an existing Function/Method node
+        const fnIds = nameToFnNodes.get(mwName);
+        if (fnIds) {
+          for (const fnId of fnIds) {
+            const edgeId = `wraps:${fnId}:${routeNode.id}`;
+            if (graph.getRelationship(edgeId)) continue;
+            graph.addRelationship({
+              id: edgeId,
+              sourceId: fnId,
+              targetId: routeNode.id,
+              type: 'WRAPS',
+              confidence: 0.8,
+              reason: `Middleware '${mwName}' wraps route ${(routeNode.properties.name as string) ?? routeNode.id}`,
+            });
+          }
+        } else {
+          // No matching Function/Method node — create a synthetic CodeElement node
+          const mwId = `middleware:${mwName}:${routeNode.properties.filePath ?? 'unknown'}`;
+          if (!graph.getNode(mwId)) {
+            graph.addNode({
+              id: mwId,
+              label: 'CodeElement',
+              properties: {
+                name: mwName,
+                filePath: (routeNode.properties.filePath as string) ?? '',
+                kind: 'middleware',
+              },
+            });
+          }
+          const edgeId = `wraps:${mwId}:${routeNode.id}`;
+          if (!graph.getRelationship(edgeId)) {
+            graph.addRelationship({
+              id: edgeId,
+              sourceId: mwId,
+              targetId: routeNode.id,
+              type: 'WRAPS',
+              confidence: 0.7,
+              reason: `Middleware '${mwName}' wraps route ${(routeNode.properties.name as string) ?? routeNode.id}`,
+            });
+          }
+        }
+      }
     }
 
     // ── FETCHES edge creation (#428) ──────────────────────────────────────
@@ -574,6 +674,7 @@ export const routesPhase: PhaseDefinition<RoutesOutput> = {
     // ── Aggregate response shape and middleware counts (#426, #427) ──────────
     let responseShapeCount = 0;
     let middlewareCount = 0;
+    let wrapsCount = 0;
     for (const node of graph.iterNodes()) {
       if (node.label !== 'Route') continue;
       const rk = node.properties.responseKeys as string[] | undefined;
@@ -582,7 +683,10 @@ export const routesPhase: PhaseDefinition<RoutesOutput> = {
       if ((rk && rk.length > 0) || (ek && ek.length > 0)) responseShapeCount++;
       if (mw && mw.length > 0) middlewareCount++;
     }
+    for (const _rel of graph.iterRelationshipsByType('WRAPS')) {
+      wrapsCount++;
+    }
 
-    return { routeCount, frameworks: Array.from(frameworks), fetchesCount, responseShapeCount, middlewareCount };
+    return { routeCount, frameworks: Array.from(frameworks), fetchesCount, responseShapeCount, middlewareCount, wrapsCount };
   },
 };

--- a/packages/core/src/mcp/api-tools.ts
+++ b/packages/core/src/mcp/api-tools.ts
@@ -17,6 +17,7 @@ export interface RouteMapEntry {
   handlerName: string;
   consumers: Array<{ id: string; name: string; filePath: string }>;
   isOrphaned: boolean;
+  middleware: string[];
 }
 
 export interface ToolMapEntry {
@@ -30,7 +31,7 @@ export interface ToolMapEntry {
 
 export interface ApiImpactResult {
   symbol: string;
-  routes: Array<{ method: string; path: string; consumers: string[]; risk: string }>;
+  routes: Array<{ method: string; path: string; consumers: string[]; risk: string; middleware: string[] }>;
   tools: Array<{ type: string; name: string }>;
   shapeDrift: Array<{ field: string; severity: string }>;
 }
@@ -38,7 +39,7 @@ export interface ApiImpactResult {
 // ── route_map ──────────────────────────────────────────────────────────────
 
 export function routeMap(graph: KnowledgeGraph): RouteMapEntry[] {
-  const routeNodes: Map<string, { method: string; path: string; handlerId: string; handlerName: string }> = new Map();
+  const routeNodes: Map<string, { method: string; path: string; handlerId: string; handlerName: string; middleware: string[] }> = new Map();
 
   // Collect Route nodes
   for (const node of graph.iterNodes()) {
@@ -48,6 +49,7 @@ export function routeMap(graph: KnowledgeGraph): RouteMapEntry[] {
       path: (node.properties.path as string) ?? '?',
       handlerId: node.id,
       handlerName: (node.properties.name as string) ?? node.id,
+      middleware: (node.properties.middleware as string[]) ?? [],
     });
   }
 
@@ -108,6 +110,7 @@ export function routeMap(graph: KnowledgeGraph): RouteMapEntry[] {
       handlerName: route.handlerName,
       consumers: consumerList,
       isOrphaned: consumerList.length === 0,
+      middleware: route.middleware,
     });
   }
 
@@ -195,8 +198,8 @@ export function apiImpact(graph: KnowledgeGraph, symbolName: string): ApiImpactR
   // #411: Pre-build indices ONCE — O(R) instead of O(T×N×R×C)
   const targetIdSet = new Set(targetIds);
 
-  // handler → routes it handles
-  const handlerToRoutes = new Map<string, Array<{ method: string; path: string }>>();
+  // handler → routes it handles (with middleware)
+  const handlerToRoutes = new Map<string, Array<{ method: string; path: string; middleware: string[] }>>();
   for (const hr of graph.iterRelationshipsByType('HANDLES_ROUTE')) {
     if (!targetIdSet.has(hr.sourceId)) continue;
     const routeNode = graph.getNode(hr.targetId);
@@ -206,6 +209,7 @@ export function apiImpact(graph: KnowledgeGraph, symbolName: string): ApiImpactR
     arr.push({
       method: (routeNode.properties.method as string) ?? '?',
       path: (routeNode.properties.path as string) ?? '?',
+      middleware: (routeNode.properties.middleware as string[]) ?? [],
     });
   }
 
@@ -268,6 +272,7 @@ export function apiImpact(graph: KnowledgeGraph, symbolName: string): ApiImpactR
         path: r.path,
         consumers,
         risk: routeRisk,
+        middleware: r.middleware,
       });
     }
 

--- a/packages/core/tests/analysis/phases/routes-middleware.test.ts
+++ b/packages/core/tests/analysis/phases/routes-middleware.test.ts
@@ -138,24 +138,144 @@ describe('Middleware Integration', () => {
   });
 
   it('reports zero middlewareCount when no middleware present', async () => {
+      const repo = makeRepo({
+        'routes/simple.ts': `
+          const app = require('express')();
+          app.get('/api/health', (req, res) => res.json({ ok: true }));
+        `,
+      });
+
+      const graph = createKnowledgeGraph();
+      graph.addNode({
+        id: 'file:routes/simple.ts',
+        label: 'File',
+        properties: { name: 'simple.ts', filePath: 'routes/simple.ts' },
+      });
+      const context = createPhaseContext(repo, graph, () => {});
+      const output = (await runPipeline([routesPhase], context))[0] as RoutesOutput;
+
+      expect(output.middlewareCount).toBe(0);
+
+      rmSync(repo, { recursive: true, force: true });
+    });
+
+  // ── #637: WRAPS edge creation ────────────────────────────────────────────
+
+  it('creates WRAPS edges from Function nodes to Route nodes for middleware (#637)', async () => {
     const repo = makeRepo({
-      'routes/simple.ts': `
+      'routes/users.ts': `
         const app = require('express')();
-        app.get('/api/health', (req, res) => res.json({ ok: true }));
+        app.get('/api/users', authenticate, authorize, (req, res) => res.json([]));
       `,
     });
 
     const graph = createKnowledgeGraph();
     graph.addNode({
-      id: 'file:routes/simple.ts',
+      id: 'file:routes/users.ts',
       label: 'File',
-      properties: { name: 'simple.ts', filePath: 'routes/simple.ts' },
+      properties: { name: 'users.ts', filePath: 'routes/users.ts' },
+    });
+    // Add Function nodes for the middleware so WRAPS edges target them
+    graph.addNode({
+      id: 'Function:routes/users.ts:authenticate',
+      label: 'Function',
+      properties: { name: 'authenticate', filePath: 'routes/users.ts', startLine: 3, endLine: 10 },
+    });
+    graph.addNode({
+      id: 'Function:routes/users.ts:authorize',
+      label: 'Function',
+      properties: { name: 'authorize', filePath: 'routes/users.ts', startLine: 12, endLine: 20 },
     });
     const context = createPhaseContext(repo, graph, () => {});
     const output = (await runPipeline([routesPhase], context))[0] as RoutesOutput;
 
-    expect(output.middlewareCount).toBe(0);
+    expect(output.wrapsCount).toBeGreaterThanOrEqual(2);
+
+    const wrapsRels = Array.from(graph.iterRelationshipsByType('WRAPS'));
+    expect(wrapsRels.length).toBeGreaterThanOrEqual(2);
+    // WRAPS edges: middleware function → Route node
+    for (const rel of wrapsRels) {
+      expect(rel.type).toBe('WRAPS');
+      const sourceNode = graph.getNode(rel.sourceId);
+      expect(sourceNode?.label === 'Function' || sourceNode?.label === 'CodeElement').toBe(true);
+      const targetNode = graph.getNode(rel.targetId);
+      expect(targetNode?.label).toBe('Route');
+    }
 
     rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('creates synthetic CodeElement nodes for middleware with no matching Function (#637)', async () => {
+    const repo = makeRepo({
+      'routes/api.ts': `
+        const app = require('express')();
+        app.get('/api/data', rateLimit, (req, res) => res.json({}));
+      `,
+    });
+
+    const graph = createKnowledgeGraph();
+    graph.addNode({
+      id: 'file:routes/api.ts',
+      label: 'File',
+      properties: { name: 'api.ts', filePath: 'routes/api.ts' },
+    });
+    // No Function node for rateLimit — should create synthetic CodeElement
+    const context = createPhaseContext(repo, graph, () => {});
+    const output = (await runPipeline([routesPhase], context))[0] as RoutesOutput;
+
+    expect(output.wrapsCount).toBeGreaterThanOrEqual(1);
+
+    const mwNodes = graph.findNodesByLabel('CodeElement').filter(n => n.properties.kind === 'middleware');
+    expect(mwNodes.length).toBeGreaterThanOrEqual(1);
+    expect(mwNodes.some(n => n.properties.name === 'rateLimit')).toBe(true);
+
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  // ── #637: New middleware pattern detection ────────────────────────────────
+
+  it('extracts FastAPI Depends() middleware (#637)', () => {
+    const code = `@router.get('/items')\ndef read_items(db: Session = Depends(get_db), user: User = Depends(get_current_user)): ...`;
+    const middleware = extractMiddlewareNames(code);
+    expect(middleware).toContain('get_db');
+    expect(middleware).toContain('get_current_user');
+  });
+
+  it('extracts Django decorators (#637)', () => {
+    const code = `@login_required\n@permission_required('polls.vote')\ndef vote(request): ...`;
+    const middleware = extractMiddlewareNames(code);
+    expect(middleware).toContain('login_required');
+    expect(middleware).toContain('permission_required');
+  });
+
+  it('extracts Django @csrf_exempt decorator (#637)', () => {
+    const code = `@csrf_exempt\ndef api_endpoint(request): ...`;
+    const middleware = extractMiddlewareNames(code);
+    expect(middleware).toContain('csrf_exempt');
+  });
+
+  it('extracts Laravel middleware() chains (#637)', () => {
+    const code = `Route::get('/profile', 'ProfileController@show')->middleware('auth');`;
+    const middleware = extractMiddlewareNames(code);
+    expect(middleware).toContain('auth');
+  });
+
+  it('extracts Laravel middleware with colon-separated params (#637)', () => {
+    const code = `Route::get('/api/data', 'DataController@index')->middleware('throttle:60,1');`;
+    const middleware = extractMiddlewareNames(code);
+    expect(middleware).toContain('throttle');
+  });
+
+  it('extracts Express app.use() middleware (#637)', () => {
+    const code = `app.use(corsHandler);\napp.use(authMiddleware);`;
+    const middleware = extractMiddlewareNames(code);
+    expect(middleware).toContain('corsHandler');
+    expect(middleware).toContain('authMiddleware');
+  });
+
+  it('extracts Koa app.use() middleware (#637)', () => {
+    const code = `koa.use(logger);`;
+    const middleware = extractMiddlewareNames(code);
+    expect(middleware).toContain('logger');
   });
 });


### PR DESCRIPTION
Detect middleware chains in routes phase and create WRAPS edges from middleware functions to Route nodes. Add new middleware extraction patterns: FastAPI Depends(), Django decorators (@login_required, @permission_required, @csrf_exempt, etc.), Laravel middleware() chains, Express/Koa app.use()/router.use(). When middleware resolves to an existing Function/Method node, creates WRAPS edge (confidence 0.8); when unresolved, creates synthetic CodeElement node (kind middleware) plus WRAPS edge (confidence 0.7). Expose middleware info in MCP API tools: RouteMapEntry.middleware array and ApiImpactResult routes now include middleware arrays. 23 middleware tests covering WRAPS edge creation, synthetic nodes, and all new patterns. Closes #637