### PR TITLE
fix: pre-merge CHANGELOG + version bump to staging, remove post-merge push to main (#704)

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,104 @@
+name: Prepare Release
+
+# ── Trigger ─────────────────────────────────────────────────────────────────
+# Manual workflow dispatch on staging. Generates CHANGELOG and bumps
+# package.json versions before the staging→main PR is opened.
+# Reviewer sees these changes in the PR diff.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (skip commit/push)'
+        type: boolean
+        default: true
+
+jobs:
+  prepare:
+    name: Prepare Release on Staging
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: staging
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # ── Calculate stable version ──────────────────────────────────────────
+      - name: Calculate stable version
+        id: version
+        run: |
+          VERSION=$(node scripts/next-version.mjs --release)
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Stable version: ${VERSION}"
+
+      # ── Generate release notes ────────────────────────────────────────────
+      - name: Generate release notes
+        id: notes
+        run: |
+          NOTES=$(node scripts/release-notes.mjs)
+          {
+            echo "notes<<NOTES_EOF"
+            echo "$NOTES"
+            echo "NOTES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      # ── Update CHANGELOG.md ───────────────────────────────────────────────
+      - name: Update CHANGELOG.md
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          HEADER="## [${VERSION}] — $(date +%Y-%m-%d)"
+          NOTES="${{ steps.notes.outputs.notes }}"
+
+          TEMP=$(mktemp)
+          {
+            echo "# Changelog"
+            echo ""
+            echo "${HEADER}"
+            echo ""
+            echo "${NOTES}"
+            echo ""
+            tail -n +3 CHANGELOG.md
+          } > "${TEMP}"
+          mv "${TEMP}" CHANGELOG.md
+
+      # ── Bump workspace versions ───────────────────────────────────────────
+      - name: Bump workspace versions
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          npm pkg set version="$VERSION"
+          npm pkg set version="$VERSION" -w packages/shared
+          npm pkg set version="$VERSION" -w packages/core
+          npm pkg set version="$VERSION" -w packages/cli
+          npm pkg set version="$VERSION" -w packages/vscode
+
+      # ── Commit and push to staging ────────────────────────────────────────
+      - name: Commit and push to staging
+        if: github.event.inputs.dry_run != 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="v${VERSION}"
+
+          git add CHANGELOG.md package.json \
+            packages/shared/package.json \
+            packages/core/package.json \
+            packages/cli/package.json \
+            packages/vscode/package.json
+
+          git diff --cached --quiet && echo "No changes to commit" || {
+            git commit -m "chore: prepare release ${TAG} — CHANGELOG + version bump [skip ci]"
+            git push origin staging
+            echo "✅ Committed and pushed to staging"
+          }
+
+      - name: Dry run — skip commit
+        if: github.event.inputs.dry_run == 'true'
+        run: |
+          echo "🔲 DRY RUN: Would commit CHANGELOG + version bump for v${{ steps.version.outputs.version }} to staging"
+          echo "Run again with dry_run=false to commit."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,20 +133,17 @@ jobs:
               echo "✅ GitHub release $TAG also exists — skipping everything (safe re-run)."
               echo "skip_npm=true" >> "$GITHUB_OUTPUT"
               echo "skip_release=true" >> "$GITHUB_OUTPUT"
-              echo "skip_changelog=true" >> "$GITHUB_OUTPUT"
               echo "skip_tag=true" >> "$GITHUB_OUTPUT"
             else
               echo "⚠️  GitHub release $TAG does NOT exist — will create it retroactively."
               echo "skip_npm=true" >> "$GITHUB_OUTPUT"
               echo "skip_release=false" >> "$GITHUB_OUTPUT"
-              echo "skip_changelog=true" >> "$GITHUB_OUTPUT"
               echo "skip_tag=false" >> "$GITHUB_OUTPUT"
             fi
           else
             echo "✅ Version $VERSION not on npm — proceeding with full release."
             echo "skip_npm=false" >> "$GITHUB_OUTPUT"
             echo "skip_release=false" >> "$GITHUB_OUTPUT"
-            echo "skip_changelog=false" >> "$GITHUB_OUTPUT"
             echo "skip_tag=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -262,42 +259,11 @@ jobs:
             git push origin "$TAG"
           fi
 
-      # ── Update package.json versions (commit with [skip ci]) ────────────
-      - name: Bump workspace versions
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          # Update root package.json
-          npm pkg set version="$VERSION"
-          # Update workspace packages
-          npm pkg set version="$VERSION" -w packages/shared
-          npm pkg set version="$VERSION" -w packages/core
-          npm pkg set version="$VERSION" -w packages/cli
-          npm pkg set version="$VERSION" -w packages/vscode
-
-      # ── App token for branch protection bypass (optional) ──────────────────
-      # Check if GitHub App secrets are configured. If not, the CHANGELOG
-      # push to main falls back to GITHUB_TOKEN (which may fail on
-      # protected branches but the release itself will still complete).
-      - name: Check for GitHub App secrets
-        id: check-app
-        run: |
-          if [ -n "${{ secrets.RELEASE_APP_ID }}" ] && [ -n "${{ secrets.RELEASE_APP_PRIVATE_KEY }}" ]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-            echo "GitHub App secrets found — will use app token for CHANGELOG push."
-          else
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "GitHub App secrets not configured — CHANGELOG push will use GITHUB_TOKEN."
-          fi
-
-      - name: Generate GitHub App token
-        id: app-token
-        if: steps.check-app.outputs.available == 'true'
-        uses: tibdex/github-app-token@v2
-        with:
-          app_id: ${{ secrets.RELEASE_APP_ID }}
-          private_key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       # ── Publish to npm ────────────────────────────────────────────────────
+      # NOTE: Version bump and CHANGELOG are now done on staging via
+      # prepare-release.yml before the staging→main PR is opened.
+      # The reviewer sees those changes in the PR diff.
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -332,52 +298,6 @@ jobs:
             echo "⏭️  SKIPPED: @astrolabe-dev/cli@${{ steps.version.outputs.version }} already exists on npm (idempotency check)"
           fi
 
-      # ── Update CHANGELOG.md ───────────────────────────────────────────────
-      - name: Update CHANGELOG.md
-        if: needs.check.outputs.dry_run != 'true' && steps.idempotency.outputs.skip_changelog != 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          VERSION="${{ steps.version.outputs.version }}"
-          TAG="v${VERSION}"
-          NOTES=$(node scripts/release-notes.mjs)
-
-          # Prepend new entry to CHANGELOG.md
-          HEADER="## [${VERSION}] — $(date +%Y-%m-%d)"
-          TEMP=$(mktemp)
-          {
-            echo "# Changelog"
-            echo ""
-            echo "${HEADER}"
-            echo ""
-            echo "${NOTES}"
-            echo ""
-            # Skip the first 2 lines (title + blank) of existing changelog
-            tail -n +3 CHANGELOG.md
-          } > "${TEMP}"
-          mv "${TEMP}" CHANGELOG.md
-
-          git add CHANGELOG.md
-          git diff --cached --quiet && echo "No CHANGELOG changes" || {
-            git commit -m "docs: update CHANGELOG for ${TAG}"
-            # Use app token if available, otherwise fall back to GITHUB_TOKEN
-            if [ "${{ steps.check-app.outputs.available }}" = "true" ]; then
-              git push "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git" HEAD:main
-            else
-              git push "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" HEAD:main
-            fi
-            echo "CHANGELOG.md updated and pushed to main"
-          }
-
-      - name: Dry run — skip CHANGELOG push
-        if: needs.check.outputs.dry_run == 'true' || steps.idempotency.outputs.skip_changelog == 'true'
-        run: |
-          if [ "${{ needs.check.outputs.dry_run }}" = "true" ]; then
-            echo "🔲 DRY RUN: Would update CHANGELOG.md for v${{ steps.version.outputs.version }}"
-          else
-            echo "⏭️  SKIPPED: CHANGELOG already up to date (idempotency check)"
-          fi
 
       # ── GitHub release ──────────────────────────────────────────────────
       - name: Generate release notes
@@ -455,7 +375,6 @@ jobs:
           echo "- Docker push (image was built only)" >> "$GITHUB_STEP_SUMMARY"
           echo "- npm publish" >> "$GITHUB_STEP_SUMMARY"
           echo "- Git tag push" >> "$GITHUB_STEP_SUMMARY"
-          echo "- CHANGELOG.md push" >> "$GITHUB_STEP_SUMMARY"
           echo "- GitHub release creation" >> "$GITHUB_STEP_SUMMARY"
           echo "- Docker image signing" >> "$GITHUB_STEP_SUMMARY"
           echo "- SBOM generation" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Problem

Release pipeline #32 failed because the \Generate GitHub App token\ step requires \RELEASE_APP_ID\/\RELEASE_APP_PRIVATE_KEY\ secrets to push CHANGELOG commits to protected \main\. This approach also bypasses the reviewer — CHANGELOG changes and version bumps were invisible until after merge.

## Solution

**New SOP**: CHANGELOG and version bumps happen on \staging\ BEFORE the staging→main PR. Reviewer sees everything in the PR diff.

### Changes

**New: \.github/workflows/prepare-release.yml\**
- \workflow_dispatch\ on \staging\ (with \dry_run\ toggle, default true)
- Calculates stable version via \
ext-version.mjs --release\
- Generates release notes via \elease-notes.mjs\
- Updates \CHANGELOG.md\ + bumps all workspace \package.json\ versions
- Commits and pushes to staging (\[skip ci]\)
- Dry-run mode shows what would change without committing

**Modified: \.github/workflows/release.yml\**
- Removed: GitHub App token step (\	ibdex/github-app-token\)
- Removed: Version bump step (now happens on staging)
- Removed: CHANGELOG push to \main\ (now happens on staging)
- Removed: Dead \skip_changelog\ idempotency flags
- Kept: Docker, SBOM, Cosign, npm publish, GitHub release — all shipping steps

### New Release Flow

\\\
1. Run prepare-release.yml on staging (dry_run=false)
2. Reviewer opens staging→main PR — sees CHANGELOG + version bump in diff
3. Reviewer approves and merges
4. release.yml runs: Docker + npm + GitHub release (no git push to main)
\\\

Closes #704