### PR TITLE
fix: make GitHub App token optional in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,9 +274,24 @@ jobs:
           npm pkg set version="$VERSION" -w packages/cli
           npm pkg set version="$VERSION" -w packages/vscode
 
-      # ── App token for branch protection bypass ──────────────────────────
+      # ── App token for branch protection bypass (optional) ──────────────────
+      # Check if GitHub App secrets are configured. If not, the CHANGELOG
+      # push to main falls back to GITHUB_TOKEN (which may fail on
+      # protected branches but the release itself will still complete).
+      - name: Check for GitHub App secrets
+        id: check-app
+        run: |
+          if [ -n "${{ secrets.RELEASE_APP_ID }}" ] && [ -n "${{ secrets.RELEASE_APP_PRIVATE_KEY }}" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "GitHub App secrets found — will use app token for CHANGELOG push."
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "GitHub App secrets not configured — CHANGELOG push will use GITHUB_TOKEN."
+          fi
+
       - name: Generate GitHub App token
         id: app-token
+        if: steps.check-app.outputs.available == 'true'
         uses: tibdex/github-app-token@v2
         with:
           app_id: ${{ secrets.RELEASE_APP_ID }}
@@ -346,7 +361,12 @@ jobs:
           git add CHANGELOG.md
           git diff --cached --quiet && echo "No CHANGELOG changes" || {
             git commit -m "docs: update CHANGELOG for ${TAG}"
-            git push "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git" HEAD:main
+            # Use app token if available, otherwise fall back to GITHUB_TOKEN
+            if [ "${{ steps.check-app.outputs.available }}" = "true" ]; then
+              git push "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git" HEAD:main
+            else
+              git push "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" HEAD:main
+            fi
             echo "CHANGELOG.md updated and pushed to main"
           }
 


### PR DESCRIPTION
## Summary
- Makes the `tibdex/github-app-token@v2` step conditional on `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` secrets being configured
- Falls back to `GITHUB_TOKEN` for CHANGELOG push when GitHub App secrets are not available
- Prevents release pipeline failure when these secrets don't exist

## Root Cause
PR #626 added GitHub App token generation for CHANGELOG pushes to protected `main`. The `tibdex/github-app-token@v2` action hard-fails with `Error: Input required and not supplied: app_id` when `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY` secrets are not configured.

## Fix
1. Added **Check for GitHub App secrets** step that tests if both secrets are available
2. Made **Generate GitHub App token** step conditional on `steps.check-app.outputs.available == 'true'`
3. Updated **CHANGELOG push** to use app token when available, `GITHUB_TOKEN` otherwise

## Impact
- Release pipeline now works without GitHub App secrets
- When secrets DO exist, CHANGELOG push still uses the app token (no regression)
- When secrets DON'T exist, CHANGELOG push may fail on protected branches, but the release itself (Docker image, npm publish, GitHub release) completes successfully

Closes the release pipeline failure triggered by merging #703.
