### PR TITLE
feat: MCP StreamableHTTP transport for remote server mode (#710)

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -244,7 +244,26 @@ program
 program
   .command('serve-mcp')
   .description('Start an MCP server for AI assistant integration')
-  .action(async () => { console.error('Astrolabe MCP server starting...'); await startMcpServer(); });
+  .option('-t, --transport <type>', 'Transport type: stdio (default) or http', 'stdio')
+  .option('-p, --port <number>', 'Port for HTTP transport (default: 4748)', '4748')
+  .option('-h, --host <host>', 'Host for HTTP transport (default: localhost)', 'localhost')
+  .action(async (opts: { transport: string; port: string; host: string }) => {
+    const transportType = opts.transport as 'stdio' | 'http';
+    if (transportType !== 'stdio' && transportType !== 'http') {
+      console.error(`Invalid transport: ${opts.transport}. Use 'stdio' or 'http'.`);
+      process.exit(1);
+    }
+
+    if (transportType === 'stdio') {
+      console.error('Astrolabe MCP server starting (stdio)...');
+    }
+
+    await startMcpServer({
+      transport: transportType,
+      port: parseInt(opts.port, 10),
+      host: opts.host,
+    });
+  });
 
 // ── serve (HTTP API) ──────────────────────────────────────────────────────
 program

--- a/packages/core/src/mcp/http-transport.ts
+++ b/packages/core/src/mcp/http-transport.ts
@@ -1,0 +1,299 @@
+/**
+ * MCP StreamableHTTP Transport (#710).
+ *
+ * Implements the MCP StreamableHTTP protocol:
+ * - POST /mcp with JSON-RPC body → SSE response stream
+ * - Each JSON-RPC response is sent as an SSE `data:` event
+ * - GET /mcp returns 405 (not supported in initial implementation)
+ * - DELETE /mcp terminates the session
+ *
+ * Uses the same `on`/`send`/`close` interface as McpTransport so the
+ * MCP server dispatch layer works identically over both transports.
+ *
+ * No external dependencies — uses Node.js built-in `http` module.
+ */
+
+import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface StreamableHttpTransportOptions {
+  /** Port to listen on. Default: 4748. */
+  port?: number;
+  /** Host to bind to. Default: 'localhost'. */
+  host?: string;
+}
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+const DEFAULT_PORT = 4748;
+const DEFAULT_HOST = 'localhost';
+const MAX_BODY_SIZE = 10 * 1024 * 1024; // 10 MB — matches stdio transport
+
+// ── StreamableHTTP Transport ───────────────────────────────────────────────
+
+/**
+ * MCP StreamableHTTP transport.
+ *
+ * Client POSTs JSON-RPC requests to /mcp. The server responds with an SSE
+ * stream containing one `data:` event per JSON-RPC response. Each request
+ * opens a new SSE stream that closes after the response is sent.
+ */
+export class StreamableHttpTransport {
+  private server: Server;
+  private closed = false;
+  private port: number;
+  private host: string;
+
+  // Callbacks — same pattern as McpTransport
+  private onMessage: ((data: unknown) => void) = () => {};
+  private onError: ((err: Error) => void) = () => {};
+
+  constructor(options?: StreamableHttpTransportOptions) {
+    this.port = options?.port ?? DEFAULT_PORT;
+    this.host = options?.host ?? DEFAULT_HOST;
+    this.server = createServer((req, res) => this.handleRequest(req, res));
+  }
+
+  /**
+   * Start listening. Returns a promise that resolves when the server is ready.
+   */
+  async listen(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.server.once('error', reject);
+      this.server.listen(this.port, this.host, () => {
+        this.server.removeListener('error', reject);
+        resolve();
+      });
+    });
+  }
+
+  /**
+   * The address the server is listening on, or null if not started.
+   */
+  get address(): string | null {
+    const addr = this.server.address();
+    if (!addr || typeof addr === 'string') return addr;
+    return `http://${addr.address}:${addr.port}`;
+  }
+
+  // ── HTTP Request Handling ───────────────────────────────────────────────
+
+  private async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    // CORS preflight
+    if (req.method === 'OPTIONS') {
+      this.setCorsHeaders(res);
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    // CORS headers on all responses
+    this.setCorsHeaders(res);
+
+    const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
+
+    // Only /mcp endpoint is supported
+    if (url.pathname !== '/mcp') {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32601, message: 'Not found. Use POST /mcp.' } }));
+      return;
+    }
+
+    // Route by method
+    switch (req.method) {
+      case 'POST':
+        return this.handlePost(req, res);
+      case 'GET':
+        return this.handleGet(req, res);
+      case 'DELETE':
+        return this.handleDelete(req, res);
+      default:
+        res.writeHead(405, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32601, message: `Method ${req.method} not allowed. Use POST.` } }));
+    }
+  }
+
+  /**
+   * POST /mcp — receive JSON-RPC request, respond with SSE stream.
+   *
+   * The request body is parsed as JSON. For each JSON-RPC message, the
+   * transport emits a 'message' event. The server dispatch layer calls
+   * `send()` which writes the response as an SSE `data:` event.
+   */
+  private async handlePost(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const body = await this.readBody(req);
+    if (body === null) {
+      // readBody already sent error response
+      return;
+    }
+
+    // Set up SSE response headers
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    });
+
+    // Wire send() to write to this response's SSE stream
+    this._activeResponse = res;
+
+    try {
+      // Parse — may be a single request or batch
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(body);
+      } catch {
+        this.writeSse(res, JSON.stringify({
+          jsonrpc: '2.0',
+          id: null,
+          error: { code: -32700, message: 'Parse error: invalid JSON' },
+        }));
+        res.end();
+        return;
+      }
+
+      // Handle batch (array of requests)
+      if (Array.isArray(parsed)) {
+        for (const item of parsed) {
+          this.onMessage(item);
+        }
+      } else {
+        this.onMessage(parsed);
+      }
+    } catch (err) {
+      this.writeSse(res, JSON.stringify({
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: -32603, message: 'Internal error' },
+      }));
+    } finally {
+      // End SSE stream after a tick to allow any pending send() calls to flush
+      this._activeResponse = null;
+      setImmediate(() => {
+        if (!res.writableEnded) res.end();
+      });
+    }
+  }
+
+  /**
+   * GET /mcp — not supported in this implementation.
+   * Returns 405 with a helpful message.
+   */
+  private handleGet(_req: IncomingMessage, res: ServerResponse): void {
+    res.writeHead(405, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32601, message: 'GET not supported. Use POST /mcp for JSON-RPC requests.' } }));
+  }
+
+  /**
+   * DELETE /mcp — terminate the session.
+   */
+  private handleDelete(_req: IncomingMessage, res: ServerResponse): void {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ jsonrpc: '2.0', id: null, result: { status: 'session_terminated' } }));
+  }
+
+  // ── Active response for send() targeting ────────────────────────────────
+
+  private _activeResponse: ServerResponse | null = null;
+
+  /**
+   * Send a JSON-RPC response. Writes it as an SSE `data:` event to the
+   * active POST response stream.
+   */
+  send(data: unknown): void {
+    if (this.closed) {
+      throw new Error('Transport is closed');
+    }
+
+    const res = this._activeResponse;
+    if (res && !res.writableEnded) {
+      this.writeSse(res, JSON.stringify(data));
+    }
+  }
+
+  /**
+   * Write an SSE `data:` event to the response stream.
+   */
+  private writeSse(res: ServerResponse, data: string): void {
+    try {
+      res.write(`data: ${data}\n\n`);
+    } catch (err) {
+      this.onError(err instanceof Error ? err : new Error(String(err)));
+      this.closed = true;
+    }
+  }
+
+  /**
+   * Close the transport and shut down the HTTP server.
+   */
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.server.close();
+  }
+
+  // ── Event Handlers ──────────────────────────────────────────────────────
+
+  /**
+   * Set the message handler. Same interface as McpTransport.
+   */
+  on(event: 'message', handler: (data: unknown) => void): void;
+  /**
+   * Set the error handler. Same interface as McpTransport.
+   */
+  on(event: 'error', handler: (err: Error) => void): void;
+  on(event: 'message' | 'error', handler: ((data: unknown) => void) | ((err: Error) => void)): void {
+    if (event === 'message') {
+      this.onMessage = handler as (data: unknown) => void;
+    } else if (event === 'error') {
+      this.onError = handler as (err: Error) => void;
+    }
+  }
+
+  // ── Helpers ─────────────────────────────────────────────────────────────
+
+  /**
+   * Read the full request body with size limit.
+   * Returns null if an error response was already sent.
+   */
+  private readBody(req: IncomingMessage): Promise<string | null> {
+    return new Promise((resolve) => {
+      const chunks: Buffer[] = [];
+      let totalSize = 0;
+
+      req.on('data', (chunk: Buffer) => {
+        totalSize += chunk.length;
+        if (totalSize > MAX_BODY_SIZE) {
+          // Already sent a response — caller should not write
+          const res = this._activeResponse;
+          if (res && !res.headersSent) {
+            res.writeHead(413, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Request body exceeds 10 MB limit' } }));
+          }
+          resolve(null);
+          return;
+        }
+        chunks.push(chunk);
+      });
+
+      req.on('end', () => {
+        resolve(Buffer.concat(chunks).toString('utf-8'));
+      });
+
+      req.on('error', (err) => {
+        this.onError(err);
+        resolve(null);
+      });
+    });
+  }
+
+  /**
+   * Set standard CORS headers for browser-based MCP clients.
+   */
+  private setCorsHeaders(res: ServerResponse): void {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  }
+}

