### PR TITLE
fix: replace git push with gh api for stable tag creation (#704, #706)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,16 +250,23 @@ jobs:
           retention-days: 90
 
       # ── Push stable Git tag ─────────────────────────────────────────────
+      # Uses GitHub API instead of git push to bypass branch protection
+      # rules that block GITHUB_TOKEN from pushing to protected main (#704, #706).
       - name: Push stable tag
         if: needs.check.outputs.dry_run != 'true' && steps.idempotency.outputs.skip_tag != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="v${{ steps.version.outputs.version }}"
-          # Skip if tag already exists (e.g. re-run)
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
+          SHA="${{ github.sha }}"
+          # Check if tag already exists via API (handles re-runs)
+          if gh api "repos/${{ github.repository }}/git/ref/tags/$TAG" >/dev/null 2>&1; then
             echo "Tag $TAG already exists, skipping."
           else
-            git tag "$TAG"
-            git push origin "$TAG"
+            gh api "repos/${{ github.repository }}/git/refs" \
+              -f ref="refs/tags/$TAG" \
+              -f sha="$SHA"
+            echo "Created tag $TAG at $SHA via GitHub API."
           fi
 
       # ── Update package.json versions (commit with [skip ci]) ────────────


### PR DESCRIPTION
## Summary

The release pipeline failed on run #25628556955 because `git push origin "$TAG"` triggered GH006 (Protected branch update failed for refs/heads/main). The GITHUB_TOKEN cannot push tags through branch protection rules on `main`.

## Root Cause

The `Publish Release` job checks out main with `GITHUB_TOKEN` and then tries to `git push origin $TAG`. Even though we're only pushing a tag ref, GitHub's branch protection rejects this because GITHUB_TOKEN is subject to protection rules.

The CHANGELOG push was already fixed (it uses a GitHub App token), but the tag push step was missed.

## Fix

Replace `git tag + git push origin $TAG` with `gh api` to create the tag ref via GitHub API. This works because the API path for creating refs (`POST /repos/{owner}/{repo}/git/refs`) respects `contents: write` permission without being subject to branch protection rules — the same reason `gh release create` already works later in this same workflow.

## Testing

- Pipeline YAML syntax is valid
- The approach mirrors the existing `gh release create` step that already works with GITHUB_TOKEN

Closes #704
Closes #706
