### PR TITLE
feat: 3-tier confidence scoring for CALLS edges (#757)

### DIFF
--- a/packages/core/src/analysis/call-processor.ts
+++ b/packages/core/src/analysis/call-processor.ts
@@ -28,12 +28,50 @@ export interface CallResolutionOutput {
   variadicMatches: number;
 }
 
-// ── Confidence tiering ─────────────────────────────────────────────────────
+// ── Confidence tiering (#757) ──────────────────────────────────────────────────
 
-function resolveConfidence(exactMatch: boolean, isVariadic: boolean): number {
-  if (exactMatch) return 1.0;
-  if (isVariadic) return 0.7;
-  return 0.5; // global fallback
+/**
+ * 3-tier confidence scoring for CALLS edges:
+ * - Same-file: 0.95 — caller and callee in the same file
+ * - Import-scoped: 0.9 — callee was imported by the caller's file
+ * - Global/fuzzy: 0.5 — callee found by name match only
+ *
+ * Additionally lowered for variadic calls (0 argCount → -0.2).
+ */
+function resolveConfidence(
+  sourceFilePath: string,
+  targetFilePath: string,
+  isImported: boolean,
+  isVariadic: boolean,
+): number {
+  let confidence: number;
+  if (sourceFilePath === targetFilePath && sourceFilePath) {
+    confidence = 0.95; // same-file
+  } else if (isImported) {
+    confidence = 0.9; // import-scoped
+  } else {
+    confidence = 0.5; // global/fuzzy
+  }
+  if (isVariadic) confidence = Math.max(0.3, confidence - 0.2);
+  return confidence;
+}
+
+/**
+ * Build an import lookup: Map<filePath, Set<importedSymbolName>>
+ * for checking if a callee was imported by the caller's file.
+ */
+function buildImportIndex(graph: KnowledgeGraph): Map<string, Set<string>> {
+  const importsByFile = new Map<string, Set<string>>();
+  for (const node of graph.iterNodes()) {
+    if (node.label !== 'Import') continue;
+    const fp = node.properties.filePath as string | undefined;
+    const name = node.properties.name as string | undefined;
+    if (!fp || !name) continue;
+    let set = importsByFile.get(fp);
+    if (!set) { set = new Set(); importsByFile.set(fp, set); }
+    set.add(name);
+  }
+  return importsByFile;
 }
 
 // ── Stage 5: Resolve target with file-scoped name→node index (#364, #366) ─
@@ -69,40 +107,48 @@ export function resolveCalls(
   let fallbackMatches = 0;
   let variadicMatches = 0;
 
+  // #757: Build import index for import-scoped confidence tiering
+  const importsByFile = buildImportIndex(graph);
+
   for (const edge of edges) {
     const sourceNode = graph.getNode(edge.sourceId);
     const targetNode = graph.getNode(edge.targetId);
     if (!sourceNode || !targetNode) continue;
 
     const callName = (targetNode.properties.name as string) ?? '';
-    const callFp = (sourceNode.properties.filePath as string) ?? '';
+    const srcFp = (sourceNode.properties.filePath as string) ?? '';
+    const tgtFp = (targetNode.properties.filePath as string) ?? '';
     const argCount = ((targetNode.properties.paramCount as number) ?? 0);
 
     // Stage 3: Infer receiver via language hook
-    const lang = languageForFile(callFp);
+    const lang = languageForFile(srcFp);
     const hooks = lang?.callResolution;
 
     // Stage 4: Select dispatch
     const decision: DispatchDecision = { primary: 'free' };
     if (hooks?.selectDispatch) {
-      const callSite: CallSite = { name: callName, form: 'free', argCount, filePath: callFp, startLine: 1 };
+      const callSite: CallSite = { name: callName, form: 'free', argCount, filePath: srcFp, startLine: 1 };
       Object.assign(decision, hooks.selectDispatch(callSite));
     }
 
-    // Stage 6: Confidence tiering
+    // Stage 6: Confidence tiering (#757: 3-tier with same-file/import/global)
     const isVariadic = argCount === 0;
+    const isImported = importsByFile.get(srcFp)?.has(callName) ?? false;
     let confidence: number;
     if (decision.primary === 'owner-scoped') {
-      confidence = 1.0;
+      confidence = 1.0; // language hook confirmed exact match
       exactMatches++;
-    } else if (decision.fallback === 'free-arity-narrowed') {
-      confidence = isVariadic ? 0.7 : 0.5;
-      if (isVariadic) variadicMatches++;
-      else fallbackMatches++;
     } else {
-      confidence = resolveConfidence(false, isVariadic);
-      if (isVariadic) variadicMatches++;
-      else fallbackMatches++;
+      confidence = resolveConfidence(srcFp, tgtFp, isImported, isVariadic);
+      if (srcFp === tgtFp && srcFp) {
+        exactMatches++;
+      } else if (isImported) {
+        exactMatches++;
+      } else if (isVariadic) {
+        variadicMatches++;
+      } else {
+        fallbackMatches++;
+      }
     }
 
     // Update existing edge with enhanced confidence (#364: use actual source/target, not self-loop)


### PR DESCRIPTION
## Summary
- Replaces 2-tier confidence scoring with 3-tier: same-file (0.95), import-scoped (0.9), global/fuzzy (0.5)
- Variadic calls get -0.2 penalty (minimum 0.3)

## Changes
- **Modified**: packages/core/src/analysis/call-processor.ts:
  - New esolveConfidence() with 3 tiers based on file proximity and import relationships
  - New uildImportIndex() � builds Map<filePath, Set<importedSymbolName>> from Import nodes
  - Updated BFS confidence assignment to check same-file, import-scoped, or global
  - Language hook (owner-scoped) still gets 1.0 confidence � highest priority

## Confidence Tiers
| Tier | Confidence | Condition |
|------|-----------|-----------|
| Language hook | 1.0 | selectDispatch returns owner-scoped |
| Same-file | 0.95 | Caller and callee in same file |
| Import-scoped | 0.9 | Callee name appears in caller's file imports |
| Global/fuzzy | 0.5 | Name match only, no file/import relationship |
| Variadic penalty | -0.2 | Applied to any non-hook tier when argCount=0 |

## Verification
- Build: all packages compile clean
- Tests: 641 pass, 19 skip � zero regressions

Closes #757
