### PR TITLE
fix: auto-trigger prepare-release on staging→main PR (#748)

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,11 +1,21 @@
 name: Prepare Release
 
 # ── Trigger ─────────────────────────────────────────────────────────────────
-# Manual workflow dispatch on staging. Generates CHANGELOG and bumps
-# package.json versions before the staging→main PR is opened.
-# Reviewer sees these changes in the PR diff.
+# Two trigger modes:
+#
+# 1. AUTOMATIC: When a staging→main PR is opened or marked ready for review,
+#    this workflow runs on staging, generates CHANGELOG + version bump, and
+#    commits to staging. The PR automatically picks up the new commit.
+#
+# 2. MANUAL: workflow_dispatch with dry_run toggle for ad-hoc preparation
+#    or validation without a PR.
+#
+# This ensures the release pipeline never fails due to missing version bumps.
 
 on:
+  pull_request:
+    branches: [main]
+    types: [opened, ready_for_review]
   workflow_dispatch:
     inputs:
       dry_run:
@@ -17,6 +27,11 @@ jobs:
   prepare:
     name: Prepare Release on Staging
     runs-on: ubuntu-latest
+    # Only run for PRs from staging branch (skip other source branches)
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.ref == 'staging')
     steps:
       - uses: actions/checkout@v4
         with:
@@ -76,8 +91,14 @@ jobs:
           npm pkg set version="$VERSION" -w packages/vscode
 
       # ── Commit and push to staging ────────────────────────────────────────
+      # Runs when:
+      #   - Triggered by PR (auto) — always commits (dry_run not applicable)
+      #   - Triggered manually with dry_run=false
       - name: Commit and push to staging
-        if: github.event.inputs.dry_run != 'true'
+        if: >
+          github.event_name == 'pull_request' ||
+          (github.event_name == 'workflow_dispatch' &&
+           github.event.inputs.dry_run != 'true')
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -98,7 +119,9 @@ jobs:
           }
 
       - name: Dry run — skip commit
-        if: github.event.inputs.dry_run == 'true'
+        if: >
+          github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.dry_run == 'true'
         run: |
           echo "🔲 DRY RUN: Would commit CHANGELOG + version bump for v${{ steps.version.outputs.version }} to staging"
           echo "Run again with dry_run=false to commit."


### PR DESCRIPTION
## Problem

The v1.0.8 release pipeline failed because \prepare-release.yml\ was never manually triggered — package.json versions stayed at 1.0.0 on main, npm publish failed with \E403 — cannot publish over previously published version\.

## Solution

Auto-trigger \prepare-release.yml\ when a staging→main PR is opened or marked ready for review.

### Changes to \prepare-release.yml\

1. **Added \pull_request\ trigger**: \ranches: [main]\, \	ypes: [opened, ready_for_review]\
2. **Guard**: Only runs when \head.ref == 'staging'\ (ignores other source branches)
3. **Auto-commit**: When PR-triggered, always commits version bump + CHANGELOG to staging (no dry_run option)
4. **Manual mode preserved**: \workflow_dispatch\ still works with \dry_run\ toggle

### Flow

\\\
Developer opens staging→main PR
  → prepare-release.yml auto-runs on staging
  → CHANGELOG.md updated, package.json versions bumped
  → Commit pushed to staging with [skip ci]
  → PR branch (staging) now has correct versions
  → Reviewer sees version bump + CHANGELOG in PR diff
  → Merge → release.yml succeeds (correct version on npm)
\\\

Closes #748