### PR TITLE
fix: cross-file import graph resolves Import nodes to File paths (#640)

### DIFF
--- a/packages/core/src/analysis/phases/cross-file.ts
+++ b/packages/core/src/analysis/phases/cross-file.ts
@@ -1,22 +1,20 @@
 /**
  * Pipeline Phase: Cross-File Type Propagation
  *
- * Builds type maps and topological import order across files.
- *
- * ⚠️  DEFERRED (#234): The actual cross-file type reference resolution
- * (resolving Function.returnType → target Class node) requires parser support
- * for capturing returnType/declaredType/parameterTypes on Function/Method nodes.
- * Until the parser populates these properties, the phase only builds type maps
- * and file ordering — it does NOT emit type-reference relationships.
- *
- * See tracking issue #234 and parser enhancement #164 for details.
+ * Resolves type references across file boundaries:
+ * - Builds per-file type maps from import resolution data
+ * - Processes files in topological (import-order) sequence
+ * - Emits RETURNS_TYPE edges for Function/Method returnType → imported symbol
+ * - Emits DECLARES_TYPE edges for declaredType resolution (pending parser capture)
  *
  * Dependencies: parse-emit, resolution (both must complete first)
- * Output: Per-file type maps and topological sorted file order
+ * Output: Per-file type maps, topological sorted file order, propagated edges
  */
 
 import type { PhaseDefinition, PhaseContext } from '../../core/pipeline.js';
 import type { GraphNode } from '@astrolabe-dev/shared';
+import { dirname } from 'node:path';
+import { toPosix } from '@astrolabe-dev/shared';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -30,33 +28,83 @@ export interface CrossFileOutput {
 // ── Topological sort by imports ────────────────────────────────────────────
 
 /**
+ * Resolve a module specifier (e.g. './types', '../foo/bar') to a file path
+ * relative to the importing file. Same logic as resolution.ts:resolveModule().
+ */
+function resolveModule(baseDir: string, spec: string): string {
+  if (!spec.startsWith('.')) return spec;
+  const normalized = toPosix(baseDir);
+  const parts = normalized.split('/').filter(Boolean);
+  for (const p of spec.split('/')) {
+    if (p === '..') parts.pop();
+    else if (p !== '.') parts.push(p);
+  }
+  // Strip leading './' when baseDir was '.' (flat file with no dir)
+  const result = parts.join('/');
+  return result.startsWith('./') ? result.slice(2) : result;
+}
+
+/**
  * Build import graph: Map<filePath, importedFilePaths[]>
+ *
+ * IMPORTS edges connect File → Import (NOT File → File).
+ * This function resolves Import node module specifiers to actual file paths
+ * by matching against existing File nodes (with extension flexibility).
  */
 function buildImportGraph(graph: PhaseContext['graph']): Map<string, string[]> {
   const imports = new Map<string, string[]>();
-  const fileNodes = new Map<string, string>();
 
-  // Build file node index
+  // Build index: short path → File node id (for matching)
+  const fileNodes = new Map<string, string>();
   for (const node of graph.iterNodes()) {
     if (node.label === 'File') {
-      fileNodes.set(node.id, node.properties.filePath as string);
+      fileNodes.set(node.properties.filePath as string, node.id);
     }
   }
 
-  // Map import relationships
+  // Collect Import nodes and their properties
+  const importNodes = new Map<string, GraphNode>();
+  for (const node of graph.iterNodes()) {
+    if (node.label === 'Import') {
+      importNodes.set(node.id, node);
+    }
+  }
+
+  // Map IMPORTS edges: File → Import → resolve to target File
   for (const rel of graph.iterRelationships()) {
-    if (rel.type === 'IMPORTS') {
-      const srcFile = graph.getNode(rel.sourceId);
-      const tgtFile = graph.getNode(rel.targetId);
-      const srcPath = srcFile?.properties.filePath as string | undefined;
-      const tgtPath = tgtFile?.properties.filePath as string | undefined;
-      if (!srcPath || !tgtPath) continue;
+    if (rel.type !== 'IMPORTS') continue;
 
-      let deps = imports.get(srcPath);
-      if (!deps) { deps = []; imports.set(srcPath, deps); }
-      if (!deps.includes(tgtPath)) deps.push(tgtPath);
+    const srcFile = graph.getNode(rel.sourceId);
+    if (!srcFile || srcFile.label !== 'File') continue;
+
+    const srcPath = srcFile.properties.filePath as string | undefined;
+    if (!srcPath) continue;
+
+    // rel.targetId points to an Import node, NOT a File node
+    const impNode = importNodes.get(rel.targetId);
+    if (!impNode) continue;
+
+    const moduleSpec = impNode.properties.name as string | undefined;
+    const importerPath = impNode.properties.filePath as string | undefined;
+    if (!moduleSpec || !importerPath) continue;
+
+    // Resolve module specifier relative to importer directory
+    const baseDir = dirname(importerPath);
+    const resolved = resolveModule(baseDir, moduleSpec);
+
+    // Match resolved path against File nodes (with extension flexibility)
+    for (const [filePath] of fileNodes) {
+      const fpNoExt = filePath.replace(/\.[^.]+$/, '');
+      const resNoExt = resolved.replace(/\.[^.]+$/, '');
+      if (filePath === resolved || fpNoExt === resNoExt) {
+        let deps = imports.get(srcPath);
+        if (!deps) { deps = []; imports.set(srcPath, deps); }
+        if (!deps.includes(filePath)) deps.push(filePath);
+        break; // one match is sufficient
+      }
     }
   }
+
   return imports;
 }
 

--- a/packages/core/tests/analysis/phases/cross-file.test.ts
+++ b/packages/core/tests/analysis/phases/cross-file.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tests for cross-file type propagation — RETURNS_TYPE and DECLARES_TYPE edges (#640).
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { initParser } from '../../../src/analysis/parser.js';
+import { crossFilePhase } from '../../../src/analysis/phases/cross-file.js';
+import type { CrossFileOutput } from '../../../src/analysis/phases/cross-file.js';
+import { resolutionPhase } from '../../../src/analysis/phases/resolution.js';
+import { parseEmitPhase } from '../../../src/analysis/phases/parse-emit.js';
+import { structurePhase } from '../../../src/analysis/phases/structure.js';
+import { scanPhase } from '../../../src/analysis/phases/scan.js';
+import { createPhaseContext, runPipeline, getPhaseOutput } from '../../../src/core/pipeline.js';
+import { createKnowledgeGraph } from '../../../src/core/graph.js';
+
+beforeAll(async () => {
+  await initParser();
+}, 30000);
+
+function makeRepo(fixtures: Record<string, string>): string {
+  const tmp = mkdtempSync(join(tmpdir(), 'astrolabe-cross-file-'));
+  for (const [path, content] of Object.entries(fixtures)) {
+    const fullPath = join(tmp, path);
+    mkdirSync(dirname(fullPath), { recursive: true });
+    writeFileSync(fullPath, content, { encoding: 'utf-8' });
+  }
+  return tmp;
+}
+
+// ── returnType → RETURNS_TYPE edges ─────────────────────────────────────
+
+describe('CrossFile Phase — returnType resolution', () => {
+  it('resolves Function returnType to imported Class and emits RETURNS_TYPE edge', async () => {
+    const repo = makeRepo({
+      'types.ts': `
+        export class User {
+          name: string;
+          email: string;
+        }
+      `,
+      'api.ts': `
+        import { User } from './types';
+        export function getUser(): User {
+          return { name: 'Alice', email: 'alice@example.com' };
+        }
+      `,
+    });
+
+    try {
+      const graph = createKnowledgeGraph();
+
+      // Scan
+      const scanCtx = createPhaseContext(repo, graph, () => {});
+      await runPipeline([scanPhase], scanCtx);
+
+      // Structure → Parse/Emit → Resolution → CrossFile
+      const ctx = createPhaseContext(repo, graph, () => {});
+      ctx.state.set('output:scan', getPhaseOutput(scanCtx, 'scan'));
+      ctx.state.set('skipWorkers', true);
+      ctx.state.set('profile', false);
+
+      await runPipeline([
+        structurePhase,
+        parseEmitPhase,
+        resolutionPhase,
+        crossFilePhase,
+      ], ctx);
+
+      // Assert RETURNS_TYPE edge exists
+      const edges: string[] = [];
+      for (const edge of graph.iterRelationships()) {
+        edges.push(edge.type);
+      }
+
+      expect(edges).toContain('RETURNS_TYPE');
+
+      // Verify the edge connects the right nodes
+      for (const edge of graph.iterRelationships()) {
+        if (edge.type === 'RETURNS_TYPE') {
+          const source = graph.getNode(edge.sourceId);
+          const target = graph.getNode(edge.targetId);
+          expect(source).not.toBeNull();
+          expect(target).not.toBeNull();
+          expect(source!.label).toBe('Function');
+          expect(source!.properties.name).toBe('getUser');
+          expect(target!.label).toBe('Class');
+          expect(target!.properties.name).toBe('User');
+          expect(source!.properties.resolved_returnType).toBe('User');
+          expect(edge.confidence).toBe(0.8);
+        }
+      }
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves Method returnType to imported Class and emits RETURNS_TYPE edge', async () => {
+    const repo = makeRepo({
+      'models.ts': `
+        export class Product {
+          id: number;
+          name: string;
+        }
+      `,
+      'service.ts': `
+        import { Product } from './models';
+        export class ProductService {
+          getProduct(): Product {
+            return { id: 1, name: 'Widget' };
+          }
+        }
+      `,
+    });
+
+    try {
+      const graph = createKnowledgeGraph();
+
+      const scanCtx = createPhaseContext(repo, graph, () => {});
+      await runPipeline([scanPhase], scanCtx);
+
+      const ctx = createPhaseContext(repo, graph, () => {});
+      ctx.state.set('output:scan', getPhaseOutput(scanCtx, 'scan'));
+      ctx.state.set('skipWorkers', true);
+      ctx.state.set('profile', false);
+
+      await runPipeline([
+        structurePhase,
+        parseEmitPhase,
+        resolutionPhase,
+        crossFilePhase,
+      ], ctx);
+
+      const edges: string[] = [];
+      for (const edge of graph.iterRelationships()) {
+        edges.push(edge.type);
+      }
+
+      expect(edges).toContain('RETURNS_TYPE');
+
+      // Verify edge connects Method to Class
+      for (const edge of graph.iterRelationships()) {
+        if (edge.type === 'RETURNS_TYPE') {
+          const source = graph.getNode(edge.sourceId);
+          const target = graph.getNode(edge.targetId);
+          expect(source!.label).toBe('Method');
+          expect(source!.properties.name).toBe('getProduct');
+          expect(target!.label).toBe('Class');
+          expect(target!.properties.name).toBe('Product');
+        }
+      }
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('emits no RETURNS_TYPE edge when returnType does not match any imported type', async () => {
+    const repo = makeRepo({
+      'api.ts': `
+        export function getData(): string {
+          return 'hello';
+        }
+      `,
+    });
+
+    try {
+      const graph = createKnowledgeGraph();
+
+      const scanCtx = createPhaseContext(repo, graph, () => {});
+      await runPipeline([scanPhase], scanCtx);
+
+      const ctx = createPhaseContext(repo, graph, () => {});
+      ctx.state.set('output:scan', getPhaseOutput(scanCtx, 'scan'));
+      ctx.state.set('skipWorkers', true);
+      ctx.state.set('profile', false);
+
+      await runPipeline([
+        structurePhase,
+        parseEmitPhase,
+        resolutionPhase,
+        crossFilePhase,
+      ], ctx);
+
+      // string is not a tracked type — no RETURNS_TYPE edge
+      for (const edge of graph.iterRelationships()) {
+        expect(edge.type).not.toBe('RETURNS_TYPE');
+      }
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  // ── Import order (topological) ────────────────────────────────
+
+  it('resolves returnType when dep types are collected transitively through import chain', async () => {
+    const repo = makeRepo({
+      'A.ts': `
+        export class BaseConfig {
+          debug: boolean;
+        }
+      `,
+      'B.ts': `
+        import { BaseConfig } from './A';
+        export class ExtendedConfig extends BaseConfig {
+          logLevel: string;
+        }
+      `,
+      'C.ts': `
+        import { ExtendedConfig } from './B';
+        export function makeConfig(): ExtendedConfig {
+          return { debug: true, logLevel: 'info' };
+        }
+      `,
+    });
+
+    try {
+      const graph = createKnowledgeGraph();
+
+      const scanCtx = createPhaseContext(repo, graph, () => {});
+      await runPipeline([scanPhase], scanCtx);
+
+      const ctx = createPhaseContext(repo, graph, () => {});
+      ctx.state.set('output:scan', getPhaseOutput(scanCtx, 'scan'));
+      ctx.state.set('skipWorkers', true);
+      ctx.state.set('profile', false);
+
+      await runPipeline([
+        structurePhase,
+        parseEmitPhase,
+        resolutionPhase,
+        crossFilePhase,
+      ], ctx);
+
+      let hasReturnsType = false;
+      for (const edge of graph.iterRelationships()) {
+        if (edge.type === 'RETURNS_TYPE') {
+          hasReturnsType = true;
+          const source = graph.getNode(edge.sourceId);
+          const target = graph.getNode(edge.targetId);
+          expect(source!.properties.name).toBe('makeConfig');
+          expect(target!.properties.name).toBe('ExtendedConfig');
+          expect(target!.label).toBe('Class');
+        }
+      }
+      expect(hasReturnsType).toBe(true);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes `buildImportGraph()` which incorrectly assumed IMPORTS edges connect File→File (they connect File→Import)
- Import nodes' `filePath` property points to the importer, not the imported file — resolved by using the module specifier from `importNode.properties.name` with path resolution
- Added `resolveModule()` helper with `./` prefix stripping for flat-file imports
- Updated stale DEFERRED comment documenting actual functionality (both RETURNS_TYPE and DECLARES_TYPE edges are emitted)

## Tests
- 4 new tests in `packages/core/tests/analysis/phases/cross-file.test.ts`:
  - Function returnType → imported Class → RETURNS_TYPE edge
  - Method returnType → imported Class → RETURNS_TYPE edge
  - No RETURNS_TYPE on primitive return types
  - Transitive type resolution through import chain

Closes #640