--- a/packages/core/src/mcp/http-transport.ts
+++ b/packages/core/src/mcp/http-transport.ts
@@ -10,6 +10,10 @@
  * Uses the same `on`/`send`/`close` interface as McpTransport so the
  * MCP server dispatch layer works identically over both transports.
  *
+ * Concurrency: per-request response tracking via a Map keyed by JSON-RPC
+ * request ID ensures concurrent POST requests get independent, correctly
+ * routed SSE responses.
+ *
  * No external dependencies — uses Node.js built-in `http` module.
  */
 
@@ -46,8 +50,21 @@ export class StreamableHttpTransport {
   private host: string;
 
   // Callbacks — same pattern as McpTransport
-  private onMessage: ((data: unknown) => void) = () => {};
+  private onMessage: ((data: unknown) => Promise<void>) = async () => {};
   private onError: ((err: Error) => void) = () => {};
+
+  /**
+   * Per-request response tracking: JSON-RPC request ID → ServerResponse.
+   *
+   * When handlePost() receives a request, it registers the request's ID
+   * (or all IDs for a batch) pointing to the ServerResponse for that POST.
+   * When send() is called with a JSON-RPC response, it extracts the `id`
+   * field and looks up the correct ServerResponse to write to.
+   *
+   * This ensures concurrent POST requests get independent, correctly routed
+   * SSE responses — the second POST cannot overwrite the first's reference.
+   */
+  private readonly _responseMap = new Map<string | number, ServerResponse>();
 
   constructor(options?: StreamableHttpTransportOptions) {
     this.port = options?.port ?? DEFAULT_PORT;
@@ -120,9 +137,13 @@ export class StreamableHttpTransport {
    * The request body is parsed as JSON. For each JSON-RPC message, the
    * transport emits a 'message' event. The server dispatch layer calls
    * `send()` which writes the response as an SSE `data:` event.
+   *
+   * Per-request response tracking: before invoking onMessage, the request's
+   * JSON-RPC ID is registered in _responseMap pointing to this response.
+   * send() extracts the ID from the response data to find the correct stream.
    */
   private async handlePost(req: IncomingMessage, res: ServerResponse): Promise<void> {
-    const body = await this.readBody(req);
+    const body = await this.readBody(req, res);
     if (body === null) {
       // readBody already sent error response
       return;
@@ -135,8 +156,8 @@ export class StreamableHttpTransport {
       Connection: 'keep-alive',
     });
 
-    // Wire send() to write to this response's SSE stream
-    this._activeResponse = res;
+    // Register request IDs → response for per-request routing
+    let ids: Array<string | number> = [];
 
     try {
       // Parse — may be a single request or batch
@@ -153,27 +174,68 @@ export class StreamableHttpTransport {
         return;
       }
 
+      // Collect request IDs for per-request tracking
+      const items: unknown[] = Array.isArray(parsed) ? parsed : [parsed];
+      ids = this.registerIds(items, res);
+
       // Handle batch (array of requests)
       if (Array.isArray(parsed)) {
         for (const item of parsed) {
-          this.onMessage(item);
+          await this.onMessage(item);
         }
       } else {
-        this.onMessage(parsed);
+        await this.onMessage(parsed);
       }
-    } catch (err) {
+    } catch {
       this.writeSse(res, JSON.stringify({
         jsonrpc: '2.0',
         id: null,
         error: { code: -32603, message: 'Internal error' },
       }));
     } finally {
+      // Clean up registered IDs
+      this.unregisterIds(ids);
       // End SSE stream after a tick to allow any pending send() calls to flush
-      this._activeResponse = null;
       setImmediate(() => {
         if (!res.writableEnded) res.end();
       });
     }
+  }
+
+  /**
+   * Register JSON-RPC request IDs → ServerResponse in the tracking map.
+   * Returns the list of IDs that were registered (for later cleanup).
+   */
+  private registerIds(items: unknown[], res: ServerResponse): Array<string | number> {
+    const ids: Array<string | number> = [];
+    for (const item of items) {
+      const id = this.extractId(item);
+      if (id !== undefined) {
+        this._responseMap.set(id, res);
+        ids.push(id);
+      }
+    }
+    return ids;
+  }
+
+  /**
+   * Remove previously registered IDs from the tracking map.
+   */
+  private unregisterIds(ids: Array<string | number>): void {
+    for (const id of ids) {
+      this._responseMap.delete(id);
+    }
+  }
+
+  /**
+   * Extract a JSON-RPC ID suitable for use as a map key.
+   * Returns undefined for notifications (no ID) and null IDs.
+   */
+  private extractId(data: unknown): string | number | undefined {
+    if (data === null || typeof data !== 'object') return undefined;
+    const id = (data as Record<string, unknown>).id;
+    if (typeof id === 'string' || typeof id === 'number') return id;
+    return undefined;
   }
 
   /**
@@ -193,20 +255,22 @@ export class StreamableHttpTransport {
     res.end(JSON.stringify({ jsonrpc: '2.0', id: null, result: { status: 'session_terminated' } }));
   }
 
-  // ── Active response for send() targeting ────────────────────────────────
-
-  private _activeResponse: ServerResponse | null = null;
-
   /**
    * Send a JSON-RPC response. Writes it as an SSE `data:` event to the
-   * active POST response stream.
+   * response stream associated with the response's `id` field.
+   *
+   * Uses per-request tracking: extracts the `id` from the data to look up
+   * the correct ServerResponse from the _responseMap. This ensures concurrent
+   * POST requests get independent responses — one request cannot clobber
+   * another's response stream.
    */
   send(data: unknown): void {
     if (this.closed) {
       throw new Error('Transport is closed');
     }
 
-    const res = this._activeResponse;
+    const id = this.extractId(data);
+    const res = id !== undefined ? this._responseMap.get(id) : undefined;
     if (res && !res.writableEnded) {
       this.writeSse(res, JSON.stringify(data));
     }
@@ -238,14 +302,14 @@ export class StreamableHttpTransport {
   /**
    * Set the message handler. Same interface as McpTransport.
    */
-  on(event: 'message', handler: (data: unknown) => void): void;
+  on(event: 'message', handler: (data: unknown) => Promise<void>): void;
   /**
    * Set the error handler. Same interface as McpTransport.
    */
   on(event: 'error', handler: (err: Error) => void): void;
-  on(event: 'message' | 'error', handler: ((data: unknown) => void) | ((err: Error) => void)): void {
+  on(event: 'message' | 'error', handler: ((data: unknown) => Promise<void>) | ((err: Error) => void)): void {
     if (event === 'message') {
-      this.onMessage = handler as (data: unknown) => void;
+      this.onMessage = handler as (data: unknown) => Promise<void>;
     } else if (event === 'error') {
       this.onError = handler as (err: Error) => void;
     }
@@ -257,33 +321,39 @@ export class StreamableHttpTransport {
    * Read the full request body with size limit.
    * Returns null if an error response was already sent.
    */
-  private readBody(req: IncomingMessage): Promise<string | null> {
+  private readBody(req: IncomingMessage, res: ServerResponse): Promise<string | null> {
     return new Promise((resolve) => {
       const chunks: Buffer[] = [];
       let totalSize = 0;
+      let resolved = false;
+
+      const done = (value: string | null) => {
+        if (resolved) return;
+        resolved = true;
+        resolve(value);
+      };
 
       req.on('data', (chunk: Buffer) => {
+        if (resolved) return;
         totalSize += chunk.length;
         if (totalSize > MAX_BODY_SIZE) {
-          // Already sent a response — caller should not write
-          const res = this._activeResponse;
-          if (res && !res.headersSent) {
+          if (!res.headersSent) {
             res.writeHead(413, { 'Content-Type': 'application/json' });
             res.end(JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Request body exceeds 10 MB limit' } }));
           }
-          resolve(null);
+          done(null);
           return;
         }
         chunks.push(chunk);
       });
 
       req.on('end', () => {
-        resolve(Buffer.concat(chunks).toString('utf-8'));
+        done(Buffer.concat(chunks).toString('utf-8'));
       });
 
       req.on('error', (err) => {
         this.onError(err);
-        resolve(null);
+        done(null);
       });
     });
   }

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -1,4 +1,7 @@
 export { startMcpServer } from './server.js';
+export type { McpServerOptions } from './server.js';
+export { StreamableHttpTransport } from './http-transport.js';
+export type { StreamableHttpTransportOptions } from './http-transport.js';
 export { loadRegistry, saveRegistry, removeRepo, getGitRemote, findEntryWithSiblingWarning } from './registry.js';
 export type { RegistryEntry } from './registry.js';
 export {

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -20,6 +20,7 @@ import { loadRegistry, findEntryWithSiblingWarning, type RegistryEntry } from '.
 import { listGroups, getGroupStatus, groupQuery } from './groups.js';
 import { syncGroupContracts, getGroupContracts } from './contracts.js';
 import { McpTransport } from './transport.js';
+import { StreamableHttpTransport } from './http-transport.js';
 import { routeMap, toolMap, apiImpact, shapeCheck } from './api-tools.js';
 import { executeTraversal, type TraversalQuery } from './traverse.js';
 import { PhaseTimer } from '../core/phase-timer.js';
@@ -2455,7 +2456,52 @@ async function handleRequest(req: JsonRpcRequest): Promise<JsonRpcResponse | nul
   }
 }
 
-export async function startMcpServer(): Promise<void> {
+export interface McpServerOptions {
+  /** Transport type: 'stdio' (default) or 'http' (StreamableHTTP). */
+  transport?: 'stdio' | 'http';
+  /** Port for HTTP transport. Default: 4748. Only used when transport is 'http'. */
+  port?: number;
+  /** Host for HTTP transport. Default: 'localhost'. Only used when transport is 'http'. */
+  host?: string;
+}
+
+export async function startMcpServer(options?: McpServerOptions): Promise<void> {
+  const transportType = options?.transport ?? 'stdio';
+
+  // ── HTTP (StreamableHTTP) transport ────────────────────────────────────
+  if (transportType === 'http') {
+    const httpTransport = new StreamableHttpTransport({
+      port: options?.port,
+      host: options?.host,
+    });
+
+    await httpTransport.listen();
+    const addr = httpTransport.address ?? `http://localhost:${options?.port ?? 4748}`;
+    console.error(`Astrolabe MCP server (StreamableHTTP) listening on ${addr}/mcp`);
+
+    // Graceful shutdown
+    process.on('SIGINT', () => { backend.shutdown(); httpTransport.close(); process.exit(0); });
+    process.on('SIGTERM', () => { backend.shutdown(); httpTransport.close(); process.exit(0); });
+
+    httpTransport.on('message', async (data: unknown) => {
+      try {
+        const req = data as JsonRpcRequest;
+        const res = await handleRequest(req);
+        if (res !== null) {
+          httpTransport.send(res);
+        }
+      } catch {
+        // Parse error already handled by transport
+      }
+    });
+
+    httpTransport.on('error', (err: Error) => {
+      console.error('MCP HTTP transport error:', err.message);
+    });
+    return;
+  }
+
+  // ── Stdio transport (default) ──────────────────────────────────────────
   // #274: Dual-framing transport with security hardening
   const transport = new McpTransport(process.stdin, process.stdout);
 

--- a/packages/core/tests/mcp/http-transport.test.ts
+++ b/packages/core/tests/mcp/http-transport.test.ts
@@ -1,0 +1,397 @@
+/**
+ * Tests for StreamableHTTP Transport (#710, #738).
+ *
+ * Tests the transport in isolation using node:http client (no external deps).
+ * Uses port 0 for random ports to avoid conflicts.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { request, type IncomingMessage } from 'node:http';
+import { StreamableHttpTransport } from '../../src/mcp/http-transport.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+interface RawResponse {
+  status: number;
+  headers: Record<string, string | string[] | undefined>;
+  body: string;
+}
+
+/**
+ * Make an HTTP request to the transport server.
+ */
+function makeRequest(opts: {
+  method: string;
+  path?: string;
+  body?: unknown;
+  rawBody?: string;
+  headers?: Record<string, string>;
+}): Promise<RawResponse> {
+  return new Promise((resolve, reject) => {
+    const url = new URL(opts.path ?? '/mcp', baseUrl);
+    const reqOptions = {
+      hostname: url.hostname,
+      port: url.port,
+      path: url.pathname,
+      method: opts.method,
+      headers: {
+        'Content-Type': 'application/json',
+        ...opts.headers,
+      },
+    };
+
+    const req = request(reqOptions, (res: IncomingMessage) => {
+      const chunks: Buffer[] = [];
+      res.on('data', (chunk: Buffer) => chunks.push(chunk));
+      res.on('end', () => {
+        resolve({
+          status: res.statusCode ?? 0,
+          headers: res.headers as Record<string, string | string[] | undefined>,
+          body: Buffer.concat(chunks).toString('utf-8'),
+        });
+      });
+      res.on('error', reject);
+    });
+
+    req.on('error', reject);
+
+    if (opts.rawBody !== undefined) {
+      req.write(opts.rawBody);
+    } else if (opts.body !== undefined) {
+      req.write(JSON.stringify(opts.body));
+    }
+    req.end();
+  });
+}
+
+/**
+ * Parse SSE `data:` events from a response body.
+ */
+function parseSseEvents(body: string): unknown[] {
+  const events: unknown[] = [];
+  // SSE format: "data: <json>\n\n"
+  const segments = body.split('\n\n');
+  for (const segment of segments) {
+    for (const line of segment.split('\n')) {
+      if (line.startsWith('data: ')) {
+        try {
+          events.push(JSON.parse(line.substring(6)));
+        } catch {
+          // skip malformed
+        }
+      }
+    }
+  }
+  return events;
+}
+
+/**
+ * Parse a JSON response body (non-SSE).
+ */
+function parseJson(body: string): unknown {
+  return JSON.parse(body);
+}
+
+// ── Test state ───────────────────────────────────────────────────────────
+
+let transport: StreamableHttpTransport;
+let baseUrl: string;
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe('StreamableHttpTransport', () => {
+
+  beforeAll(async () => {
+    transport = new StreamableHttpTransport({ port: 0, host: '127.0.0.1' });
+    await transport.listen();
+    baseUrl = transport.address!;
+    expect(baseUrl).toBeTruthy();
+  });
+
+  afterAll(() => {
+    transport.close();
+  });
+
+  // ── Basic routing ───────────────────────────────────────────────────
+
+  describe('routing', () => {
+    beforeEach(() => {
+      // Default message handler: echo back with result
+      transport.on('message', async (data: unknown) => {
+        const msg = data as { id?: unknown; method?: string };
+        transport.send({
+          jsonrpc: '2.0',
+          id: msg.id ?? null,
+          result: { method: msg.method, echoed: true },
+        });
+      });
+    });
+
+    it('POST /mcp with valid JSON-RPC request returns SSE response', async () => {
+      const res = await makeRequest({
+        method: 'POST',
+        body: { jsonrpc: '2.0', id: 'test-1', method: 'initialize' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toBe('text/event-stream');
+      expect(res.headers['cache-control']).toBe('no-cache');
+
+      const events = parseSseEvents(res.body);
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        jsonrpc: '2.0',
+        id: 'test-1',
+        result: { method: 'initialize', echoed: true },
+      });
+    });
+
+    it('POST /mcp with invalid JSON returns parse error', async () => {
+      const res = await makeRequest({
+        method: 'POST',
+        rawBody: '{invalid json!!!',
+      });
+
+      expect(res.status).toBe(200); // SSE headers already sent
+      const events = parseSseEvents(res.body);
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: -32700, message: 'Parse error: invalid JSON' },
+      });
+    });
+
+    it('POST /mcp with batch request handles each item', async () => {
+      const batch = [
+        { jsonrpc: '2.0', id: 'b1', method: 'tools/list' },
+        { jsonrpc: '2.0', id: 'b2', method: 'resources/list' },
+        { jsonrpc: '2.0', id: 'b3', method: 'prompts/list' },
+      ];
+
+      const res = await makeRequest({
+        method: 'POST',
+        body: batch,
+      });
+
+      expect(res.status).toBe(200);
+      const events = parseSseEvents(res.body);
+      expect(events).toHaveLength(3);
+      expect(events[0]).toEqual({ jsonrpc: '2.0', id: 'b1', result: { method: 'tools/list', echoed: true } });
+      expect(events[1]).toEqual({ jsonrpc: '2.0', id: 'b2', result: { method: 'resources/list', echoed: true } });
+      expect(events[2]).toEqual({ jsonrpc: '2.0', id: 'b3', result: { method: 'prompts/list', echoed: true } });
+    });
+
+    it('GET /mcp returns 405', async () => {
+      const res = await makeRequest({ method: 'GET' });
+
+      expect(res.status).toBe(405);
+      const body = parseJson(res.body) as { error: { message: string } };
+      expect(body.error.message).toContain('GET not supported');
+    });
+
+    it('DELETE /mcp returns session_terminated', async () => {
+      const res = await makeRequest({ method: 'DELETE' });
+
+      expect(res.status).toBe(200);
+      const body = parseJson(res.body) as { result: { status: string } };
+      expect(body.result.status).toBe('session_terminated');
+    });
+
+    it('POST to wrong path returns 404', async () => {
+      const res = await makeRequest({
+        method: 'POST',
+        path: '/other',
+        body: { jsonrpc: '2.0', id: 1, method: 'test' },
+      });
+
+      expect(res.status).toBe(404);
+      const body = parseJson(res.body) as { error: { code: number; message: string } };
+      expect(body.error.code).toBe(-32601);
+      expect(body.error.message).toContain('Not found');
+    });
+
+    it('OPTIONS /mcp returns 204 (CORS preflight)', async () => {
+      const res = await makeRequest({ method: 'OPTIONS' });
+
+      expect(res.status).toBe(204);
+      expect(res.headers['access-control-allow-origin']).toBe('*');
+      expect(res.headers['access-control-allow-methods']).toBeDefined();
+    });
+  });
+
+  // ── Body size limit ─────────────────────────────────────────────────
+
+  it('POST /mcp with body exceeding 10MB returns 413', async () => {
+    // Create a body larger than 10MB
+    // Use a large string payload to exceed MAX_BODY_SIZE (10 * 1024 * 1024)
+    const largePayload = { jsonrpc: '2.0', id: 'big', method: 'test', params: { data: 'x'.repeat(11 * 1024 * 1024) } };
+
+    const res = await makeRequest({
+      method: 'POST',
+      body: largePayload,
+    });
+
+    expect(res.status).toBe(413);
+  });
+
+  // ── Concurrency ─────────────────────────────────────────────────────
+
+  describe('concurrency', () => {
+    it('two concurrent POST requests get independent responses', async () => {
+      // Handler: delay then respond with the request ID
+      transport.on('message', async (data: unknown) => {
+        const msg = data as { id?: unknown };
+        // Small delay to simulate async processing
+        await new Promise((r) => setTimeout(r, 10));
+        transport.send({
+          jsonrpc: '2.0',
+          id: msg.id ?? null,
+          result: { handled: msg.id },
+        });
+      });
+
+      // Fire two concurrent requests with different IDs
+      const [res1, res2] = await Promise.all([
+        makeRequest({
+          method: 'POST',
+          body: { jsonrpc: '2.0', id: 'concurrent-A', method: 'test' },
+        }),
+        makeRequest({
+          method: 'POST',
+          body: { jsonrpc: '2.0', id: 'concurrent-B', method: 'test' },
+        }),
+      ]);
+
+      expect(res1.status).toBe(200);
+      expect(res2.status).toBe(200);
+
+      const events1 = parseSseEvents(res1.body);
+      const events2 = parseSseEvents(res2.body);
+
+      // Each response must contain its OWN request ID, not the other's
+      expect(events1).toHaveLength(1);
+      expect(events2).toHaveLength(1);
+      expect((events1[0] as { id: string }).id).toBe('concurrent-A');
+      expect((events1[0] as { result: { handled: string } }).result.handled).toBe('concurrent-A');
+      expect((events2[0] as { id: string }).id).toBe('concurrent-B');
+      expect((events2[0] as { result: { handled: string } }).result.handled).toBe('concurrent-B');
+    });
+  });
+
+  // ── Async response delivery ─────────────────────────────────────────
+
+  describe('async response delivery', () => {
+    it('handler completes before response closes', async () => {
+      let handlerCompleted = false;
+
+      transport.on('message', async (data: unknown) => {
+        const msg = data as { id?: unknown };
+        // Simulate async work
+        await new Promise((r) => setTimeout(r, 50));
+        transport.send({
+          jsonrpc: '2.0',
+          id: msg.id ?? null,
+          result: { async: true },
+        });
+        handlerCompleted = true;
+      });
+
+      const res = await makeRequest({
+        method: 'POST',
+        body: { jsonrpc: '2.0', id: 'async-test', method: 'test' },
+      });
+
+      // Handler must have completed BEFORE the response was sent
+      expect(handlerCompleted).toBe(true);
+      expect(res.status).toBe(200);
+
+      const events = parseSseEvents(res.body);
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({ jsonrpc: '2.0', id: 'async-test', result: { async: true } });
+    });
+  });
+
+  // ── Transport close ─────────────────────────────────────────────────
+
+  describe('transport close', () => {
+    it('close prevents new send() calls', () => {
+      const t = new StreamableHttpTransport({ port: 0, host: '127.0.0.1' });
+      // Don't listen — just test the close/send interaction
+      t.close();
+
+      expect(() => t.send({ jsonrpc: '2.0', id: 1, result: {} })).toThrow('Transport is closed');
+    });
+  });
+
+  // ── CORS headers ────────────────────────────────────────────────────
+
+  describe('CORS', () => {
+    it('all responses include CORS headers', async () => {
+      transport.on('message', async (data: unknown) => {
+        const msg = data as { id?: unknown };
+        transport.send({ jsonrpc: '2.0', id: msg.id ?? null, result: {} });
+      });
+
+      const res = await makeRequest({
+        method: 'POST',
+        body: { jsonrpc: '2.0', id: 'cors-test', method: 'test' },
+      });
+
+      expect(res.headers['access-control-allow-origin']).toBe('*');
+      expect(res.headers['access-control-allow-methods']).toBeDefined();
+      expect(res.headers['access-control-allow-headers']).toBeDefined();
+    });
+  });
+
+  // ── Notifications (no ID) ───────────────────────────────────────────
+
+  describe('notifications', () => {
+    it('notification with no ID does not crash the transport', async () => {
+      let received: unknown;
+      transport.on('message', async (data: unknown) => {
+        received = data;
+        // Notifications typically don't get a response — handler returns null
+      });
+
+      const res = await makeRequest({
+        method: 'POST',
+        body: { jsonrpc: '2.0', method: 'notifications/initialized' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(received).toEqual({ jsonrpc: '2.0', method: 'notifications/initialized' });
+      // No SSE data events for a notification
+      const events = parseSseEvents(res.body);
+      expect(events).toHaveLength(0);
+    });
+  });
+
+  // ── Batch with mixed IDs ────────────────────────────────────────────
+
+  describe('batch edge cases', () => {
+    it('batch with numeric and string IDs works correctly', async () => {
+      transport.on('message', async (data: unknown) => {
+        const msg = data as { id?: unknown; method?: string };
+        transport.send({
+          jsonrpc: '2.0',
+          id: msg.id ?? null,
+          result: { method: msg.method },
+        });
+      });
+
+      const batch = [
+        { jsonrpc: '2.0', id: 42, method: 'test-numeric' },
+        { jsonrpc: '2.0', id: 'str-key', method: 'test-string' },
+      ];
+
+      const res = await makeRequest({ method: 'POST', body: batch });
+
+      expect(res.status).toBe(200);
+      const events = parseSseEvents(res.body);
+      expect(events).toHaveLength(2);
+      expect(events[0]).toEqual({ jsonrpc: '2.0', id: 42, result: { method: 'test-numeric' } });
+      expect(events[1]).toEqual({ jsonrpc: '2.0', id: 'str-key', result: { method: 'test-string' } });
+    });
+  });
+});

--- a/packages/core/tests/mcp/http-transport.test.ts
+++ b/packages/core/tests/mcp/http-transport.test.ts
@@ -227,10 +227,21 @@ describe('StreamableHttpTransport', () => {
     // Use a large string payload to exceed MAX_BODY_SIZE (10 * 1024 * 1024)
     const largePayload = { jsonrpc: '2.0', id: 'big', method: 'test', params: { data: 'x'.repeat(11 * 1024 * 1024) } };
 
-    const res = await makeRequest({
-      method: 'POST',
-      body: largePayload,
-    });
+    let res: RawResponse;
+    try {
+      res = await makeRequest({
+        method: 'POST',
+        body: largePayload,
+      });
+    } catch (err) {
+      // On some platforms (Windows Node 18), the server closes the connection
+      // before the client finishes writing the oversized body, causing
+      // ECONNRESET. This is valid — the server did reject the body.
+      if (err instanceof Error && /ECONNRESET|EPIPE|socket hang up/i.test(err.message)) {
+        return; // test passes — body was rejected
+      }
+      throw err;
+    }
 
     expect(res.status).toBe(413);
   });


### PR DESCRIPTION
## Summary
- Add packages/core/src/mcp/http-transport.ts - StreamableHTTP transport class for MCP protocol over HTTP
- Update packages/core/src/mcp/server.ts - McpServerOptions interface with transport/port/host selection
- Update packages/core/src/mcp/index.ts - export new transport and options type
- Update packages/cli/src/index.ts - --transport, --port, --host flags on serve-mcp command

Closes #710