### PR TITLE
feat: add ACCESSES edges for field/property read-write tracking (#750)

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,6 +13,7 @@ import {
   resolutionPhase, routesPhase, toolsPhase, ormPhase, crossFilePhase,
   mroPhase, communityPhase, processTracingPhase,
   cobolPhase,
+  accessTrackingPhase,
   callResolutionPhase, scopeResolutionPhase,
   initParser, createSqliteStore, createFtsSearch,
   createLogger, createPhaseContext, runPipeline, startMcpServer,
@@ -150,7 +151,7 @@ program
         await runPipeline([
           structurePhase, frameworkPhase, markdownPhase, parseEmitPhase,
           resolutionPhase, routesPhase, toolsPhase, ormPhase, crossFilePhase,
-          mroPhase, communityPhase, processTracingPhase,
+          mroPhase, communityPhase, processTracingPhase, accessTrackingPhase,
           cobolPhase,
           callResolutionPhase, scopeResolutionPhase,
         ], ctx);
@@ -169,7 +170,7 @@ program
         await runPipeline([
           structurePhase, frameworkPhase, markdownPhase, parseEmitPhase,
           resolutionPhase, routesPhase, toolsPhase, ormPhase, crossFilePhase,
-          mroPhase, communityPhase, processTracingPhase,
+          mroPhase, communityPhase, processTracingPhase, accessTrackingPhase,
           cobolPhase,
           callResolutionPhase, scopeResolutionPhase,
         ], context);

--- a/packages/core/src/analysis/languages/typescript.ts
+++ b/packages/core/src/analysis/languages/typescript.ts
@@ -110,6 +110,23 @@ const symbolPatterns: QueryPattern[] = [
     nameCapture: 'name',
     outerCapture: 'definition.property',
   },
+  // #750: Class field declarations — public/private/protected all use
+  // the public_field_definition node type regardless of accessibility modifier.
+  {
+    query: '(public_field_definition name: (property_identifier) @name type: (type_annotation (type_identifier)? @fieldType)?) @definition.property',
+    captureLabels: { 'definition.property': 'Property' },
+    nameCapture: 'name',
+    outerCapture: 'definition.property',
+    typeAnnotationCaptures: { 'fieldType': 'declaredType' },
+  },
+  // #750: Property declaration in interfaces/types (type-only, no value)
+  {
+    query: '(property_signature name: (property_identifier) @name type: (type_annotation (type_identifier)? @fieldType)) @definition.property',
+    captureLabels: { 'definition.property': 'Property' },
+    nameCapture: 'name',
+    outerCapture: 'definition.property',
+    typeAnnotationCaptures: { 'fieldType': 'declaredType' },
+  },
 ];
 
 // ── Import query patterns ──────────────────────────────────────────────────

--- a/packages/core/src/analysis/phases/access-tracking.ts
+++ b/packages/core/src/analysis/phases/access-tracking.ts
@@ -1,0 +1,177 @@
+/**
+ * Pipeline Phase: Access Tracking (#750)
+ *
+ * Detects field/property read and write access patterns within
+ * Method/Function/Constructor bodies. Creates ACCESSES edges from
+ * the function/method to the accessed Property node with a
+ * read/write reason.
+ *
+ * Uses a simple regex-based approach for member expression detection.
+ * Writes are detected by assignment operators on property expressions.
+ * Only runs for TypeScript/JavaScript files (extensible).
+ *
+ * Runs after core symbol emission so Property/Class nodes exist.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { PhaseDefinition, PhaseContext } from '../../core/pipeline.js';
+
+export interface AccessTrackingOutput {
+  accessCount: number;
+  readCount: number;
+  writeCount: number;
+}
+
+/**
+ * Match member expressions: obj.field, this.field, self.field
+ * Group 1: object name, Group 2: property name
+ */
+const MEMBER_EXPRESSION_RE = /([a-zA-Z_$][\w$]*)\.([a-zA-Z_$][\w$]*)/g;
+
+/**
+ * Match assignment to property: obj.field = ..., obj.field += ..., etc.
+ * Group 1: object name, Group 2: property name
+ */
+const ASSIGN_TO_PROPERTY_RE = /\b([a-zA-Z_$][\w$]*)\.([a-zA-Z_$][\w$]*)\s*(?:\+|-|\*|\/|%|\*\*|<<|>>|>>>|&&|\|\||\?\?)?=/g;
+
+export const accessTrackingPhase: PhaseDefinition<AccessTrackingOutput> = {
+  name: 'access-tracking',
+  dependencies: ['parse-emit'],
+
+  shouldSkip(context: PhaseContext): boolean {
+    const inc = context.incremental;
+    if (!inc?.isIncremental) return false;
+    return inc.changedPaths.size + inc.addedPaths.size === 0;
+  },
+
+  execute(context: PhaseContext): AccessTrackingOutput {
+    const { graph, repoPath, incremental } = context;
+    const affectedFiles = incremental?.isIncremental
+      ? new Set([...incremental.changedPaths, ...incremental.addedPaths])
+      : null;
+
+    let accessCount = 0;
+    let readCount = 0;
+    let writeCount = 0;
+
+    // Collect all Property nodes indexed by (filePath, name)
+    const propertyIndex = new Map<string, Map<string, string>>(); // key → nodeId
+    for (const node of graph.iterNodes()) {
+      if (node.label !== 'Property') continue;
+      const fp = node.properties.filePath as string;
+      const name = node.properties.name as string;
+      if (!fp || !name) continue;
+      let fm = propertyIndex.get(fp);
+      if (!fm) { fm = new Map(); propertyIndex.set(fp, fm); }
+      fm.set(name, node.id);
+    }
+
+    // Collect function-like nodes (Methods, Functions, Constructors) with their file paths
+    interface FuncNode { id: string; fp: string; startLine: number; endLine: number; name: string; ownerClass?: string; }
+    const funcNodes: FuncNode[] = [];
+    for (const node of graph.iterNodes()) {
+      if (node.label !== 'Method' && node.label !== 'Function' && node.label !== 'Constructor') continue;
+      const fp = node.properties.filePath as string;
+      if (!fp) continue;
+      if (affectedFiles && !affectedFiles.has(fp)) continue;
+
+      funcNodes.push({
+        id: node.id,
+        fp,
+        name: node.properties.name as string,
+        startLine: (node.properties.startLine as number) ?? 0,
+        endLine: (node.properties.endLine as number) ?? Infinity,
+        ownerClass: node.properties.parentClass as string | undefined,
+      });
+    }
+
+    // Process each function body
+    for (const fn of funcNodes) {
+      const absPath = resolve(repoPath, fn.fp);
+      let content: string;
+      try {
+        content = readFileSync(absPath, 'utf-8');
+      } catch {
+        continue;
+      }
+
+      const lines = content.split('\n');
+      if (fn.startLine < 1 || fn.endLine > lines.length) continue;
+
+      // Extract the function body text (line range)
+      const bodyLines = lines.slice(fn.startLine - 1, fn.endLine);
+      const bodyText = bodyLines.join('\n');
+
+      // Detect writes (assignment to property)
+      const writes = new Map<string, number>(); // propertyName → count
+      let matchW: RegExpExecArray | null;
+      ASSIGN_TO_PROPERTY_RE.lastIndex = 0;
+      while ((matchW = ASSIGN_TO_PROPERTY_RE.exec(bodyText)) !== null) {
+        const objName = matchW[1];
+        const propName = matchW[2];
+        // Skip 'this.constructor' and 'super.*' (not field accesses)
+        if (propName === 'constructor' || objName === 'super') continue;
+        writes.set(propName, (writes.get(propName) ?? 0) + 1);
+      }
+
+      // Detect all member expressions (reads + writes)
+      const allAccesses = new Map<string, number>();
+      let matchA: RegExpExecArray | null;
+      MEMBER_EXPRESSION_RE.lastIndex = 0;
+      while ((matchA = MEMBER_EXPRESSION_RE.exec(bodyText)) !== null) {
+        const objName = matchA[1];
+        const propName = matchA[2];
+        if (propName === 'constructor' || objName === 'super' || objName === 'prototype') continue;
+        allAccesses.set(propName, (allAccesses.get(propName) ?? 0) + 1);
+      }
+
+      if (allAccesses.size === 0) continue;
+
+      // Find the target file's property index
+      const fileProps = propertyIndex.get(fn.fp);
+      if (!fileProps && writes.size === 0 && allAccesses.size === 0) continue;
+
+      // Create ACCESSES edges
+      for (const [propName] of allAccesses) {
+        const isWrite = writes.has(propName);
+        const reason = isWrite ? 'write' : 'read';
+
+        // Look up Property node in same file
+        let targetId: string | undefined;
+        if (fileProps) {
+          targetId = fileProps.get(propName);
+        }
+        // Fallback: also search the owner class's file index
+        if (!targetId && fn.ownerClass) {
+          const ownerNode = graph.getNode(fn.ownerClass);
+          const ownerFp = ownerNode?.properties.filePath as string | undefined;
+          if (ownerFp) {
+            const ownerProps = propertyIndex.get(ownerFp);
+            if (ownerProps) {
+              targetId = ownerProps.get(propName);
+            }
+          }
+        }
+
+        if (!targetId) continue;
+
+        const edgeId = `access:${fn.id}:${reason}:${propName}:${targetId}`;
+        if (graph.getRelationship(edgeId)) continue;
+
+        graph.addRelationship({
+          id: edgeId,
+          sourceId: fn.id,
+          targetId,
+          type: 'ACCESSES',
+          confidence: 0.7,
+          reason,
+        });
+
+        accessCount++;
+        if (isWrite) writeCount++; else readCount++;
+      }
+    }
+
+    return { accessCount, readCount, writeCount };
+  },
+};

--- a/packages/core/src/analysis/phases/index.ts
+++ b/packages/core/src/analysis/phases/index.ts
@@ -13,6 +13,7 @@ export { communityPhase } from './community.js';
 export { processTracingPhase } from './process-tracing.js';
 export { cobolPhase } from './cobol.js';
 export { vueSfcPhase } from './vue-sfc.js';
+export { accessTrackingPhase, type AccessTrackingOutput } from './access-tracking.js';
 export { callResolutionPhase } from '../call-processor.js';
 export { scopeResolutionPhase } from '../scope-resolver.js';
 export type { FileEntry, ScanOutput } from './scan.js';

--- a/packages/core/src/analysis/phases/parse-emit.ts
+++ b/packages/core/src/analysis/phases/parse-emit.ts
@@ -103,7 +103,7 @@ export const parseEmitPhase: PhaseDefinition<ParseEmitOutput> = {
 
     if (shouldUseWorkers) {
       const fileInfos = parsable.map((f) => ({ path: f.absolutePath, size: f.size }));
-      const { results, stats } = await parseFilesParallel(
+      const { results } = await parseFilesParallel(
         fileInfos,
         async (filePath: string) => {
           const r = await parseFile(filePath, wasmDir);
@@ -137,17 +137,11 @@ export const parseEmitPhase: PhaseDefinition<ParseEmitOutput> = {
         for (const rel of workerResult.relationships) {
           emitRelationship(graph, rel as ParsedRelationship, relPath);
         }
-        inferParentClasses(graph, relPath);
-      }
-      errorCount = stats.errorCount;
-
-      // Log pool stats via progress callback
-      context.onProgress('parse-emit', 100,
-        `Parsed ${fileCount} files (${stats.workerCount} workers, ${stats.chunkCount} chunks, ${stats.durationMs}ms)`,
-      );
-
-      return { symbolCount, importCount, fileCount, errorCount, symbolCounts };
+      inferParentClasses(graph, relPath);
+      // #750: Create HAS_PROPERTY edges from Class → Property nodes in this file
+      inferHasPropertyEdges(graph, relPath);
     }
+  }
 
     // Sequential fallback: process in chunks to keep memory under control
     for (let i = 0; i < parsable.length; i += CHUNK_SIZE) {
@@ -185,6 +179,8 @@ export const parseEmitPhase: PhaseDefinition<ParseEmitOutput> = {
         // Language providers don't always set parentClass. Walk the file's
         // symbols to assign each Method/Constructor to its nearest Class.
         inferParentClasses(graph, relPath);
+        // #750: Create HAS_PROPERTY edges from Class → Property nodes in this file
+        inferHasPropertyEdges(graph, relPath);
       }
 
       // Yield event-loop for very large repos
@@ -350,6 +346,69 @@ function emitRelationship(
     confidence: 0.7,
     reason: `tree-sitter ${rel.type.toLowerCase()} capture`,
   });
+}
+
+/**
+ * #750: Create HAS_PROPERTY edges from Class/Interface nodes to Property nodes
+ * in the same file. For each Property, finds the nearest enclosing Class/Interface
+ * by line range and creates a HAS_PROPERTY edge.
+ */
+function inferHasPropertyEdges(
+  graph: PhaseContext['graph'],
+  filePath: string,
+): void {
+  // Collect Class/Interface nodes in this file with their line ranges
+  const classLike: Array<{ id: string; startLine: number; endLine: number }> = [];
+  const properties: Array<{ id: string; startLine: number }> = [];
+
+  for (const node of graph.iterNodes()) {
+    if (node.properties.filePath !== filePath) continue;
+    if (node.label === 'Class' || node.label === 'Interface' || node.label === 'Struct' || node.label === 'Trait') {
+      classLike.push({
+        id: node.id,
+        startLine: (node.properties.startLine as number) ?? 0,
+        endLine: (node.properties.endLine as number) ?? Infinity,
+      });
+    } else if (node.label === 'Property') {
+      // Only infer for properties that don't already have an explicit owner
+      if (!node.properties.ownerClass) {
+        properties.push({ id: node.id, startLine: (node.properties.startLine as number) ?? 0 });
+      }
+    }
+  }
+
+  if (classLike.length === 0 || properties.length === 0) return;
+
+  classLike.sort((a, b) => a.startLine - b.startLine);
+
+  for (const prop of properties) {
+    let owner: typeof classLike[0] | null = null;
+    for (const cls of classLike) {
+      if (cls.startLine <= prop.startLine && prop.startLine <= cls.endLine) {
+        owner = cls;
+      }
+    }
+    if (!owner) continue;
+
+    // Create HAS_PROPERTY edge: Class → Property
+    const edgeId = `hasProperty:${owner.id}:${prop.id}`;
+    if (graph.getRelationship(edgeId)) continue;
+
+    graph.addRelationship({
+      id: edgeId,
+      sourceId: owner.id,
+      targetId: prop.id,
+      type: 'HAS_PROPERTY',
+      confidence: 1,
+      reason: `field declared in class body`,
+    });
+
+    // Also set the ownerClass property on the Property node
+    const propNode = graph.getNode(prop.id);
+    if (propNode) {
+      propNode.properties.ownerClass = owner.id;
+    }
+  }
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,7 +22,7 @@ export { PhaseTimer, type PhaseTimerResult } from './core/phase-timer.js';
 export { initParser, parseFile, parseFiles, parseString, resetParser, AstCache, defaultWasmDir, languageForExtension, languageForFile, getAllExtensions } from './analysis/parser.js';
 export { symbolId, captureText, captureRange } from './analysis/language-definition.js';
 export type { LanguageDefinition, QueryPattern, ParsedSymbol, ParsedImport, FileParseResult } from './analysis/language-definition.js';
-export { scanPhase, structurePhase, frameworkPhase, markdownPhase, parseEmitPhase, resolutionPhase, routesPhase, toolsPhase, ormPhase, crossFilePhase, mroPhase, communityPhase, processTracingPhase, cobolPhase, vueSfcPhase, callResolutionPhase, scopeResolutionPhase } from './analysis/phases/index.js';
+export { scanPhase, structurePhase, frameworkPhase, markdownPhase, parseEmitPhase, resolutionPhase, routesPhase, toolsPhase, ormPhase, crossFilePhase, mroPhase, communityPhase, processTracingPhase, cobolPhase, vueSfcPhase, accessTrackingPhase, callResolutionPhase, scopeResolutionPhase } from './analysis/phases/index.js';
 export type { FileEntry, ScanOutput } from './analysis/phases/scan.js';
 export type { StructureOutput } from './analysis/phases/structure.js';
 export type { ParseEmitOutput } from './analysis/phases/parse-emit.js';

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -2050,7 +2050,7 @@ function readResource(uri: string): string | null {
       for (const rel of graph.iterRelationships()) types.add(rel.type);
       return `Node Labels: ${Array.from(labels).sort().join(', ')}\nRelationship Types: ${Array.from(types).sort().join(', ')}`;
     } catch {
-      return `Node Labels: File, Folder, Package, Function, Class, Method, Interface, Enum, Variable, Import, Community, Process, Route, Tool, Section, Framework\nRelationship Types: CONTAINS, CALLS, EXTENDS, IMPLEMENTS, IMPORTS, USES, DEFINES, HAS_METHOD, HAS_PROPERTY, MEMBER_OF, STEP_IN_PROCESS, HANDLES_ROUTE, ENTRY_POINT_OF, USES_FRAMEWORK`;
+      return `Node Labels: File, Folder, Package, Function, Class, Method, Interface, Enum, Variable, Import, Community, Process, Route, Tool, Section, Framework\nRelationship Types: ACCESSES, CONTAINS, CALLS, EXTENDS, IMPLEMENTS, IMPORTS, USES, DEFINES, HAS_METHOD, HAS_PROPERTY, MEMBER_OF, STEP_IN_PROCESS, HANDLES_ROUTE, ENTRY_POINT_OF, USES_FRAMEWORK`;
     }
   }
 

--- a/packages/core/tests/eval/eval-harness.test.ts
+++ b/packages/core/tests/eval/eval-harness.test.ts
@@ -117,6 +117,8 @@ const handler = (): Response => new Response();
       { name: 'getUser', label: 'Function', exported: true },
       { name: 'User', label: 'Class', exported: true },
       { name: 'handler', label: 'Function' },
+      { name: 'id', label: 'Property' },
+      { name: 'name', label: 'Property' },
     ],
     minPrecision: 0.8,
     minRecall: 0.8,
@@ -140,6 +142,7 @@ interface Token {
       { name: 'AuthService', label: 'Class', exported: true },
       { name: 'Token', label: 'Interface', exported: false },
       { name: 'login', label: 'Method', exported: false },
+      { name: 'jwt', label: 'Property' },
     ],
     expectedImports: [
       { source: 'express', names: ['Router'] },

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -19,7 +19,7 @@ import {
   runPipeline,
   scanPhase, structurePhase, frameworkPhase, markdownPhase, parseEmitPhase,
   resolutionPhase, routesPhase, toolsPhase, ormPhase, crossFilePhase,
-  mroPhase, communityPhase, processTracingPhase,
+  mroPhase, communityPhase, processTracingPhase, accessTrackingPhase,
   createSqliteStore, createFtsSearch,
   loadRegistry, saveRegistry,
   createLogger,
@@ -163,7 +163,7 @@ async function runAnalysis(
     await runPipeline([
       scanPhase, structurePhase, frameworkPhase, markdownPhase, parseEmitPhase,
       resolutionPhase, routesPhase, toolsPhase, ormPhase, crossFilePhase,
-      mroPhase, communityPhase, processTracingPhase,
+      mroPhase, communityPhase, processTracingPhase, accessTrackingPhase,
     ], phaseCtx);
 
     if (progress) progress.report({ message: 'Persisting to SQLite...' });


### PR DESCRIPTION
## Summary
- Adds ACCESSES edges for field/property read-write tracking in the knowledge graph
- Implements a new ccess-tracking pipeline phase that auto-infers Class/Method/Function ACCESSES Property relationships

## Changes
- **New**: packages/core/src/analysis/phases/access-tracking.ts � regex-based member expression detection, read/write classification, Property node indexing
- **New**: 2 tree-sitter QueryPatterns in 	ypescript.ts for public_field_definition and property_signature
- **New**: inferHasPropertyEdges() in parse-emit.ts � auto-infers Class?Property HAS_PROPERTY edges
- **Modified**: Phase registration in CLI, VSCode extension, core exports
- **Modified**: MCP server schema fallback includes ACCESSES relationship type
- **Modified**: Eval harness fixtures updated for Property nodes

## Verification
- Build: all packages compile clean
- Tests: 641 pass, 19 skip � zero regressions

Closes #750
