### PR TITLE
feat: add timeoutMs parameter for impact analysis with budget control (#753)

### DIFF
--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -478,7 +478,7 @@ class LocalBackend {
     return { match_count: results.length, matches: results, siblingWarning };
   }
 
-  impact(target: string, direction: 'upstream' | 'downstream' = 'upstream', repo?: string, maxDepth = 5, minConfidence = 0.3) {
+  impact(target: string, direction: 'upstream' | 'downstream' = 'upstream', repo?: string, maxDepth = 5, minConfidence = 0.3, timeoutMs = 30_000) {
     const ctx = this.getRepo(repo);
     const graph = ctx.loadGraph();
 
@@ -528,8 +528,10 @@ class LocalBackend {
     const visited = new Set<string>([targetNode.id]);
     const queue: Array<{ id: string; depth: number }> = [{ id: targetNode.id, depth: 0 }];
     let truncated = false;
+    const deadline = Date.now() + Math.min(timeoutMs, 3_600_000);
 
     while (queue.length > 0 && affected.length < MAX_IMPACT_RESULTS) {
+      if (Date.now() >= deadline) { truncated = true; break; }
       const current = queue.shift()!;
       if (current.depth >= maxDepth) continue;
 
@@ -969,6 +971,7 @@ service: monorepo path prefix filter (only active in group mode).`,
         maxDepth: { type: 'number', description: 'How many levels to traverse in local graph', default: 5 },
         minConfidence: { type: 'number', description: 'Minimum edge confidence (0.0-1.0)', default: 0.3 },
         crossDepth: { type: 'number', description: 'Cross-repo hop depth via contract bridge (0 = single repo only)', default: 0 },
+        timeoutMs: { type: 'number', description: 'Wall-clock budget in ms (default 30000, max 3600000). Returns partial results if exceeded.', default: 30000 },
         repo: { type: 'string', description: 'Repository name, or "@<groupName>" / "@<groupName>/<memberPath>" for group mode' },
         service: { type: 'string', description: 'Optional monorepo path prefix filter (only active in group mode)' },
         subgroup: { type: 'string', description: 'Optional group subgroup prefix limiting cross-repo fan-out' },
@@ -981,6 +984,7 @@ service: monorepo path prefix filter (only active in group mode).`,
       const target = requireString(params, 'target');
       const repo = params.repo as string | undefined;
       const crossDepth = requireNumber(params, 'crossDepth', 0);
+      const timeoutMs = Math.min(requireNumber(params, 'timeoutMs', 30000), 3_600_000);
       let result: unknown;
 
       if (repo?.startsWith('@') && crossDepth > 0) {
@@ -996,6 +1000,7 @@ service: monorepo path prefix filter (only active in group mode).`,
           anchor.repo.entry.name,
           requireNumber(params, 'maxDepth', 5),
           requireNumber(params, 'minConfidence', 0.3),
+          timeoutMs,
         );
 
         // Cross-repo fan-out via contract links
@@ -1031,6 +1036,7 @@ service: monorepo path prefix filter (only active in group mode).`,
                     targetRepo,
                     requireNumber(params, 'maxDepth', 3),
                     requireNumber(params, 'minConfidence', 0.3),
+                    timeoutMs,
                   );
                   crossResults.push({ repo: targetRepo, contract: link.contractType, link, result: crossResult });
                 } catch { /* skip unreachable repos */ }
@@ -1056,6 +1062,7 @@ service: monorepo path prefix filter (only active in group mode).`,
           anchor?.repo.entry.name,
           requireNumber(params, 'maxDepth', 5),
           requireNumber(params, 'minConfidence', 0.3),
+          timeoutMs,
         );
       } else {
         result = backend.impact(
@@ -1064,6 +1071,7 @@ service: monorepo path prefix filter (only active in group mode).`,
           repo,
           requireNumber(params, 'maxDepth', 5),
           requireNumber(params, 'minConfidence', 0.3),
+          timeoutMs,
         );
       }
 


### PR DESCRIPTION
## Summary
- Adds timeoutMs parameter to MCP impact tool for wall-clock budget control
- Returns partial results with truncated=true when budget exceeded (graceful degradation)

## Changes
- **Modified**: packages/core/src/mcp/server.ts:
  - Added 	imeoutMs parameter to impact tool input schema (default 30000ms, max 3600000ms)
  - Updated LocalBackend.impact() signature with 	imeoutMs parameter
  - Added Date.now() deadline check inside BFS loop � breaks with 	runcated = true when budget exceeded
  - Passed 	imeoutMs through all 4 ackend.impact() call sites (local, cross-repo, group anchor, single repo)

## How It Works
- Before BFS: const deadline = Date.now() + Math.min(timeoutMs, 3_600_000)
- Each BFS iteration: checks Date.now() >= deadline ? breaks and sets 	runcated = true
- Existing 	runcated flag (previously only for 500-result cap) now also covers timeout
- group_impact calls use the default 30s budget (no param exposed at group level)

## Verification
- Build: all packages compile clean
- Tests: 641 pass, 19 skip � zero regressions

Closes #753
