### PR TITLE
feat: overloaded method resolution with arity, type-hash, and const suffixes (#635)

### DIFF
--- a/packages/core/src/analysis/language-definition.ts
+++ b/packages/core/src/analysis/language-definition.ts
@@ -258,7 +258,7 @@ export function symbolId(
   filePath: string,
   name: string,
   startLine?: number,
-  overload?: { parameterCount?: number; parameterTypes?: string[] },
+  overload?: { parameterCount?: number; parameterTypes?: string[]; isConst?: boolean },
 ): string {
   let base = `${label}:${filePath}:${name}`;
   if (overload?.parameterCount != null && overload.parameterCount > 0) {
@@ -267,6 +267,9 @@ export function symbolId(
       const hash = overload.parameterTypes.map((t) => t.replace(/[^a-zA-Z0-9<>,_[\]]/g, '')).join(',');
       base += `~${hash}`;
     }
+  }
+  if (overload?.isConst) {
+    base += '\\';
   }
   return startLine != null ? `${base}:L${startLine}` : base;
 }

--- a/packages/core/src/analysis/parser.ts
+++ b/packages/core/src/analysis/parser.ts
@@ -305,12 +305,29 @@ function extractSymbols(
       }
     }
 
-    const id = symbolId(label, filePath, name, startLine, { parameterCount: paramCount });
-    // Dedup by filePath|name|startLine|paramCount (exclude label) so the same node
-    // matched by multiple patterns produces only one entry.
+    // #635: Extract parameter types early for overload disambiguation
+    const paramTypes = (label === 'Method' || label === 'Function' || label === 'Constructor')
+      ? extractParameterTypes(outerNode.node, languageName)
+      : [];
+
+    // #635: Detect C++ const-qualified methods
+    let isConst = false;
+    if ((languageName === 'cpp' || languageName === 'c') && (label === 'Method' || label === 'Function')) {
+      for (let i = 0; i < outerNode.node.childCount; i++) {
+        const child = outerNode.node.child(i);
+        if (child && child.type === 'const') {
+          isConst = true;
+          break;
+        }
+      }
+    }
+
+    const id = symbolId(label, filePath, name, startLine, { parameterCount: paramCount, parameterTypes: paramTypes, isConst });
+    // Dedup by filePath|name|startLine|paramCount|paramTypes so overloaded methods
+    // with the same name but different parameter types are not collapsed.
     // Use label priority: more specific labels (Method, Constructor) beat
     // less specific ones (Function) to fix Rust impl method dedup (#178).
-    const dedupKey = `${filePath}|${name}|${startLine}|${paramCount ?? 0}`;
+    const dedupKey = `${filePath}|${name}|${startLine}|${paramCount ?? 0}|${paramTypes.join(',')}`;
     const existing = seen.get(dedupKey);
 
     if (shouldReplaceDedup(existing, { id, filePath, name, label, startLine, endLine, isExported: exported })) {
@@ -367,6 +384,17 @@ function extractSymbols(
               entry.properties[key] = value;
             }
           }
+        }
+      }
+    }
+
+    // #635: Store paramCount in node properties for downstream consumers
+    if (paramCount != null) {
+      const entry = seen.get(dedupKey);
+      if (entry) {
+        if (!entry.properties) entry.properties = {};
+        if (entry.properties.paramCount === undefined) {
+          entry.properties.paramCount = paramCount;
         }
       }
     }
@@ -501,6 +529,79 @@ function findChildByType(node: any, type: string): any {
     if (child && child.type === type) return child;
   }
   return null;
