### PR TITLE
feat: extend cross-file type propagation to Property nodes (#766)

### DIFF
--- a/packages/core/src/analysis/phases/cross-file.ts
+++ b/packages/core/src/analysis/phases/cross-file.ts
@@ -242,7 +242,7 @@ export const crossFilePhase: PhaseDefinition<CrossFileOutput> = {
       for (const node of graph.iterNodes()) {
         const fp = node.properties.filePath as string | undefined;
         if (fp !== filePath) continue;
-        if (node.label !== 'Function' && node.label !== 'Method') continue;
+        if (node.label !== 'Function' && node.label !== 'Method' && node.label !== 'Property') continue;
 
         // #376: Resolve returnType to target symbol
         const returnType = node.properties.returnType as string | undefined;


### PR DESCRIPTION
## Summary
- Extends cross-file type propagation to include Property nodes
- Property nodes with declaredType (already captured via tree-sitter 	ypeAnnotationCaptures) now get resolved to DECLARES_TYPE edges connecting them to their type nodes (Class, Interface, Enum, etc.)

## Why
- This is the foundation for deep call chain tracing (#766)
- Field type resolution: when code accesses obj.field, we can now trace ield ? its declared type
- Enables downstream phases to resolve obj.field.method() chains by knowing the field's type

## Changes
- **Modified**: packages/core/src/analysis/phases/cross-file.ts line 245 � adds Property to the node label gate
- Property nodes already have declaredType populated via TypeScript 	ypeAnnotationCaptures (fieldType ? declaredType from #750)
- The declaredType path (DECLARES_TYPE edges) now fires for Property nodes in addition to Function/Method
- The eturnType path is harmless for Property nodes (they don't have eturnType set, so the check at line 249 is falsy)

## Verification
- Build: all packages compile clean
- Tests: 641 pass, 19 skip � zero regressions

Part of #766
