### PR TITLE
fix: auto-bump workspace versions in release pipeline (#748)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,9 +268,10 @@ jobs:
 
 
       # ── Publish to npm ────────────────────────────────────────────────────
-      # NOTE: Version bump and CHANGELOG are now done on staging via
-      # prepare-release.yml before the staging→main PR is opened.
-      # The reviewer sees those changes in the PR diff.
+      # Auto-bumps workspace versions to the calculated release version.
+      # This makes the pipeline self-sufficient even if prepare-release.yml
+      # was not run on staging before the staging→main PR (#748).
+      # NOTE: CHANGELOG updates still require prepare-release.yml on staging.
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -281,6 +282,15 @@ jobs:
       - run: npm ci
 
       - run: npm install --no-save --package-lock=false --legacy-peer-deps
+
+      - name: Bump workspace versions for release
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          echo "Bumping workspace versions to ${VERSION}..."
+          npm pkg set version="${VERSION}" --workspace packages/shared
+          npm pkg set version="${VERSION}" --workspace packages/core
+          npm pkg set version="${VERSION}" --workspace packages/cli
+          echo "✅ Workspace versions set to ${VERSION}"
 
       - name: Build CLI package
         run: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astrolabe",
-  "version": "1.0.0",
+  "version": "1.0.8",
   "description": "Codebase knowledge graph engine — multi-language static analysis with graph persistence, community detection, and hybrid search",
   "private": true,
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astrolabe-dev/cli",
-  "version": "1.0.0",
+  "version": "1.0.8",
   "description": "Astrolabe CLI — command-line interface for codebase knowledge graph analysis",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astrolabe-dev/core",
-  "version": "1.0.0",
+  "version": "1.0.8",
   "description": "Codebase knowledge graph engine — multi-language static analysis with graph persistence",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astrolabe-dev/shared",
-  "version": "1.0.0",
+  "version": "1.0.8",
   "description": "Shared type definitions for Astrolabe packages",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astrolabe-vscode",
-  "version": "1.0.0",
+  "version": "1.0.8",
   "description": "VSCode extension for Astrolabe — interactive codebase knowledge graph exploration",
   "icon": "icon.png",
   "private": true,


### PR DESCRIPTION
﻿## Summary
- **Root cause**: `prepare-release.yml` was never run on staging before the staging to main PR. The release pipeline calculated v1.0.8 from git tags but `npm publish` used the hardcoded `1.0.0` from `package.json` — which was already published, hence `403 Forbidden`.

- **Fix**: Added a `Bump workspace versions for release` step to `release.yml` that auto-bumps workspace versions to the calculated release version before `npm publish`. This makes the release pipeline self-sufficient even if `prepare-release.yml` was not run on staging.

- Also bumps all workspace package.json versions to `1.0.8` for the current release.

## Changes
1. **`.github/workflows/release.yml`**: Added auto-version-bump step before `npm publish`. Updated comment to reflect self-sufficient design.
2. **`package.json`** (root + all workspaces): Bumped version from `1.0.0` to `1.0.8`

## Test Plan
After merging to staging and then to main, the release pipeline will:
1. Calculate version `1.0.8` from git tags
2. Auto-bump workspace versions before publish
3. Publish `@astrolabe-dev/cli@1.0.8` to npm successfully

Closes #748
