### PR TITLE
fix: Windows PID check + perf pre-indexing for apiImpact/impact (#696, #694, #695)

### DIFF
--- a/packages/core/src/mcp/api-tools.ts
+++ b/packages/core/src/mcp/api-tools.ts
@@ -227,10 +227,14 @@ export function apiImpact(graph: KnowledgeGraph, symbolName: string): ApiImpactR
     });
   }
 
-  // callee → callers (CALLS relationships)
+  // callee → callers (CALLS relationships) + pre-index: which nodes
+  // participate in ANY CALLS edge (for untraceable detection — #694)
   const calleeToCallers = new Map<string, string[]>();
+  const nodesWithCallsEdges = new Set<string>();
   for (const rel of graph.iterRelationships()) {
     if (rel.type !== 'CALLS') continue;
+    nodesWithCallsEdges.add(rel.sourceId);
+    nodesWithCallsEdges.add(rel.targetId);
     const caller = graph.getNode(rel.sourceId);
     if (!caller) continue;
     let arr = calleeToCallers.get(rel.targetId);
@@ -252,18 +256,7 @@ export function apiImpact(graph: KnowledgeGraph, symbolName: string): ApiImpactR
     if (consumers.length > 0) {
       routeRisk = 'BREAKING: has consumers';
     } else {
-      // Check if this target is involved in any CALLS relationship
-      let hasCallsEdges = false;
-      if (consumers.length === 0) {
-        for (const rel of graph.iterRelationships()) {
-          if (rel.type !== 'CALLS') continue;
-          if (rel.sourceId === targetId || rel.targetId === targetId) {
-            hasCallsEdges = true;
-            break;
-          }
-        }
-      }
-      routeRisk = hasCallsEdges ? 'UNKNOWN: untraceable callers' : 'safe to change';
+      routeRisk = nodesWithCallsEdges.has(targetId) ? 'UNKNOWN: untraceable callers' : 'safe to change';
     }
 
     for (const r of matchedRoutes) {

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -492,10 +492,21 @@ class LocalBackend {
     if (!targetNode) return { error: `Target "${target}" not found.` };
 
     // Pre-build adjacency index: Map<nodeId, { neighborId, type, confidence }[]> (#119)
+    // Also track unfiltered edge counts per node for untraceable detection (#695):
+    // edges that exist but were filtered by confidence → UNKNOWN risk, not safe.
     const adj = new Map<string, Array<{ neighborId: string; type: string; confidence: number }>>();
+    const edgePresence = new Map<string, { upstream: number; downstream: number }>();
     for (const rel of graph.iterRelationships()) {
       // #290: Exclude synthetic STEP_IN_PROCESS edges — being in same process ≠ dependency
       if (rel.type === 'STEP_IN_PROCESS') continue;
+      // Track unfiltered edge counts before confidence filter
+      const srcP = edgePresence.get(rel.sourceId) ?? { upstream: 0, downstream: 0 };
+      const tgtP = edgePresence.get(rel.targetId) ?? { upstream: 0, downstream: 0 };
+      srcP.downstream++;
+      tgtP.upstream++;
+      edgePresence.set(rel.sourceId, srcP);
+      edgePresence.set(rel.targetId, tgtP);
+      // Confidence filter for actual traversal
       if (rel.confidence < minConfidence) continue;
       // Upstream: target <- source (who calls me)
       if (direction === 'upstream') {
@@ -575,17 +586,12 @@ class LocalBackend {
     // #643 Pitfall 4: When affected is empty, check if the target had edges
     // that were filtered out (by confidence or direction). If edges exist
     // but couldn't be traced → UNKNOWN risk, not safe.
-    let untraceable = false;
-    if (affected.length === 0) {
-      // Count unfiltered edges for the target (excluding STEP_IN_PROCESS)
-      let totalEdges = 0;
-      for (const rel of graph.iterRelationships()) {
-        if (rel.type === 'STEP_IN_PROCESS') continue;
-        if (direction === 'upstream' && rel.targetId === targetNode.id) totalEdges++;
-        if (direction === 'downstream' && rel.sourceId === targetNode.id) totalEdges++;
-      }
-      untraceable = totalEdges > 0; // edges exist but didn't pass confidence filter
-    }
+    // Uses pre-built edgePresence map from adjacency pass (#695): O(1) lookup
+    // instead of a second O(E) scan.
+    const presence = affected.length === 0 ? edgePresence.get(targetNode.id) : undefined;
+    const untraceable = presence
+      ? (direction === 'upstream' ? presence.upstream : presence.downstream) > 0
+      : false;
 
     return {
       target: { name: targetNode.properties.name ?? targetNode.id, type: targetNode.label, filePath: targetNode.properties.filePath ?? '' },

--- a/packages/core/src/persist/lock.ts
+++ b/packages/core/src/persist/lock.ts
@@ -7,6 +7,8 @@
  */
 import { writeFileSync, readFileSync, unlinkSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
+import { platform } from 'node:os';
+import { execSync } from 'node:child_process';
 
 const LOCK_FILE_NAME = 'astrolabe.lock';
 
@@ -16,8 +18,24 @@ export interface DbLock {
 
 function isProcessAlive(pid: number): boolean {
   try {
-    // Signal 0 is a no-op that checks if the process exists
+    // Signal 0 is a no-op that checks if the process exists.
+    // On Unix this correctly returns ESRCH for nonexistent PIDs.
+    // On Windows, process.kill(pid, 0) always returns true for any
+    // running PID regardless of process identity (#696), so we
+    // additionally verify via tasklist.
     process.kill(pid, 0);
+
+    if (platform() === 'win32') {
+      // tasklist /FI "PID eq NNN" returns the header line plus one
+      // data line if the PID exists — filter out to check.
+      const output = execSync(`tasklist /FI "PID eq ${pid}" /NH`, {
+        encoding: 'utf-8',
+        windowsHide: true,
+        timeout: 3000
+      }).trim();
+      return output.length > 0 && !output.startsWith('INFO:');
+    }
+
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Summary

- Fixed Windows PID verification bug in lock.ts - added `tasklist`-based check (#696)
- Pre-indexed CALLS edges in `apiImpact()` - replaces O(T x E) double loop with O(E + T) (#694)
- Pre-indexed edge counts in `impact()` - replaces O(E) untraceable rescan with O(1) map lookup (#695)

Closes #696, Closes #694, Closes #695
