### PR TITLE
feat: extract visibility and static metadata for Property nodes (#751)

### DIFF
--- a/packages/core/src/analysis/parser.ts
+++ b/packages/core/src/analysis/parser.ts
@@ -372,8 +372,8 @@ function extractSymbols(
       }
     }
 
-    // #432: Extract metadata from AST for function-like symbols
-    if (label === 'Function' || label === 'Method' || label === 'Constructor') {
+    // #432: Extract metadata from AST for function-like symbols and Property nodes
+    if (label === 'Function' || label === 'Method' || label === 'Constructor' || label === 'Property') {
       const metadata = extractSymbolMetadata(outerNode.node, label, languageName);
       if (Object.keys(metadata).length > 0) {
         const entry = seen.get(dedupKey);
@@ -614,7 +614,7 @@ function extractSymbolMetadata(
   label: string,
   languageName: string,
 ): Record<string, unknown> {
-  if (label !== 'Function' && label !== 'Method' && label !== 'Constructor') return {};
+  if (label !== 'Function' && label !== 'Method' && label !== 'Constructor' && label !== 'Property') return {};
 
   const props: Record<string, unknown> = {};
   const funcNode = findFunctionNode(node);


### PR DESCRIPTION
## Summary
- Enables visibility (public/private/protected) and static flag extraction for Property nodes
- Builds on the HAS_PROPERTY/Accesses infrastructure from #750

## Changes
- **Modified**: packages/core/src/analysis/parser.ts � adds Property to the label gates in extractSymbolMetadata() and the calling block in extractSymbols()
- The existing AST-walking logic in extractTsJsMetadata() already handles ccessibility_modifier, static, sync, and bstract � just never ran for Property nodes
- indFunctionNode() falls back to returning the outer node for public_field_definition/property_signature nodes, so modifier child walks work correctly

## Verification
- Build: all packages compile clean
- Tests: 641 pass, 19 skip � zero regressions

Closes #751
