### PR TITLE
feat: Vue SFC single-file component extraction phase (#730)

### DIFF
--- a/packages/core/src/analysis/phases/index.ts
+++ b/packages/core/src/analysis/phases/index.ts
@@ -12,6 +12,7 @@ export { mroPhase } from './mro.js';
 export { communityPhase } from './community.js';
 export { processTracingPhase } from './process-tracing.js';
 export { cobolPhase } from './cobol.js';
+export { vueSfcPhase } from './vue-sfc.js';
 export { callResolutionPhase } from '../call-processor.js';
 export { scopeResolutionPhase } from '../scope-resolver.js';
 export type { FileEntry, ScanOutput } from './scan.js';

--- a/packages/core/src/analysis/phases/vue-sfc.ts
+++ b/packages/core/src/analysis/phases/vue-sfc.ts
@@ -1,0 +1,241 @@
+/**
+ * Pipeline Phase: Vue Single File Component extraction (#730)
+ *
+ * Regex-based `.vue` file parser that extracts `<template>`, `<script>`,
+ * `<script setup>`, `<style>`, and `<style scoped>` blocks as separate
+ * logical nodes with proper relationships.
+ *
+ * For `<script setup>` blocks the phase also extracts top-level imports
+ * and export-like declarations (composition API patterns) using simple
+ * regex — no AST dependency required.
+ */
+
+import { readFileSync } from 'node:fs';
+import { basename } from 'node:path';
+import type { PhaseDefinition, PhaseContext } from '../../core/pipeline.js';
+import { getPhaseOutput } from '../../core/pipeline.js';
+import type { ScanOutput } from '../phases/scan.js';
+import { createLogger } from '../../logging/index.js';
+
+const log = createLogger({ level: 'debug' });
+
+// ── Output type ─────────────────────────────────────────────────────────────
+
+export interface VueSfcOutput {
+  /** Number of Vue components discovered. */
+  componentCount: number;
+  /** Total blocks extracted across all components. */
+  blockCount: number;
+  /** Number of import references found in `<script setup>` blocks. */
+  importCount: number;
+}
+
+// ── Regex patterns ──────────────────────────────────────────────────────────
+
+/**
+ * Matches Vue SFC top-level blocks: `<template>`, `<script>`, `<style>`.
+ * Captures: (1) tag name, (2) attribute string (may be empty), (3) inner content.
+ */
+const VUE_BLOCK_RE = /<(template|script|style)([^>]*)>([\s\S]*?)<\/\1>/gi;
+
+/** Detect `setup` attribute on `<script>` tags. */
+const SETUP_ATTR_RE = /\bsetup\b/;
+
+/** Detect `scoped` attribute on `<style>` tags. */
+const SCOPED_ATTR_RE = /\bscoped\b/;
+
+/** Detect `lang` attribute value. */
+const LANG_ATTR_RE = /\blang\s*=\s*["']?(\w+)/;
+
+/** ES-module import statement (simplified). */
+const IMPORT_RE = /import\s+(?:(?:\{[^}]*\}|\*\s+as\s+\w+|\w+)(?:\s*,\s*(?:\{[^}]*\}|\*\s+as\s+\w+|\w+))*)\s+from\s+['"]([^'"]+)['"]/g;
+
+/** Top-level `export default` or named exports in `<script setup>`. */
+const EXPORT_RE = /export\s+(?:default\s+)?(?:const|let|var|function|class|interface|type)\s+(\w+)/g;
+
+// ── Block classification ────────────────────────────────────────────────────
+
+interface VueBlock {
+  tag: 'template' | 'script' | 'style';
+  attrs: string;
+  content: string;
+  isSetup: boolean;
+  isScoped: boolean;
+  lang: string | null;
+}
+
+function extractBlocks(source: string): VueBlock[] {
+  const blocks: VueBlock[] = [];
+  for (const m of source.matchAll(VUE_BLOCK_RE)) {
+    const tag = m[1] as 'template' | 'script' | 'style';
+    const attrs = m[2] ?? '';
+    const content = m[3] ?? '';
+    blocks.push({
+      tag,
+      attrs,
+      content,
+      isSetup: tag === 'script' && SETUP_ATTR_RE.test(attrs),
+      isScoped: tag === 'style' && SCOPED_ATTR_RE.test(attrs),
+      lang: LANG_ATTR_RE.exec(attrs)?.[1] ?? null,
+    });
+  }
+  return blocks;
+}
+
+// ── Phase ───────────────────────────────────────────────────────────────────
+
+export const vueSfcPhase: PhaseDefinition<VueSfcOutput> = {
+  name: 'vue-sfc',
+  dependencies: ['scan', 'structure'],
+
+  execute(context: PhaseContext): VueSfcOutput {
+    const scanOutput = getPhaseOutput<ScanOutput>(context, 'scan');
+    const { graph } = context;
+    let componentCount = 0;
+    let blockCount = 0;
+    let importCount = 0;
+
+    const vueFiles = scanOutput?.files?.filter(
+      (f) => /\.vue$/i.test(f.path),
+    ) ?? [];
+
+    if (vueFiles.length === 0) {
+      return { componentCount: 0, blockCount: 0, importCount: 0 };
+    }
+
+    for (const file of vueFiles) {
+      let source: string;
+      try {
+        source = readFileSync(file.path, 'utf-8');
+      } catch (err) {
+        log.debug('Skipping unreadable Vue file', { file: file.path, error: String(err) });
+        continue;
+      }
+
+      const componentName = basename(file.path, '.vue');
+      const componentId = `vue:component:${file.path}:${componentName}`;
+
+      // Create parent VueComponent node (uses File label with vueComponent kind).
+      if (!graph.getNode(componentId)) {
+        graph.addNode({
+          id: componentId,
+          label: 'File',
+          properties: {
+            name: componentName,
+            filePath: file.path,
+            kind: 'VueComponent',
+            language: 'vue',
+          },
+        });
+        componentCount++;
+      }
+
+      const blocks = extractBlocks(source);
+
+      for (let i = 0; i < blocks.length; i++) {
+        const block = blocks[i];
+        const blockId = `vue:block:${file.path}:${componentName}:${block.tag}:${i}`;
+
+        if (!graph.getNode(blockId)) {
+          graph.addNode({
+            id: blockId,
+            label: 'CodeElement',
+            properties: {
+              name: `<${block.tag}>`,
+              filePath: file.path,
+              kind: `Vue${capitalize(block.tag)}Block`,
+              language: block.lang ?? (block.tag === 'template' ? 'html' : block.tag === 'style' ? 'css' : 'javascript'),
+              isSetup: block.isSetup || undefined,
+              isScoped: block.isScoped || undefined,
+              lineCount: block.content.split('\n').length,
+            },
+          });
+          blockCount++;
+        }
+
+        // CONTAINS edge from component → block.
+        const edgeId = `vue:contains:${componentId}:${blockId}`;
+        if (!graph.getRelationship(edgeId)) {
+          graph.addRelationship({
+            id: edgeId,
+            sourceId: componentId,
+            targetId: blockId,
+            type: 'CONTAINS',
+            confidence: 1.0,
+            reason: `Vue SFC block <${block.tag}> in ${componentName}.vue`,
+          });
+        }
+
+        // For <script setup>, extract imports and exports.
+        if (block.isSetup) {
+          for (const imp of block.content.matchAll(IMPORT_RE)) {
+            const importSource = imp[1];
+            const importId = `vue:import:${file.path}:${componentName}:${importSource}`;
+            if (!graph.getNode(importId)) {
+              graph.addNode({
+                id: importId,
+                label: 'Import',
+                properties: {
+                  name: importSource,
+                  filePath: file.path,
+                  kind: 'VueSfcImport',
+                  source: importSource,
+                },
+              });
+              importCount++;
+            }
+
+            const importEdgeId = `vue:imports:${blockId}:${importSource}`;
+            if (!graph.getRelationship(importEdgeId)) {
+              graph.addRelationship({
+                id: importEdgeId,
+                sourceId: blockId,
+                targetId: importId,
+                type: 'IMPORTS',
+                confidence: 0.9,
+                reason: `import from '${importSource}' in <script setup> of ${componentName}.vue`,
+              });
+            }
+          }
+
+          for (const exp of block.content.matchAll(EXPORT_RE)) {
+            const exportName = exp[1];
+            const exportId = `vue:export:${file.path}:${componentName}:${exportName}`;
+            if (!graph.getNode(exportId)) {
+              graph.addNode({
+                id: exportId,
+                label: 'CodeElement',
+                properties: {
+                  name: exportName,
+                  filePath: file.path,
+                  kind: 'VueSfcExport',
+                  isExported: true,
+                },
+              });
+            }
+
+            const exportEdgeId = `vue:defines:${blockId}:${exportName}`;
+            if (!graph.getRelationship(exportEdgeId)) {
+              graph.addRelationship({
+                id: exportEdgeId,
+                sourceId: blockId,
+                targetId: exportId,
+                type: 'DEFINES',
+                confidence: 0.9,
+                reason: `export '${exportName}' in <script setup> of ${componentName}.vue`,
+              });
+            }
+          }
+        }
+      }
+    }
+
+    return { componentCount, blockCount, importCount };
+  },
+};
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,7 +21,7 @@ export { runPipeline, createPhaseContext, getPhaseOutput, type PhaseDefinition, 
 export { initParser, parseFile, parseFiles, parseString, resetParser, AstCache, defaultWasmDir, languageForExtension, languageForFile, getAllExtensions } from './analysis/parser.js';
 export { symbolId, captureText, captureRange } from './analysis/language-definition.js';
 export type { LanguageDefinition, QueryPattern, ParsedSymbol, ParsedImport, FileParseResult } from './analysis/language-definition.js';
-export { scanPhase, structurePhase, frameworkPhase, markdownPhase, parseEmitPhase, resolutionPhase, routesPhase, toolsPhase, ormPhase, crossFilePhase, mroPhase, communityPhase, processTracingPhase, cobolPhase, callResolutionPhase, scopeResolutionPhase } from './analysis/phases/index.js';
+export { scanPhase, structurePhase, frameworkPhase, markdownPhase, parseEmitPhase, resolutionPhase, routesPhase, toolsPhase, ormPhase, crossFilePhase, mroPhase, communityPhase, processTracingPhase, cobolPhase, vueSfcPhase, callResolutionPhase, scopeResolutionPhase } from './analysis/phases/index.js';
 export type { FileEntry, ScanOutput } from './analysis/phases/scan.js';
 export type { StructureOutput } from './analysis/phases/structure.js';
 export type { ParseEmitOutput } from './analysis/phases/parse-emit.js';

--- a/packages/core/tests/analysis/phases/vue-sfc.test.ts
+++ b/packages/core/tests/analysis/phases/vue-sfc.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Tests for Vue SFC phase (#730) — regex-based Vue component extraction.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { writeFileSync, rmSync, mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createKnowledgeGraph } from '../../../src/core/graph.js';
+import { createPhaseContext } from '../../../src/core/pipeline.js';
+import { vueSfcPhase } from '../../../src/analysis/phases/vue-sfc.js';
+
+let testDir: string;
+
+function makeContext(graph: any, filePaths: string[]) {
+  const ctx = createPhaseContext(testDir, graph, () => {});
+  ctx.state.set('output:scan', {
+    files: filePaths.map((fp) => ({
+      path: join(testDir, fp),
+      hash: 'abc',
+      ext: fp.split('.').pop() || '',
+      size: 100,
+      language: 'vue' as any,
+      extension: fp.split('.').pop() || '',
+      absolutePath: join(testDir, fp),
+    })),
+    directoryCount: 1,
+  });
+  return ctx;
+}
+
+describe('Vue SFC Phase (#730)', () => {
+  beforeAll(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'astrolabe-vue-'));
+  });
+
+  afterAll(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('extracts template, script, and style blocks from a Vue SFC', () => {
+    writeFileSync(join(testDir, 'App.vue'), `
+<template>
+  <div class="app">
+    <h1>{{ title }}</h1>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return { title: 'Hello' };
+  },
+};
+</script>
+
+<style>
+.app { color: red; }
+</style>
+`, 'utf-8');
+
+    const graph = createKnowledgeGraph();
+    const ctx = makeContext(graph, ['App.vue']);
+
+    const result = vueSfcPhase.execute(ctx) as any;
+    expect(result.componentCount).toBe(1);
+    expect(result.blockCount).toBe(3);
+
+    // Check parent component node
+    const componentId = `vue:component:${join(testDir, 'App.vue')}:App`;
+    const componentNode = graph.getNode(componentId);
+    expect(componentNode).toBeDefined();
+    expect(componentNode!.label).toBe('File');
+    expect(componentNode!.properties.kind).toBe('VueComponent');
+    expect(componentNode!.properties.language).toBe('vue');
+
+    // Check block nodes exist
+    const allNodes = graph.nodes;
+    const blockNodes = allNodes.filter((n) => n.label === 'CodeElement');
+    expect(blockNodes.length).toBe(3);
+
+    const kinds = blockNodes.map((n) => n.properties.kind).sort();
+    expect(kinds).toEqual(['VueScriptBlock', 'VueStyleBlock', 'VueTemplateBlock']);
+  });
+
+  it('detects <script setup> and extracts imports', () => {
+    writeFileSync(join(testDir, 'Setup.vue'), `
+<template>
+  <button @click="increment">{{ count }}</button>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import MyButton from './MyButton.vue';
+
+const count = ref(0);
+function increment() {
+  count.value++;
+}
+</script>
+`, 'utf-8');
+
+    const graph = createKnowledgeGraph();
+    const ctx = makeContext(graph, ['Setup.vue']);
+
+    const result = vueSfcPhase.execute(ctx) as any;
+    expect(result.componentCount).toBe(1);
+    expect(result.blockCount).toBe(2); // template + script setup
+    expect(result.importCount).toBe(2);
+
+    // Verify import nodes
+    const importNodes = graph.nodes.filter((n) => n.label === 'Import');
+    expect(importNodes.length).toBe(2);
+
+    const importSources = importNodes.map((n) => n.properties.source).sort();
+    expect(importSources).toEqual(['./MyButton.vue', 'vue']);
+  });
+
+  it('detects <style scoped> blocks', () => {
+    writeFileSync(join(testDir, 'ScopedStyle.vue'), `
+<template>
+  <p>Scoped</p>
+</template>
+
+<style scoped>
+p { color: blue; }
+</style>
+`, 'utf-8');
+
+    const graph = createKnowledgeGraph();
+    const ctx = makeContext(graph, ['ScopedStyle.vue']);
+
+    const result = vueSfcPhase.execute(ctx) as any;
+    expect(result.blockCount).toBe(2);
+
+    const styleBlock = graph.nodes.find(
+      (n) => n.label === 'CodeElement' && n.properties.kind === 'VueStyleBlock',
+    );
+    expect(styleBlock).toBeDefined();
+    expect(styleBlock!.properties.isScoped).toBe(true);
+  });
+
+  it('handles multiple <style> blocks', () => {
+    writeFileSync(join(testDir, 'MultiStyle.vue'), `
+<template><span>test</span></template>
+
+<style>
+span { display: block; }
+</style>
+
+<style scoped>
+span { color: green; }
+</style>
+`, 'utf-8');
+
+    const graph = createKnowledgeGraph();
+    const ctx = makeContext(graph, ['MultiStyle.vue']);
+
+    const result = vueSfcPhase.execute(ctx) as any;
+    expect(result.blockCount).toBe(3); // 1 template + 2 style
+
+    const styleBlocks = graph.nodes.filter(
+      (n) => n.label === 'CodeElement' && n.properties.kind === 'VueStyleBlock',
+    );
+    expect(styleBlocks.length).toBe(2);
+  });
+
+  it('creates CONTAINS edges from component to blocks', () => {
+    writeFileSync(join(testDir, 'Edges.vue'), `
+<template><div>edges</div></template>
+<script>export default {}</script>
+<style scoped>div {}</style>
+`, 'utf-8');
+
+    const graph = createKnowledgeGraph();
+    const ctx = makeContext(graph, ['Edges.vue']);
+
+    vueSfcPhase.execute(ctx);
+
+    const containsEdges = graph.relationships.filter((r) => r.type === 'CONTAINS');
+    expect(containsEdges.length).toBe(3); // component → template, script, style
+
+    for (const edge of containsEdges) {
+      expect(edge.confidence).toBe(1.0);
+      expect(edge.reason).toContain('Vue SFC block');
+    }
+  });
+
+  it('extracts exports from <script setup>', () => {
+    writeFileSync(join(testDir, 'Exports.vue'), `
+<template><div>exports</div></template>
+
+<script setup>
+export const TITLE = 'Hello';
+export function greet() { return TITLE; }
+</script>
+`, 'utf-8');
+
+    const graph = createKnowledgeGraph();
+    const ctx = makeContext(graph, ['Exports.vue']);
+
+    const result = vueSfcPhase.execute(ctx) as any;
+    expect(result.componentCount).toBe(1);
+
+    // Check export nodes
+    const exportNodes = graph.nodes.filter(
+      (n) => n.properties.kind === 'VueSfcExport',
+    );
+    expect(exportNodes.length).toBe(2);
+
+    const names = exportNodes.map((n) => n.properties.name).sort();
+    expect(names).toEqual(['TITLE', 'greet']);
+
+    // Check DEFINES edges
+    const definesEdges = graph.relationships.filter((r) => r.type === 'DEFINES');
+    expect(definesEdges.length).toBe(2);
+  });
+
+  it('skips non-Vue files', () => {
+    writeFileSync(join(testDir, 'main.ts'), `
+export function hello() { return 'world'; }
+`, 'utf-8');
+
+    const graph = createKnowledgeGraph();
+    const ctx = makeContext(graph, ['main.ts']);
+
+    const result = vueSfcPhase.execute(ctx) as any;
+    expect(result.componentCount).toBe(0);
+    expect(result.blockCount).toBe(0);
+    expect(result.importCount).toBe(0);
+  });
+
+  it('handles empty scan output', () => {
+    const graph = createKnowledgeGraph();
+    const ctx = makeContext(graph, []);
+
+    const result = vueSfcPhase.execute(ctx) as any;
+    expect(result.componentCount).toBe(0);
+    expect(result.blockCount).toBe(0);
+    expect(result.importCount).toBe(0);
+  });
+
+  it('handles Vue files with only a template block', () => {
+    writeFileSync(join(testDir, 'TemplateOnly.vue'), `
+<template>
+  <p>Just a template</p>
+</template>
+`, 'utf-8');
+
+    const graph = createKnowledgeGraph();
+    const ctx = makeContext(graph, ['TemplateOnly.vue']);
+
+    const result = vueSfcPhase.execute(ctx) as any;
+    expect(result.componentCount).toBe(1);
+    expect(result.blockCount).toBe(1);
+    expect(result.importCount).toBe(0);
+  });
+
+  it('detects lang attribute on blocks', () => {
+    writeFileSync(join(testDir, 'Langs.vue'), `
+<template><div>langs</div></template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+const count = ref<number>(0);
+</script>
+
+<style lang="scss">
+div { color: red; }
+</style>
+`, 'utf-8');
+
+    const graph = createKnowledgeGraph();
+    const ctx = makeContext(graph, ['Langs.vue']);
+
+    vueSfcPhase.execute(ctx);
+
+    const blockNodes = graph.nodes.filter((n) => n.label === 'CodeElement');
+
+    const scriptBlock = blockNodes.find((n) => n.properties.kind === 'VueScriptBlock');
+    expect(scriptBlock).toBeDefined();
+    expect(scriptBlock!.properties.language).toBe('ts');
+    expect(scriptBlock!.properties.isSetup).toBe(true);
+
+    const styleBlock = blockNodes.find((n) => n.properties.kind === 'VueStyleBlock');
+    expect(styleBlock).toBeDefined();
+    expect(styleBlock!.properties.language).toBe('scss');
+  });
+
+  it('handles multiple Vue files', () => {
+    writeFileSync(join(testDir, 'CompA.vue'), `
+<template><span>A</span></template>
+<script>export default {}</script>
+`, 'utf-8');
+
+    writeFileSync(join(testDir, 'CompB.vue'), `
+<template><span>B</span></template>
+<script setup lang="ts">
+import { ref } from 'vue';
+</script>
+`, 'utf-8');
+
+    const graph = createKnowledgeGraph();
+    const ctx = makeContext(graph, ['CompA.vue', 'CompB.vue']);
+
+    const result = vueSfcPhase.execute(ctx) as any;
+    expect(result.componentCount).toBe(2);
+    expect(result.blockCount).toBe(4); // 2 per file
+    expect(result.importCount).toBe(1); // only CompB has a script setup import
+  });
+});


### PR DESCRIPTION
## Summary
- Add packages/core/src/analysis/phases/vue-sfc.ts - extracts script, template, and style sections from .vue files
- Add packages/core/tests/analysis/phases/vue-sfc.test.ts - 11 tests covering multi-block, scoped style, and edge cases
- Update phases/index.ts and core/index.ts to export vueSfcPhase

Closes #730