### PR TITLE
feat: symbol disambiguation in MCP context and impact tools (#764)

### DIFF
--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -311,12 +311,12 @@ class LocalBackend {
   }
 
   /** #401: Context across group repos with optional service filtering. */
-  contextGroup(nameOrUid: string, repoParam: string, service?: string) {
+  contextGroup(nameOrUid: string, repoParam: string, service?: string, kind?: string, filePath?: string) {
     const { contexts, groupName } = this.resolveGroupRepos(repoParam);
     const allMatches: Array<{ repoName: string; match: Record<string, unknown> }> = [];
 
     for (const { repo, memberPath } of contexts) {
-      const result = this.context(nameOrUid, repo.entry.name);
+      const result = this.context(nameOrUid, repo.entry.name, kind, filePath);
       if (!('error' in result)) {
         allMatches.push({ repoName: `${groupName}/${memberPath}`, match: result as unknown as Record<string, unknown> });
       }
@@ -390,7 +390,7 @@ class LocalBackend {
     return { processes, process_symbols: processSymbols, definitions, siblingWarning };
   }
 
-  context(nameOrUid: string, repo?: string) {
+  context(nameOrUid: string, repo?: string, kind?: string, filePath?: string) {
     const ctx = this.getRepo(repo);
     const graph = ctx.loadGraph();
 
@@ -398,13 +398,30 @@ class LocalBackend {
     const siblingWarning = this.getSiblingWarning(ctx.entry.path);
 
     // Find ALL matching symbols (handle overloads) (#116)
-    const symbols: GraphNode[] = [];
+    // #764: Compute relevance score for disambiguation
+    const symbols: Array<{ node: GraphNode; relevance: number }> = [];
     for (const node of graph.iterNodes()) {
       if (node.id === nameOrUid || node.properties.name === nameOrUid) {
-        symbols.push(node);
+        let relevance: number;
+        if (node.id === nameOrUid) {
+          relevance = 1.0;
+        } else if (kind && node.label === kind) {
+          relevance = 0.9;
+        } else if (filePath && (node.properties.filePath ?? '').includes(filePath)) {
+          relevance = 0.7;
+        } else {
+          relevance = 0.5;
+        }
+        // Apply filters if provided
+        if (kind && node.label !== kind) continue;
+        if (filePath && !(node.properties.filePath ?? '').includes(filePath)) continue;
+        symbols.push({ node, relevance });
       }
     }
     if (symbols.length === 0) return { error: `Symbol "${nameOrUid}" not found.`, siblingWarning };
+
+    // Sort by relevance (highest first)
+    symbols.sort((a, b) => b.relevance - a.relevance);
 
     // #177: Build adjacency index ONCE for all symbols (O(R) not O(S × R))
     const incomingMap = new Map<string, Map<string, string[]>>();
@@ -445,26 +462,26 @@ class LocalBackend {
       });
     }
 
-    const results = symbols.map((symbol) => {
-      const inc = incomingMap.get(symbol.id);
+    const results = symbols.map((entry) => {
+      const inc = incomingMap.get(entry.node.id);
       const incoming: Record<string, string[]> = {};
       if (inc) { for (const [t, names] of inc) incoming[t] = names; }
 
-      const out = outgoingMap.get(symbol.id);
+      const out = outgoingMap.get(entry.node.id);
       const outgoing: Record<string, string[]> = {};
       if (out) { for (const [t, names] of out) outgoing[t] = names; }
 
-      const processes = processMap.get(symbol.id) ?? [];
+      const processes = processMap.get(entry.node.id) ?? [];
 
       // TODO(#164): Include resolved type information once parser captures
       // returnType/declaredType on Function/Method nodes and cross-file
       // phase produces resolved_returnType.
       const symbolInfo: Record<string, unknown> = {
-        uid: symbol.id,
-        kind: symbol.label,
-        name: (symbol.properties.name as string) ?? '',
-        filePath: symbol.properties.filePath ?? '',
-        startLine: symbol.properties.startLine ?? 0,
+        uid: entry.node.id,
+        kind: entry.node.label,
+        name: (entry.node.properties.name as string) ?? '',
+        filePath: entry.node.properties.filePath ?? '',
+        startLine: entry.node.properties.startLine ?? 0,
       };
 
       return {
@@ -472,25 +489,64 @@ class LocalBackend {
         incoming,
         outgoing,
         processes,
+        relevance: entry.relevance,
       };
     });
 
     return { match_count: results.length, matches: results, siblingWarning };
   }
 
-  impact(target: string, direction: 'upstream' | 'downstream' = 'upstream', repo?: string, maxDepth = 5, minConfidence = 0.3, timeoutMs = 30_000) {
+  impact(target: string, direction: 'upstream' | 'downstream' = 'upstream', repo?: string, maxDepth = 5, minConfidence = 0.3, timeoutMs = 30_000, targetUid?: string, kind?: string, filePath?: string) {
     const ctx = this.getRepo(repo);
     const graph = ctx.loadGraph();
 
-    // Find target symbol
-    let targetNode: GraphNode | undefined;
+    // #764: Disambiguation — collect ALL matching candidates instead of first-match break
+    const candidates: Array<{ node: GraphNode; relevance: number }> = [];
     for (const node of graph.iterNodes()) {
-      if (node.id === target || node.properties.name === target) {
-        targetNode = node;
-        break;
+      let matched = false;
+      let relevance = 0;
+      if (targetUid && node.id === targetUid) {
+        matched = true;
+        relevance = 1.0;
+      } else if (!targetUid && (node.id === target || node.properties.name === target)) {
+        matched = true;
+        if (node.id === target) {
+          relevance = 1.0;
+        } else if (kind && node.label === kind) {
+          relevance = 0.9;
+        } else if (filePath && (node.properties.filePath ?? '').includes(filePath)) {
+          relevance = 0.7;
+        } else {
+          relevance = 0.5;
+        }
       }
+      if (!matched) continue;
+      // Apply filters
+      if (kind && node.label !== kind) continue;
+      if (filePath && !(node.properties.filePath ?? '').includes(filePath)) continue;
+      candidates.push({ node, relevance });
     }
-    if (!targetNode) return { error: `Target "${target}" not found.` };
+
+    if (candidates.length === 0) return { error: `Target "${target}" not found.` };
+
+    // Sort by relevance
+    candidates.sort((a, b) => b.relevance - a.relevance);
+
+    // If multiple candidates remain, return disambiguation result instead of picking one
+    if (candidates.length > 1) {
+      return {
+        ambiguous: true as const,
+        candidates: candidates.map((c) => ({
+          uid: c.node.id,
+          name: (c.node.properties.name as string) ?? '',
+          kind: c.node.label,
+          filePath: c.node.properties.filePath ?? '',
+          relevance: c.relevance,
+        })),
+      };
+    }
+
+    const targetNode = candidates[0].node;
 
     // Pre-build adjacency index: Map<nodeId, { neighborId, type, confidence }[]> (#119)
     // Also track unfiltered edge counts per node for untraceable detection (#695):
@@ -930,6 +986,8 @@ GROUP MODE: set "repo" to "@<groupName>" to search all member repos, or "@<group
         name: { type: 'string', description: 'Symbol name or node ID' },
         repo: { type: 'string', description: 'Repository name, or "@<groupName>" / "@<groupName>/<memberPath>" for group mode' },
         service: { type: 'string', description: 'Optional monorepo path prefix filter (only active in group mode)' },
+        kind: { type: 'string', description: 'Node label filter (Function, Class, Method, etc.) for disambiguation' },
+        file_path: { type: 'string', description: 'File path filter (substring match) for disambiguation' },
       },
       required: ['name'],
     },
@@ -939,12 +997,14 @@ GROUP MODE: set "repo" to "@<groupName>" to search all member repos, or "@<group
       const name = requireString(params, 'name');
       const repo = params.repo as string | undefined;
       const service = params.service as string | undefined;
+      const kind = params.kind as string | undefined;
+      const filePath = params.file_path as string | undefined;
       let result: unknown;
 
       if (repo?.startsWith('@')) {
-        result = backend.contextGroup(name, repo, service);
+        result = backend.contextGroup(name, repo, service, kind, filePath);
       } else {
-        result = backend.context(name, repo);
+        result = backend.context(name, repo, kind, filePath);
       }
 
       timer.mark('lookup');
@@ -975,6 +1035,9 @@ service: monorepo path prefix filter (only active in group mode).`,
         repo: { type: 'string', description: 'Repository name, or "@<groupName>" / "@<groupName>/<memberPath>" for group mode' },
         service: { type: 'string', description: 'Optional monorepo path prefix filter (only active in group mode)' },
         subgroup: { type: 'string', description: 'Optional group subgroup prefix limiting cross-repo fan-out' },
+        targetUid: { type: 'string', description: 'Exact node ID for zero-ambiguity lookup (skips name resolution)' },
+        kind: { type: 'string', description: 'Node label filter for disambiguation when target name is ambiguous' },
+        file_path: { type: 'string', description: 'File path filter for disambiguation' },
       },
       required: ['target', 'direction'],
     },
@@ -985,6 +1048,9 @@ service: monorepo path prefix filter (only active in group mode).`,
       const repo = params.repo as string | undefined;
       const crossDepth = requireNumber(params, 'crossDepth', 0);
       const timeoutMs = Math.min(requireNumber(params, 'timeoutMs', 30000), 3_600_000);
+      const targetUid = params.targetUid as string | undefined;
+      const kind = params.kind as string | undefined;
+      const filePath = params.file_path as string | undefined;
       let result: unknown;
 
       if (repo?.startsWith('@') && crossDepth > 0) {
@@ -1001,6 +1067,9 @@ service: monorepo path prefix filter (only active in group mode).`,
           requireNumber(params, 'maxDepth', 5),
           requireNumber(params, 'minConfidence', 0.3),
           timeoutMs,
+          targetUid,
+          kind,
+          filePath,
         );
 
         // Cross-repo fan-out via contract links
@@ -1063,6 +1132,9 @@ service: monorepo path prefix filter (only active in group mode).`,
           requireNumber(params, 'maxDepth', 5),
           requireNumber(params, 'minConfidence', 0.3),
           timeoutMs,
+          targetUid,
+          kind,
+          filePath,
         );
       } else {
         result = backend.impact(
@@ -1072,6 +1144,9 @@ service: monorepo path prefix filter (only active in group mode).`,
           requireNumber(params, 'maxDepth', 5),
           requireNumber(params, 'minConfidence', 0.3),
           timeoutMs,
+          targetUid,
+          kind,
+          filePath,
         );
       }
 
@@ -1427,6 +1502,9 @@ Returns direct impacts (within same repo) plus cross-repo impacts discovered thr
         maxDepth: { type: 'number', default: 3 },
         crossDepth: { type: 'number', default: 2 },
         minConfidence: { type: 'number', default: 0.3 },
+        targetUid: { type: 'string', description: 'Exact node ID for zero-ambiguity lookup (skips name resolution)' },
+        kind: { type: 'string', description: 'Node label filter for disambiguation when target name is ambiguous' },
+        file_path: { type: 'string', description: 'File path filter for disambiguation' },
       },
       required: ['name', 'target'],
     },
@@ -1439,6 +1517,9 @@ Returns direct impacts (within same repo) plus cross-repo impacts discovered thr
       const maxDepth = requireNumber(params, 'maxDepth', 3);
       const crossDepth = requireNumber(params, 'crossDepth', 2);
       const minConfidence = requireNumber(params, 'minConfidence', 0.3);
+      const targetUid = params.targetUid as string | undefined;
+      const kind = params.kind as string | undefined;
+      const filePath = params.file_path as string | undefined;
 
       // 1. Resolve the group
       const groups = listGroups();
@@ -1458,19 +1539,42 @@ Returns direct impacts (within same repo) plus cross-repo impacts discovered thr
         return { content: [{ type: 'text', text: JSON.stringify({ error: `No reachable repos in group '${groupName}'` }) }] };
       }
 
-      // 3. Search for target across all group members
+      // 3. Search for target across all group members (#764: collect all matches, not first-match break)
       let anchorRepo: string | undefined;
       const reposWithTarget: string[] = [];
       for (const { repo } of contexts) {
         const graph = repo.loadGraph();
-        let found = false;
+        const repoCandidates: Array<{ uid: string; name: string; kind: string; filePath: string; relevance: number }> = [];
         for (const node of graph.iterNodes()) {
-          if (node.id === target || node.properties.name === target) {
-            found = true;
-            break;
+          let matched = false;
+          let relevance = 0;
+          if (targetUid && node.id === targetUid) {
+            matched = true;
+            relevance = 1.0;
+          } else if (!targetUid && (node.id === target || node.properties.name === target)) {
+            matched = true;
+            if (node.id === target) {
+              relevance = 1.0;
+            } else if (kind && node.label === kind) {
+              relevance = 0.9;
+            } else if (filePath && (node.properties.filePath ?? '').includes(filePath)) {
+              relevance = 0.7;
+            } else {
+              relevance = 0.5;
+            }
           }
+          if (!matched) continue;
+          if (kind && node.label !== kind) continue;
+          if (filePath && !(node.properties.filePath ?? '').includes(filePath)) continue;
+          repoCandidates.push({
+            uid: node.id,
+            name: (node.properties.name as string) ?? '',
+            kind: node.label,
+            filePath: node.properties.filePath ?? '',
+            relevance,
+          });
         }
-        if (found) {
+        if (repoCandidates.length > 0) {
           if (!anchorRepo) anchorRepo = repo.entry.name;
           if (!reposWithTarget.includes(repo.entry.name)) {
             reposWithTarget.push(repo.entry.name);


### PR DESCRIPTION
﻿Adds symbol disambiguation to MCP context and impact tools with ranked candidates.

## Changes
- **context()**: Added \kind\ and \ile_path\ params for filtering, relevance scoring (1.0 UID, 0.9 name+kind, 0.7 name+filePath, 0.5 name-only), results sorted by relevance
- **impact()**: Added \	argetUid\, \kind\, \ile_path\ params. Returns \{ambiguous: true, candidates: [...]}\ instead of silently picking first match when multiple symbols share a name
- **contextGroup()**: Passes kind/filePath through to context() calls
- **Tool schemas**: Both context and impact tools updated with disambiguation params
- **Group impact**: Same disambiguation logic applied to cross-repo group impact handler

## Key Fix
impact() previously used \reak\ on first name match — silently picked wrong symbol when multiple symbols shared the same name (e.g. \User\, \Session\, \create\). Now collects all candidates and returns ranked choices.

Closes #764
