### PR TITLE
feat: benchmarking infrastructure with profile output (#732)

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -28,7 +28,8 @@ import {
   generateWiki,
   startEvalServer,
 } from '@astrolabe-dev/core';
-import type { ScanOutput, IncrementalInfo } from '@astrolabe-dev/core';
+import type { ScanOutput, IncrementalInfo, PhaseTimerResult } from '@astrolabe-dev/core';
+import { PIPELINE_TIMING_KEY, PIPELINE_MEMORY_KEY } from '@astrolabe-dev/core';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
@@ -93,6 +94,9 @@ program
       let edgeCount = 0;
       let isIncremental = false; // #338: track for AGENTS.md generation
 
+      // #732: Capture pipeline context for --profile / benchmark output
+      let profileCtx: { state: Map<string, unknown> } | null = null;
+
       if (storedMeta && dbExists) {
         // ── Incremental mode ──
         isIncremental = true; // #338: track for AGENTS.md generation
@@ -154,6 +158,8 @@ program
         nodeCount = graph.nodeCount;
         edgeCount = graph.relationshipCount;
         log.info('Incremental analysis complete', { nodes: nodeCount, edges: edgeCount });
+        // #732: Capture pipeline context for --profile / benchmark output
+        profileCtx = ctx;
       } else {
         // ── Full analysis (first run or missing meta/DB) ──
         graph = createKnowledgeGraph();
@@ -170,6 +176,27 @@ program
         nodeCount = graph.nodeCount;
         edgeCount = graph.relationshipCount;
         log.info('Full analysis complete', { nodes: nodeCount, edges: edgeCount });
+        // #732: Capture pipeline context for --profile / benchmark output
+        profileCtx = context;
+      }
+
+      // #732: Emit structured profile/benchmark output to stderr
+      if (opts.profile && profileCtx) {
+        const timing = profileCtx.state.get(PIPELINE_TIMING_KEY) as PhaseTimerResult | undefined;
+        const mem = profileCtx.state.get(PIPELINE_MEMORY_KEY) as { before: NodeJS.MemoryUsage; after: NodeJS.MemoryUsage } | undefined;
+        const profileData = {
+          version: pkg.version,
+          timestamp: new Date().toISOString(),
+          phases: timing?.phases ?? {},
+          totalMs: timing?.totalMs ?? 0,
+          memory: mem ?? null,
+          nodeCount,
+          edgeCount,
+        };
+        // Emit structured JSON to stderr so piped/scripted consumers can capture it
+        console.error('---ASTROLABE_PROFILE_START---');
+        console.error(JSON.stringify(profileData, null, 2));
+        console.error('---ASTROLABE_PROFILE_END---');
       }
 
       // Save graph to SQLite

--- a/packages/core/src/core/pipeline.ts
+++ b/packages/core/src/core/pipeline.ts
@@ -98,6 +98,20 @@ export interface PhaseDefinition<TOutput = unknown> {
 export const AST_TREE_CACHE_KEY = 'astTreeCache';
 
 /**
+ * Key used to store per-phase timing breakdown in `context.state`.
+ * Available after `runPipeline` completes when profiling is enabled.
+ * Value is a `PhaseTimerResult` (tool/pipeline timing breakdown).
+ */
+export const PIPELINE_TIMING_KEY = 'pipeline:timing';
+
+/**
+ * Key used to store memory usage snapshot in `context.state`.
+ * Available after `runPipeline` completes when profiling is enabled.
+ * Value is a `MemoryUsage` object (before/after heapUsed, rss, etc.).
+ */
+export const PIPELINE_MEMORY_KEY = 'pipeline:memory';
+
+/**
  * Run a set of pipeline phases in dependency order.
  *
  * Phases are executed in topological order based on their `dependencies`.
@@ -121,6 +135,9 @@ export async function runPipeline(
   const profile = context.state.get('profile') === true || isDebug;
   const pipelineTimer = profile ? new PhaseTimer('pipeline') : null;
   if (pipelineTimer) pipelineTimer.start();
+
+  // #732: Capture memory snapshot before pipeline execution
+  const memoryBefore = profile ? process.memoryUsage() : null;
 
   // Create AST tree cache and store in context for phase access.
   // The treeCache singleton (from parser.ts) is used so that parseFile()
@@ -163,7 +180,14 @@ export async function runPipeline(
     context.state.delete(AST_TREE_CACHE_KEY);
   }
 
-  if (pipelineTimer) pipelineTimer.stop();
+  if (pipelineTimer) {
+    const timingResult = pipelineTimer.stop();
+    // Store timing result in context.state for downstream consumers (CLI, etc.)
+    context.state.set(PIPELINE_TIMING_KEY, timingResult);
+    // #732: Store memory usage snapshot (before/after)
+    const memoryAfter = process.memoryUsage();
+    context.state.set(PIPELINE_MEMORY_KEY, { before: memoryBefore!, after: memoryAfter });
+  }
   return results;
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,7 +17,8 @@ export {
 } from '@astrolabe-dev/shared';
 
 export { createKnowledgeGraph } from './core/graph.js';
-export { runPipeline, createPhaseContext, getPhaseOutput, type PhaseDefinition, type PhaseContext, type IncrementalInfo } from './core/pipeline.js';
+export { runPipeline, createPhaseContext, getPhaseOutput, PIPELINE_TIMING_KEY, PIPELINE_MEMORY_KEY, type PhaseDefinition, type PhaseContext, type IncrementalInfo } from './core/pipeline.js';
+export { PhaseTimer, type PhaseTimerResult } from './core/phase-timer.js';
 export { initParser, parseFile, parseFiles, parseString, resetParser, AstCache, defaultWasmDir, languageForExtension, languageForFile, getAllExtensions } from './analysis/parser.js';
 export { symbolId, captureText, captureRange } from './analysis/language-definition.js';
 export type { LanguageDefinition, QueryPattern, ParsedSymbol, ParsedImport, FileParseResult } from './analysis/language-definition.js';

--- a/scripts/benchmark.mjs
+++ b/scripts/benchmark.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+/**
+ * benchmark.mjs — Run the analysis pipeline against a repo and collect metrics.
+ *
+ * Usage:
+ *   node scripts/benchmark.mjs                             # Default: packages/shared
+ *   node scripts/benchmark.mjs --repo /path/to/repo        # Custom repo path
+ *   node scripts/benchmark.mjs --repo packages/core --json  # JSON-only output
+ *
+ * The script runs `astrolabe analyze --profile` against the target repo,
+ * captures the structured timing output from stderr, and prints a JSON
+ * summary with per-phase breakdown, memory usage, and graph stats.
+ *
+ * Output schema:
+ *   {
+ *     version: string,        // CLI package version
+ *     timestamp: string,      // ISO 8601
+ *     phases: { name: ms },   // Per-phase duration in ms
+ *     totalMs: number,        // Pipeline timing total
+ *     wallClockMs: number,    // Real wall-clock time
+ *     memory: { before, after, delta },
+ *     nodeCount: number,
+ *     edgeCount: number,
+ *     cli: { command, entry }
+ *   }
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, statSync } from 'node:fs';
+import { resolve, join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+
+// ── Configuration ──────────────────────────────────────────────────────────
+
+const DEFAULT_REPO = join(repoRoot, 'packages', 'shared');
+const CLI_ENTRY = join(repoRoot, 'packages', 'cli', 'dist', 'index.js');
+const NPM_ENTRY = 'astrolabe';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  let repo = DEFAULT_REPO;
+  let jsonOnly = false;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--repo' && i + 1 < args.length) {
+      repo = resolve(repoRoot, args[++i]);
+    } else if (args[i] === '--json') {
+      jsonOnly = true;
+    } else if (args[i] === '--help' || args[i] === '-h') {
+      console.log(`
+Usage: node scripts/benchmark.mjs [options]
+
+Options:
+  --repo <path>   Path to the repository to analyze (default: packages/shared)
+  --json          Only output the JSON result (no progress messages to stderr)
+  --help, -h      Show this help message
+      `);
+      process.exit(0);
+    }
+  }
+
+  return { repo, jsonOnly };
+}
+
+function resolveCli() {
+  // Prefer the built CLI dist, fall back to npx astrolabe
+  if (existsSync(CLI_ENTRY)) {
+    return { cmd: 'node', cliArgs: [CLI_ENTRY] };
+  }
+  // Try npx as fallback
+  return { cmd: 'npx', cliArgs: [NPM_ENTRY] };
+}
+
+function formatBytes(bytes) {
+  if (bytes == null) return 'N/A';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function parseProfileOutput(stderr) {
+  const startMarker = '---ASTROLABE_PROFILE_START---';
+  const endMarker = '---ASTROLABE_PROFILE_END---';
+
+  const startIdx = stderr.indexOf(startMarker);
+  const endIdx = stderr.indexOf(endMarker);
+
+  if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) {
+    return null;
+  }
+
+  const jsonStr = stderr.substring(startIdx + startMarker.length, endIdx).trim();
+  try {
+    return JSON.parse(jsonStr);
+  } catch {
+    return null;
+  }
+}
+
+function buildOutput(profileData, wallClockMs, cmd, entry) {
+  const base = {
+    version: profileData?.version ?? 'unknown',
+    timestamp: profileData?.timestamp ?? new Date().toISOString(),
+    phases: profileData?.phases ?? {},
+    totalMs: profileData?.totalMs ?? 0,
+    wallClockMs,
+    memory: null,
+    nodeCount: profileData?.nodeCount ?? 0,
+    edgeCount: profileData?.edgeCount ?? 0,
+    cli: { command: cmd, entry },
+  };
+
+  // Format memory with human-readable + raw bytes for programmatic consumers
+  if (profileData?.memory) {
+    const m = profileData.memory;
+    base.memory = {
+      before: {
+        rss: formatBytes(m.before.rss),
+        heapUsed: formatBytes(m.before.heapUsed),
+        heapTotal: formatBytes(m.before.heapTotal),
+        external: formatBytes(m.before.external),
+      },
+      after: {
+        rss: formatBytes(m.after.rss),
+        heapUsed: formatBytes(m.after.heapUsed),
+        heapTotal: formatBytes(m.after.heapTotal),
+        external: formatBytes(m.after.external),
+      },
+      delta: {
+        rss: formatBytes(m.after.rss - m.before.rss),
+        heapUsed: formatBytes(m.after.heapUsed - m.before.heapUsed),
+      },
+    };
+    base.memoryRaw = m;
+  }
+
+  if (profileData?.error) {
+    base.error = profileData.error;
+  }
+
+  return base;
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────
+
+function main() {
+  const { repo, jsonOnly } = parseArgs();
+
+  // Validate repo path
+  if (!existsSync(repo)) {
+    console.error(`Error: repo path does not exist: ${repo}`);
+    process.exit(1);
+  }
+  if (!statSync(repo).isDirectory()) {
+    console.error(`Error: repo path is not a directory: ${repo}`);
+    process.exit(1);
+  }
+
+  const { cmd, cliArgs } = resolveCli();
+  const analyzeArgs = [...cliArgs, 'analyze', repo, '--profile', '--log-level', 'error'];
+
+  if (!jsonOnly) {
+    console.error(`Benchmarking analysis against: ${repo}`);
+    console.error(`Command: ${cmd} ${analyzeArgs.join(' ')}`);
+    console.error('Running analysis...');
+  }
+
+  const startTime = Date.now();
+
+  // Use spawnSync to capture stdout and stderr separately
+  const result = spawnSync(cmd, analyzeArgs, {
+    cwd: repoRoot,
+    encoding: 'utf-8',
+    timeout: 300000, // 5 minutes max
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  const wallClockMs = Date.now() - startTime;
+  const stderr = result.stderr || '';
+  const profileData = parseProfileOutput(stderr);
+
+  const output = buildOutput(profileData, wallClockMs, cmd, cliArgs.join(' '));
+
+  if (!profileData) {
+    // Include diagnostics in output on failure
+    output.error = output.error || 'Could not parse profile output from stderr';
+    output.stderrSnippet = stderr.slice(-2000);
+    output.status = result.status;
+    process.exitCode = 1;
+  }
+
+  console.log(JSON.stringify(output, null, 2));
+}
+
+main();


### PR DESCRIPTION
## Summary
- Add scripts/benchmark.mjs - standalone benchmark script for performance regression testing
- Update packages/core/src/core/pipeline.ts - PIPELINE_TIMING_KEY and PIPELINE_MEMORY_KEY for timing/memory storage in context.state
- Update packages/core/src/index.ts - export timing keys and PhaseTimer type
- Update packages/cli/src/index.ts - structured JSON profile output to stderr via --profile flag

Closes #732