+}
+
+/**
+ * #635: Extract ONLY the parameter type strings from a tree-sitter AST node
+ * for overload disambiguation. Returns an empty array when no typed params are found.
+ * This is a lightweight version of extractSymbolMetadata() that runs BEFORE symbolId()
+ * so that parameterTypes can be threaded into the ID construction.
+ */
+function extractParameterTypes(node: any, languageName: string): string[] {
+  const funcNode = findFunctionNode(node);
+  const params = findParamsNode(funcNode);
+  if (!params) return [];
+
+  switch (languageName) {
+    case 'typescript':
+    case 'tsx':
+    case 'javascript': {
+      const types = extractParamTypesTs(params);
+      return types ?? [];
+    }
+    case 'python': {
+      const types = extractParamTypesPython(params);
+      return types ?? [];
+    }
+    case 'java': {
+      const types = extractParamTypesJava(params);
+      return types ?? [];
+    }
+    case 'csharp': {
+      const types = extractParamTypesCSharp(params);
+      return types ?? [];
+    }
+    // C/C++: parameter types come from type descriptors in parameter_list
+    case 'cpp':
+    case 'c': {
+      const types = extractParamTypesCpp(params);
+      return types ?? [];
+    }
+    default:
+      return [];
+  }
+}
+
+/**
+ * #635: Extract parameter type strings from C/C++ parameter lists.
+ * C/C++ parameters use `parameter_declaration` nodes with an optional `type` child.
+ * Also handles `optional_parameter_declaration` (C++ default arguments).
+ */
+function extractParamTypesCpp(paramsNode: any): string[] | undefined {
+  const types: string[] = [];
+  let hasAny = false;
+  for (let i = 0; i < paramsNode.namedChildCount; i++) {
+    const param = paramsNode.namedChild(i);
+    if (!param) { types.push(''); continue; }
+    // parameter_declaration or optional_parameter_declaration
+    const typeDecl = param.childForFieldName
+      ? param.childForFieldName('type')
+      : null;
+    if (typeDecl) {
+      types.push(typeDecl.text);
+      hasAny = true;
+    } else {
+      // Fallback: first named child is often the type in C/C++
+      const firstNamed = param.namedChildCount > 0 ? param.namedChild(0) : null;
+      if (firstNamed && firstNamed.type !== 'identifier') {
+        types.push(firstNamed.text);
+        hasAny = true;
+      } else {
+        types.push('');
+      }
+    }
+  }
+  return hasAny ? types : undefined;
 }
 
 /**

--- a/packages/core/src/analysis/phases/parse-emit.ts
+++ b/packages/core/src/analysis/phases/parse-emit.ts
@@ -214,10 +214,16 @@ function emitSymbol(
   sym: ParsedSymbol,
   relPath: string,
 ): void {
-  // Extract the :L<line> suffix from the parser's ID for uniqueness
+  // Extract the overload suffix (#N~types) and const marker from the full symbol ID
+  // so the graph node preserves them.  Format: label:filePath:name[#N~types][\\][:L<line>]
+  const overloadMatch = sym.id.match(/(#\d+(?:~[^:\\]+)?)/);
+  const overloadSuffix = overloadMatch ? overloadMatch[1] : '';
   const lineSuffix = sym.id.includes(':L') ? sym.id.substring(sym.id.lastIndexOf(':L')) : '';
+  // Const marker (backslash) sits between the overload suffix and :L line suffix
+  const basePart = sym.id.includes(':L') ? sym.id.substring(0, sym.id.lastIndexOf(':L')) : sym.id;
+  const constSuffix = basePart.endsWith('\\') ? '\\' : '';
 
-  const nodeId = `${sym.label}:${relPath}:${sym.name}${lineSuffix}`;
+  const nodeId = `${sym.label}:${relPath}:${sym.name}${overloadSuffix}${constSuffix}${lineSuffix}`;
   const node: GraphNode = {
     id: nodeId,
     label: sym.label,

--- a/packages/core/tests/analysis/overload.test.ts
+++ b/packages/core/tests/analysis/overload.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Tests for overload method disambiguation (#635).
+ *
+ * Verifies that:
+ * - symbolId() produces distinct IDs for same-name methods with different arities
+ * - symbolId() produces distinct IDs for same-arity, different-type overloads
+ * - Zero-arity functions get no #0 suffix (existing behaviour preserved)
+ * - C++ const-qualified methods get \\ suffix
+ * - The parser threads parameterTypes into symbolId so graph nodes carry overload suffixes
+ * - The dedup key includes parameterTypes so overloaded methods are not collapsed
+ * - paramCount is stored in node properties
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  initParser,
+  resetParser,
+  parseFile,
+} from '../../src/analysis/parser.js';
+import { symbolId } from '../../src/analysis/language-definition.js';
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+// ── Test helpers ────────────────────────────────────────────────────────────
+
+// Resolve wasm directory — works whether vitest runs from project root or packages/core
+const wasmDir = existsSync(resolve(process.cwd(), 'packages/core/wasm'))
+  ? resolve(process.cwd(), 'packages/core/wasm')
+  : resolve(process.cwd(), 'wasm');
+let tmpDir: string;
+
+function hasWasm(file: string): boolean {
+  return existsSync(join(wasmDir, file));
+}
+
+function writeFixture(relativePath: string, content: string): string {
+  const fullPath = join(tmpDir, relativePath);
+  writeFileSync(fullPath, content, 'utf-8');
+  return fullPath;
+}
+
+function nl(...lines: string[]): string {
+  return lines.join('\n') + '\n';
+}
+
+// ── Setup / Teardown ────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'astrolabe-overload-test-'));
+  await initParser();
+}, 15000);
+
+afterAll(() => {
+  resetParser();
+  if (tmpDir && existsSync(tmpDir)) {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('Overload disambiguation (#635)', () => {
+  // ── symbolId() unit tests ──────────────────────────────────────────────
+
+  describe('symbolId() — arity suffix', () => {
+    it('generates distinct IDs for same-name methods with different parameter counts', () => {
+      const id1 = symbolId('Method', 'src/foo.ts', 'save', 10, { parameterCount: 1 });
+      const id2 = symbolId('Method', 'src/foo.ts', 'save', 20, { parameterCount: 2 });
+
+      expect(id1).toBe('Method:src/foo.ts:save#1:L10');
+      expect(id2).toBe('Method:src/foo.ts:save#2:L20');
+      expect(id1).not.toBe(id2);
+    });
+  });
+
+  describe('symbolId() — type hash suffix', () => {
+    it('generates distinct IDs for same-arity, different-type overloads', () => {
+      const id1 = symbolId('Method', 'src/foo.ts', 'save', 10, {
+        parameterCount: 2,
+        parameterTypes: ['int', 'string'],
+      });
+      const id2 = symbolId('Method', 'src/foo.ts', 'save', 20, {
+        parameterCount: 2,
+        parameterTypes: ['string', 'int'],
+      });
+
+      expect(id1).toBe('Method:src/foo.ts:save#2~int,string:L10');
+      expect(id2).toBe('Method:src/foo.ts:save#2~string,int:L20');
+      expect(id1).not.toBe(id2);
+    });
+
+    it('same parameter types produce same type hash', () => {
+      const id1 = symbolId('Method', 'src/foo.ts', 'save', 10, {
+        parameterCount: 2,
+        parameterTypes: ['int', 'string'],
+      });
+      const id2 = symbolId('Method', 'src/foo.ts', 'save', 20, {
+        parameterCount: 2,
+        parameterTypes: ['int', 'string'],
+      });
+
+      // Different lines → different IDs, but the overload suffix part is identical
+      expect(id1).toContain('#2~int,string');
+      expect(id2).toContain('#2~int,string');
+    });
+  });
+
+  describe('symbolId() — zero-arity gets no suffix', () => {
+    it('omits #0 suffix for zero-arity functions', () => {
+      const id = symbolId('Function', 'src/foo.ts', 'noop', 1, { parameterCount: 0 });
+      expect(id).toBe('Function:src/foo.ts:noop:L1');
+      expect(id).not.toContain('#0');
+    });
+
+    it('omits suffix entirely when parameterCount is undefined', () => {
+      const id = symbolId('Function', 'src/foo.ts', 'noop', 1);
+      expect(id).toBe('Function:src/foo.ts:noop:L1');
+    });
+  });
+
+  describe('symbolId() — C++ const suffix', () => {
+    it('appends backslash for const-qualified methods', () => {
+      const id = symbolId('Method', 'src/foo.cpp', 'getValue', 5, {
+        parameterCount: 0,
+        isConst: true,
+      });
+      // Zero arity → no #N suffix, but \\ still applies
+      expect(id).toBe('Method:src/foo.cpp:getValue\\:L5');
+    });
+
+    it('appends backslash after type hash for const-qualified methods with params', () => {
+      const id = symbolId('Method', 'src/foo.cpp', 'compute', 10, {
+        parameterCount: 2,
+        parameterTypes: ['int', 'float'],
+        isConst: true,
+      });
+      expect(id).toBe('Method:src/foo.cpp:compute#2~int,float\\:L10');
+    });
+
+    it('does not append backslash when isConst is false', () => {
+      const id = symbolId('Method', 'src/foo.cpp', 'compute', 10, {
+        parameterCount: 2,
+        parameterTypes: ['int', 'float'],
+        isConst: false,
+      });
+      expect(id).toBe('Method:src/foo.cpp:compute#2~int,float:L10');
+    });
+  });
+
+  // ── Full parser pipeline tests ─────────────────────────────────────────
+
+  describe('TypeScript overload parsing', () => {
+    let tsOverloadFile: string;
+
+    beforeAll(() => {
+      tsOverloadFile = writeFixture(
+        'overloads.ts',
+        nl(
+          'class Renderer {',
+          '  draw(shape: string): void {}',
+          '  draw(shape: string, color: number): void {}',
+          '  draw(shape: string, color: number, bold: boolean): void {}',
+          '  clear(): void {}',
+          '}',
+        ),
+      );
+    });
+
+    it('produces distinct IDs for methods with different parameter counts', async () => {
+      const result = await parseFile(tsOverloadFile, wasmDir);
+      const draws = result.symbols.filter((s) => s.name === 'draw');
+      expect(draws.length).toBe(3);
+      const ids = draws.map((s) => s.id).sort();
+      // 1-param, 2-param, 3-param versions
+      expect(ids[0]).toContain('#1');
+      expect(ids[1]).toContain('#2');
+      expect(ids[2]).toContain('#3');
+      // All IDs are unique
+      expect(new Set(ids).size).toBe(3);
+    });
+
+    it('preserves type hash in symbol ID when parameter types are available', async () => {
+      const result = await parseFile(tsOverloadFile, wasmDir);
+      const twoParam = result.symbols.find(
+        (s) => s.name === 'draw' && s.id.includes('#2'),
+      );
+      expect(twoParam).toBeDefined();
+      // Should have #2~string,number or similar type hash
+      expect(twoParam!.id).toMatch(/#2~[^:]+/);
+    });
+
+    it('zero-arity method gets no #0 suffix', async () => {
+      const result = await parseFile(tsOverloadFile, wasmDir);
+      const clear = result.symbols.find((s) => s.name === 'clear');
+      expect(clear).toBeDefined();
+      expect(clear!.id).not.toContain('#0');
+    });
+
+    it('paramCount is stored in node properties', async () => {
+      const result = await parseFile(tsOverloadFile, wasmDir);
+      const twoParam = result.symbols.find(
+        (s) => s.name === 'draw' && s.id.includes('#2'),
+      );
+      expect(twoParam).toBeDefined();
+      expect(twoParam!.properties).toBeDefined();
+      expect(twoParam!.properties!.paramCount).toBe(2);
+    });
+
+    it('overloaded methods are NOT deduplicated', async () => {
+      const result = await parseFile(tsOverloadFile, wasmDir);
+      const draws = result.symbols.filter((s) => s.name === 'draw');
+      // All 3 overloads should survive dedup
+      expect(draws.length).toBe(3);
+    });
+  });
+
+  describe('TypeScript same-arity different-type overloads', () => {
+    let tsSameArityFile: string;
+
+    beforeAll(() => {
+      tsSameArityFile = writeFixture(
+        'same-arity.ts',
+        nl(
+          'class Calculator {',
+          '  add(a: number, b: number): number { return a + b; }',
+          '  add(a: string, b: string): string { return a + b; }',
+          '}',
+        ),
+      );
+    });
+
+    it('same-arity methods with different types get distinct IDs', async () => {
+      const result = await parseFile(tsSameArityFile, wasmDir);
+      const adds = result.symbols.filter((s) => s.name === 'add');
+      expect(adds.length).toBe(2);
+      // Both have #2 but different type hashes
+      const ids = adds.map((s) => s.id);
+      expect(ids[0]).not.toBe(ids[1]);
+      // Both should contain #2
+      for (const id of ids) {
+        expect(id).toContain('#2');
+      }
+    });
+  });
+
+  // ── C/C++ const method tests (conditional on WASM availability) ──────
+
+  describe.runIf(hasWasm('tree-sitter-cpp.wasm'))('C++ const methods', () => {
+    let cppFile: string;
+
+    beforeAll(() => {
+      cppFile = writeFixture(
+        'const.cpp',
+        nl(
+          'class Config {',
+          '  int getValue() const { return val; }',
+          '  void setValue(int v) { val = v; }',
+          '  int val;',
+          '};',
+        ),
+      );
+    });
+
+    it('const-qualified method gets backslash suffix in ID', async () => {
+      const result = await parseFile(cppFile, wasmDir);
+      const getValue = result.symbols.find((s) => s.name === 'getValue');
+      expect(getValue).toBeDefined();
+      // Zero-arity const method → no #N, but has \\ suffix
+      expect(getValue!.id).toContain('\\');
+    });
+
+    it('non-const method does not get backslash suffix', async () => {
+      const result = await parseFile(cppFile, wasmDir);
+      const setValue = result.symbols.find((s) => s.name === 'setValue');
+      expect(setValue).toBeDefined();
+      expect(setValue!.id).not.toContain('\\');
+    });
+  });
+});


### PR DESCRIPTION
Fixes the broken plumbing between symbolId() format and the parser/emit pipeline. The symbolId function already supported #N~typeHash format but parameterTypes were never threaded through — extracted after ID construction and only stored in properties. Changes: Thread extractParameterTypes() before symbolId() call so type hashes appear in node IDs. Update dedup key to include parameterTypes (filePath|name|startLine|paramCount|types). Preserve #N~typeHash and const backslash suffixes in parse-emit.ts emitSymbol(). Detect C++ const qualifier and append backslash suffix. Store paramCount in node properties. 16 new tests (14 passing, 2 skipped for C++ WASM). All 522 core tests pass. Closes #635