### PR TITLE
feat: tsconfig path alias parsing for TypeScript import resolution (#729)

### DIFF
--- a/packages/core/src/analysis/scope-resolver.ts
+++ b/packages/core/src/analysis/scope-resolver.ts
@@ -21,6 +21,7 @@
 import type { KnowledgeGraph, GraphNode } from '../core/types.js';
 import type { PhaseDefinition, PhaseContext } from '../core/pipeline.js';
 import type { SupportedLanguage } from '@astrolabe-dev/shared';
+import { loadTsconfigAliases, resolveAliasImport, type TsconfigPaths } from './tsconfig-utils.js';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -52,6 +53,8 @@ export interface ScopeResolutionIndex {
   classScopes: Map<string, ClassScope>;
   moduleScopes: Map<string, ModuleScope>;
   typeBindings: Map<string, TypeBinding>;
+  /** Parsed tsconfig.json path aliases for TypeScript import resolution. */
+  tsconfigAliases: TsconfigPaths;
 }
 
 /** Emitted edges from scope resolution. */
@@ -274,12 +277,13 @@ const typescriptResolver: ScopeResolver = {
       // Strip extension if present
       resolved = resolved.replace(/\.(ts|tsx|js|jsx)$/, '');
     }
-    // Path aliases: @/ prefix → strip and resolve
-    else if (resolved.startsWith('@/')) {
-      resolved = resolved.replace(/^@\//, '');
-    }
-    // Bare specifier → strip extension
+    // Path aliases: resolve via tsconfig.json compilerOptions.paths (#729)
     else {
+      const aliasResolved = resolveAliasImport(resolved, index.tsconfigAliases);
+      if (aliasResolved !== resolved) {
+        resolved = aliasResolved;
+      }
+      // Bare specifier or alias-resolved path → strip extension
       resolved = resolved.replace(/\.(ts|tsx|js|jsx)$/, '');
     }
 
@@ -517,6 +521,7 @@ function buildScopeIndex(graph: KnowledgeGraph, incremental?: { changedPaths: Se
     classScopes: new Map(),
     moduleScopes: new Map(),
     typeBindings: new Map(),
+    tsconfigAliases: { aliases: [], baseUrl: null },
   };
 
   // #632: In incremental mode, only index affected files. Unchanged files'
@@ -624,6 +629,10 @@ export const scopeResolutionPhase: PhaseDefinition<ScopeResolutionOutput> = {
         ? { changedPaths: incremental.changedPaths, addedPaths: incremental.addedPaths }
         : undefined,
     );
+
+    // Load tsconfig path aliases for TypeScript import resolution (#729)
+    index.tsconfigAliases = loadTsconfigAliases(context.repoPath);
+
     let edgeCount = 0;
     let resolverCount = 0;
 

--- a/packages/core/src/analysis/tsconfig-utils.ts
+++ b/packages/core/src/analysis/tsconfig-utils.ts
@@ -1,0 +1,186 @@
+/**
+ * tsconfig-utils — parse tsconfig.json path aliases for TypeScript import resolution.
+ *
+ * Reads compilerOptions.paths and compilerOptions.baseUrl from tsconfig.json
+ * and returns a Map of alias prefix → target path prefix for use during
+ * import resolution.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+/** A single parsed alias entry ready for prefix matching. */
+export interface AliasEntry {
+  /** The prefix to match against import specifiers (e.g. "@/" or "@lib"). */
+  prefix: string;
+  /** The target path prefix to replace with (e.g. "src/" or "src/lib/index"). */
+  target: string;
+  /** Whether this entry uses `*` wildcard matching (true) or exact match (false). */
+  wildcard: boolean;
+}
+
+/** Parsed tsconfig paths + baseUrl. */
+export interface TsconfigPaths {
+  /** Ordered list of alias entries (first match wins). */
+  aliases: AliasEntry[];
+  /** compilerOptions.baseUrl, or null if not set. */
+  baseUrl: string | null;
+}
+
+// ── Cache ──────────────────────────────────────────────────────────────────
+
+const aliasCache = new Map<string, TsconfigPaths>();
+
+/**
+ * Clear the cached tsconfig alias data for all repos.
+ * Useful in tests to ensure fresh state.
+ */
+export function clearTsconfigCache(): void {
+  aliasCache.clear();
+}
+
+// ── Parser ─────────────────────────────────────────────────────────────────
+
+/**
+ * Read tsconfig.json from the repo root and extract path aliases + baseUrl.
+ *
+ * Handles:
+ * - Wildcard aliases: `"@/*": ["src/*"]` → prefix "@/" → target "src/"
+ * - Exact aliases:    `"@lib": ["src/lib"]` → prefix "@lib" → target "src/lib"
+ * - Aliases with extension: `"@lib": ["src/lib/index.ts"]` → extension stripped
+ * - compoundPathKeyPaths (array of backup paths): only the first target is used
+ * - compilerOptions.baseUrl for context
+ *
+ * Results are cached per repoPath. Call clearTsconfigCache() to invalidate.
+ *
+ * @param repoPath - Absolute path to the repository root.
+ * @returns Parsed paths, or empty aliases if tsconfig.json doesn't exist.
+ */
+export function loadTsconfigAliases(repoPath: string): TsconfigPaths {
+  const cached = aliasCache.get(repoPath);
+  if (cached) return cached;
+
+  const result = parseTsconfigFile(repoPath);
+  aliasCache.set(repoPath, result);
+  return result;
+}
+
+/**
+ * Internal parse implementation (no caching).
+ * Separated so tests can call it directly without cache interference.
+ */
+export function parseTsconfigFile(repoPath: string): TsconfigPaths {
+  const tsconfigPath = join(repoPath, 'tsconfig.json');
+  if (!existsSync(tsconfigPath)) {
+    return { aliases: [], baseUrl: null };
+  }
+
+  let raw: Record<string, unknown>;
+  try {
+    const content = readFileSync(tsconfigPath, 'utf-8');
+    raw = JSON.parse(content) as Record<string, unknown>;
+  } catch {
+    // Malformed JSON — return empty
+    return { aliases: [], baseUrl: null };
+  }
+
+  const compilerOptions = raw.compilerOptions as Record<string, unknown> | undefined;
+  if (!compilerOptions) {
+    return { aliases: [], baseUrl: null };
+  }
+
+  const baseUrl = typeof compilerOptions.baseUrl === 'string'
+    ? compilerOptions.baseUrl
+    : null;
+
+  const paths = compilerOptions.paths as Record<string, string[]> | undefined;
+  if (!paths || typeof paths !== 'object') {
+    return { aliases: [], baseUrl };
+  }
+
+  const aliases: AliasEntry[] = [];
+
+  for (const [aliasKey, targetArr] of Object.entries(paths)) {
+    if (!Array.isArray(targetArr) || targetArr.length === 0) continue;
+
+    // Only use the first target path (TypeScript falls through to subsequent
+    // entries, but for our resolution purposes the first is authoritative)
+    let target = targetArr[0];
+
+    // Normalize: strip leading ./ from target paths
+    if (target.startsWith('./')) {
+      target = target.slice(2);
+    }
+
+    // Handle wildcard alias:  "@/*" → prefix "@/"  or  "@components/*" → prefix "@components/"
+    // Wildcard target:        "src/*" → target "src/"
+    const aliasHasStar = aliasKey.includes('*');
+    const targetHasStar = target.includes('*');
+
+    if (aliasHasStar) {
+      // Extract prefix (everything before the first `*`)
+      const aliasPrefix = aliasKey.substring(0, aliasKey.indexOf('*'));
+
+      let targetPrefix: string;
+      if (targetHasStar) {
+        targetPrefix = target.substring(0, target.indexOf('*'));
+      } else {
+        // Alias has wildcard but target doesn't — unexpected but valid.
+        // Treat as exact replacement.
+        targetPrefix = target;
+      }
+
+      aliases.push({
+        prefix: aliasPrefix,
+        target: targetPrefix,
+        wildcard: true,
+      });
+    } else {
+      // Exact alias: "@lib" → "src/lib"
+      let normalizedTarget = target;
+      // Strip file extension for consistent matching
+      normalizedTarget = normalizedTarget.replace(/\.(ts|tsx|js|jsx|mjs|cjs)$/, '');
+
+      aliases.push({
+        prefix: aliasKey,
+        target: normalizedTarget,
+        wildcard: false,
+      });
+    }
+  }
+
+  return { aliases, baseUrl };
+}
+
+/**
+ * Resolve an import specifier using tsconfig path aliases.
+ *
+ * @param importSpec - The bare import specifier (e.g. "@/components/Button").
+ * @param tsconfigPaths - Parsed tsconfig paths from loadTsconfigAliases().
+ * @returns The resolved file path (relative to repo root), or the original
+ *          importSpec if no alias matches.
+ */
+export function resolveAliasImport(
+  importSpec: string,
+  tsconfigPaths: TsconfigPaths,
+): string {
+  for (const alias of tsconfigPaths.aliases) {
+    if (alias.wildcard) {
+      if (importSpec.startsWith(alias.prefix)) {
+        const rest = importSpec.slice(alias.prefix.length);
+        // Strip extension from the resolved part if present
+        const cleaned = rest.replace(/\.(ts|tsx|js|jsx|mjs|cjs)$/, '');
+        return alias.target + cleaned;
+      }
+    } else {
+      if (importSpec === alias.prefix) {
+        return alias.target;
+      }
+    }
+  }
+
+  // No alias matched — return as-is
+  return importSpec;
+}

--- a/packages/core/tests/analysis/tsconfig-utils.test.ts
+++ b/packages/core/tests/analysis/tsconfig-utils.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Tests for tsconfig-utils — tsconfig.json path alias parsing.
+ *
+ * Exercises parseTsconfigFile, loadTsconfigAliases, resolveAliasImport,
+ * and the per-repo cache behaviour.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  parseTsconfigFile,
+  loadTsconfigAliases,
+  resolveAliasImport,
+  clearTsconfigCache,
+} from '../../src/analysis/tsconfig-utils.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Create a temporary repo directory with an optional tsconfig.json. */
+function makeRepo(tsconfig?: Record<string, unknown>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'astrolabe-tsconfig-'));
+  if (tsconfig) {
+    writeFileSync(join(dir, 'tsconfig.json'), JSON.stringify(tsconfig, null, 2));
+  }
+  return dir;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('tsconfig-utils', () => {
+  let repoDir: string;
+
+  beforeEach(() => {
+    clearTsconfigCache();
+  });
+
+  afterEach(() => {
+    if (repoDir) {
+      try { rmSync(repoDir, { recursive: true, force: true }); } catch { /* ok */ }
+    }
+  });
+
+  // ── parseTsconfigFile ──────────────────────────────────────────────────────
+
+  describe('parseTsconfigFile', () => {
+    it('returns empty aliases when tsconfig.json does not exist', () => {
+      repoDir = mkdtempSync(join(tmpdir(), 'no-tsconfig-'));
+      const result = parseTsconfigFile(repoDir);
+      expect(result.aliases).toEqual([]);
+      expect(result.baseUrl).toBeNull();
+    });
+
+    it('returns empty aliases when tsconfig.json has no compilerOptions', () => {
+      repoDir = makeRepo({});
+      const result = parseTsconfigFile(repoDir);
+      expect(result.aliases).toEqual([]);
+      expect(result.baseUrl).toBeNull();
+    });
+
+    it('returns empty aliases when tsconfig has no paths', () => {
+      repoDir = makeRepo({
+        compilerOptions: { target: 'ES2022' },
+      });
+      const result = parseTsconfigFile(repoDir);
+      expect(result.aliases).toEqual([]);
+      expect(result.baseUrl).toBeNull();
+    });
+
+    it('returns empty aliases for malformed JSON', () => {
+      repoDir = mkdtempSync(join(tmpdir(), 'bad-json-'));
+      writeFileSync(join(repoDir, 'tsconfig.json'), 'not-json{');
+      const result = parseTsconfigFile(repoDir);
+      expect(result.aliases).toEqual([]);
+      expect(result.baseUrl).toBeNull();
+    });
+
+    it('parses baseUrl from compilerOptions', () => {
+      repoDir = makeRepo({
+        compilerOptions: {
+          baseUrl: 'src',
+        },
+      });
+      const result = parseTsconfigFile(repoDir);
+      expect(result.baseUrl).toBe('src');
+      expect(result.aliases).toEqual([]);
+    });
+
+    it('parses a single wildcard alias @/* → src/*', () => {
+      repoDir = makeRepo({
+        compilerOptions: {
+          paths: {
+            '@/*': ['src/*'],
+          },
+        },
+      });
+      const result = parseTsconfigFile(repoDir);
+      expect(result.aliases).toHaveLength(1);
+      expect(result.aliases[0]).toEqual({
+        prefix: '@/*'.substring(0, '@/*'.indexOf('*')),
+        target: 'src/',
+        wildcard: true,
+      });
+    });
+
+    it('parses multiple wildcard aliases', () => {
+      repoDir = makeRepo({
+        compilerOptions: {
+          paths: {
+            '@/*': ['src/*'],
+            '@components/*': ['src/components/*'],
+            '@lib/*': ['src/lib/*'],
+          },
+        },
+      });
+      const result = parseTsconfigFile(repoDir);
+      expect(result.aliases).toHaveLength(3);
+      expect(result.aliases[0].prefix).toBe('@/');
+      expect(result.aliases[0].target).toBe('src/');
+      expect(result.aliases[1].prefix).toBe('@components/');
+      expect(result.aliases[1].target).toBe('src/components/');
+      expect(result.aliases[2].prefix).toBe('@lib/');
+      expect(result.aliases[2].target).toBe('src/lib/');
+    });
+
+    it('parses exact (non-wildcard) aliases', () => {
+      repoDir = makeRepo({
+        compilerOptions: {
+          paths: {
+            '@lib': ['src/lib/index.ts'],
+            '@utils': ['src/utils/index'],
+          },
+        },
+      });
+      const result = parseTsconfigFile(repoDir);
+      expect(result.aliases).toHaveLength(2);
+      // Exact aliases strip extension from target
+      expect(result.aliases[0]).toEqual({
+        prefix: '@lib',
+        target: 'src/lib/index',
+        wildcard: false,
+      });
+      expect(result.aliases[1]).toEqual({
+        prefix: '@utils',
+        target: 'src/utils/index',
+        wildcard: false,
+      });
+    });
+
+    it('ignores empty path target arrays', () => {
+      repoDir = makeRepo({
+        compilerOptions: {
+          paths: {
+            '@/*': [],
+          },
+        },
+      });
+      const result = parseTsconfigFile(repoDir);
+      expect(result.aliases).toEqual([]);
+    });
+
+    it('uses first target path when array has multiple entries', () => {
+      repoDir = makeRepo({
+        compilerOptions: {
+          paths: {
+            '@/*': ['src/*', 'dist/*'],
+          },
+        },
+      });
+      const result = parseTsconfigFile(repoDir);
+      expect(result.aliases).toHaveLength(1);
+      expect(result.aliases[0].target).toBe('src/');
+    });
+
+    it('handles wildcard alias where target has no wildcard', () => {
+      repoDir = makeRepo({
+        compilerOptions: {
+          paths: {
+            '@constants': ['src/constants.ts'],
+          },
+        },
+      });
+      const result = parseTsconfigFile(repoDir);
+      expect(result.aliases).toHaveLength(1);
+      expect(result.aliases[0].wildcard).toBe(false);
+      expect(result.aliases[0].target).toBe('src/constants');
+    });
+
+    it('strips leading ./ from target paths', () => {
+      repoDir = makeRepo({
+        compilerOptions: {
+          paths: {
+            '@/*': ['./src/*'],
+          },
+        },
+      });
+      const result = parseTsconfigFile(repoDir);
+      expect(result.aliases[0].target).toBe('src/');
+    });
+
+    it('parses both baseUrl and paths together', () => {
+      repoDir = makeRepo({
+        compilerOptions: {
+          baseUrl: 'src',
+          paths: {
+            '@/*': ['./*'],
+          },
+        },
+      });
+      const result = parseTsconfigFile(repoDir);
+      expect(result.baseUrl).toBe('src');
+      expect(result.aliases).toHaveLength(1);
+      expect(result.aliases[0].target).toBe('');
+      expect(result.aliases[0].prefix).toBe('@/');
+    });
+  });
+
+  // ── resolveAliasImport ─────────────────────────────────────────────────────
+
+  describe('resolveAliasImport', () => {
+    it('resolves a wildcard alias import', () => {
+      const paths = {
+        aliases: [{ prefix: '@/', target: 'src/', wildcard: true }],
+        baseUrl: null,
+      };
+      expect(resolveAliasImport('@/components/Button', paths)).toBe('src/components/Button');
+    });
+
+    it('resolves a deeply nested wildcard alias import', () => {
+      const paths = {
+        aliases: [{ prefix: '@/', target: 'src/', wildcard: true }],
+        baseUrl: null,
+      };
+      expect(resolveAliasImport('@/components/sub/Button', paths)).toBe('src/components/sub/Button');
+    });
+
+    it('resolves an exact alias import', () => {
+      const paths = {
+        aliases: [{ prefix: '@lib', target: 'src/lib/index', wildcard: false }],
+        baseUrl: null,
+      };
+      expect(resolveAliasImport('@lib', paths)).toBe('src/lib/index');
+    });
+
+    it('returns original import when no alias matches', () => {
+      const paths = {
+        aliases: [{ prefix: '@/', target: 'src/', wildcard: true }],
+        baseUrl: null,
+      };
+      expect(resolveAliasImport('lodash', paths)).toBe('lodash');
+    });
+
+    it('returns original import when path has no matching prefix', () => {
+      const paths = {
+        aliases: [{ prefix: '@lib/', target: 'src/lib/', wildcard: true }],
+        baseUrl: null,
+      };
+      expect(resolveAliasImport('@components/Button', paths)).toBe('@components/Button');
+    });
+
+    it('resolves first matching alias from multiple entries', () => {
+      const paths = {
+        aliases: [
+          { prefix: '@/', target: 'src/', wildcard: true },
+          { prefix: '@components/', target: 'src/components/', wildcard: true },
+        ],
+        baseUrl: null,
+      };
+      expect(resolveAliasImport('@/components/Button', paths)).toBe('src/components/Button');
+      expect(resolveAliasImport('@components/Button', paths)).toBe('src/components/Button');
+    });
+
+    it('strips file extension from alias-resolved paths', () => {
+      const paths = {
+        aliases: [{ prefix: '@/', target: 'src/', wildcard: true }],
+        baseUrl: null,
+      };
+      expect(resolveAliasImport('@/utils/helper.ts', paths)).toBe('src/utils/helper');
+    });
+
+    it('handles empty aliases array gracefully', () => {
+      const paths = { aliases: [], baseUrl: null };
+      expect(resolveAliasImport('@/components/Button', paths)).toBe('@/components/Button');
+    });
+  });
+
+  // ── loadTsconfigAliases (caching) ──────────────────────────────────────────
+
+  describe('loadTsconfigAliases', () => {
+    it('loads and caches aliases from a real tsconfig.json', () => {
+      repoDir = makeRepo({
+        compilerOptions: {
+          paths: {
+            '@/*': ['src/*'],
+          },
+        },
+      });
+      const result = loadTsconfigAliases(repoDir);
+      expect(result.aliases).toHaveLength(1);
+      expect(result.aliases[0].prefix).toBe('@/');
+      expect(result.aliases[0].target).toBe('src/');
+    });
+
+    it('returns empty aliases when no tsconfig.json exists', () => {
+      repoDir = mkdtempSync(join(tmpdir(), 'no-tsconfig-'));
+      const result = loadTsconfigAliases(repoDir);
+      expect(result.aliases).toEqual([]);
+      expect(result.baseUrl).toBeNull();
+    });
+
+    it('caches results and returns same object for same repoPath', () => {
+      repoDir = makeRepo({
+        compilerOptions: {
+          paths: {
+            '@/*': ['src/*'],
+          },
+        },
+      });
+      const first = loadTsconfigAliases(repoDir);
+      const second = loadTsconfigAliases(repoDir);
+      expect(first).toBe(second); // Same reference from cache
+    });
+
+    it('returns fresh results after cache is cleared', () => {
+      repoDir = makeRepo({
+        compilerOptions: {
+          paths: {
+            '@/*': ['src/*'],
+          },
+        },
+      });
+      const first = loadTsconfigAliases(repoDir);
+      clearTsconfigCache();
+      const second = loadTsconfigAliases(repoDir);
+      expect(first).not.toBe(second); // Different reference
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add packages/core/src/analysis/tsconfig-utils.ts - parses tsconfig.json compilerOptions.paths for import alias resolution
- Add packages/core/tests/analysis/tsconfig-utils.test.ts - 25 tests covering alias loading, resolution, and edge cases
- Update packages/core/src/analysis/scope-resolver.ts - integrates alias resolution into TypeScript scope resolution, replacing the hardcoded @/ prefix handling

Closes #729