### PR TITLE
feat: Python Graph Dataset API for Data Science consumption (#804)

### DIFF
--- a/packages/astrolabe-datasets/astrolabe_datasets/__init__.py
+++ b/packages/astrolabe-datasets/astrolabe_datasets/__init__.py
@@ -1,0 +1,26 @@
+"""Astrolabe Datasets — Python Graph Dataset API for Astrolabe knowledge graphs.
+
+Exposes Astrolabe SQLite knowledge graph data as rich graph datasets consumable
+by major Data Science and ML frameworks: PyTorch-Geometric, cuGraph, Spark
+GraphFrames, igraph, graph-tool, and NetworkX.
+"""
+
+from astrolabe_datasets.core import (
+    NODE_LABELS,
+    RELATIONSHIP_TYPES,
+    CodeGraph,
+    list_available_graphs,
+    load_graph,
+    load_graphs,
+)
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "NODE_LABELS",
+    "RELATIONSHIP_TYPES",
+    "CodeGraph",
+    "list_available_graphs",
+    "load_graph",
+    "load_graphs",
+]

--- a/packages/astrolabe-datasets/astrolabe_datasets/core.py
+++ b/packages/astrolabe-datasets/astrolabe_datasets/core.py
@@ -1,0 +1,481 @@
+"""Core data structures and SQLite loaders for Astrolabe knowledge graphs.
+
+This module defines the :class:`CodeGraph` dataclass and a family of loader
+functions that read an Astrolabe-generated SQLite database and return
+ready-to-use ``pandas`` DataFrames plus structured metadata.
+
+Only three dependencies are required: **pandas**, **numpy**, and the
+standard-library :mod:`sqlite3` module.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+# ---------------------------------------------------------------------------
+# Label / relationship constants
+# ---------------------------------------------------------------------------
+
+NODE_LABELS: list[str] = [
+    "Project",
+    "Package",
+    "Module",
+    "Folder",
+    "File",
+    "Section",
+    "Class",
+    "Function",
+    "Method",
+    "Variable",
+    "Interface",
+    "Enum",
+    "Decorator",
+    "Import",
+    "Type",
+    "CodeElement",
+    "Struct",
+    "Constructor",
+    "Community",
+    "Process",
+    "Macro",
+    "Typedef",
+    "Union",
+    "Namespace",
+    "Trait",
+    "Impl",
+    "TypeAlias",
+    "Const",
+    "Static",
+    "Property",
+    "Record",
+    "Delegate",
+    "Annotation",
+    "Template",
+    "Route",
+    "Tool",
+    "Framework",
+]
+"""Canonical node labels recognised by the Astrolabe engine."""
+
+RELATIONSHIP_TYPES: list[str] = [
+    "CONTAINS",
+    "CALLS",
+    "EXTENDS",
+    "METHOD_OVERRIDES",
+    "METHOD_IMPLEMENTS",
+    "IMPORTS",
+    "USES",
+    "DEFINES",
+    "DECORATES",
+    "IMPLEMENTS",
+    "HAS_METHOD",
+    "HAS_PROPERTY",
+    "ACCESSES",
+    "MEMBER_OF",
+    "STEP_IN_PROCESS",
+    "HANDLES_ROUTE",
+    "FETCHES",
+    "HANDLES_TOOL",
+    "ENTRY_POINT_OF",
+    "WRAPS",
+    "QUERIES",
+    "USES_FRAMEWORK",
+    "RETURNS_TYPE",
+    "DECLARES_TYPE",
+    "CHAINABLE_TO",
+]
+"""Canonical directed-edge types in the Astrolabe knowledge graph."""
+
+# ---------------------------------------------------------------------------
+# Helper — safe table existence check
+# ---------------------------------------------------------------------------
+
+
+def _table_exists(cursor: sqlite3.Cursor, table_name: str) -> bool:
+    """Return ``True`` when *table_name* exists in the connected database."""
+    cursor.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (table_name,),
+    )
+    return cursor.fetchone() is not None
+
+
+# ---------------------------------------------------------------------------
+# Core data structure
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CodeGraph:
+    """In-memory representation of a single Astrolabe knowledge graph.
+
+    Attributes
+    ----------
+    nodes:
+        DataFrame with one row per graph node.  The ``properties`` JSON column
+        from the SQLite ``nodes`` table is expanded into individual columns
+        (``name``, ``filePath``, ``startLine``, …).
+    edges:
+        DataFrame with one row per directed relationship.
+    embeddings:
+        DataFrame with one row per embedded node.  The ``vector`` BLOB is
+        decoded into a NumPy ``float32`` array stored in the ``vector`` column.
+    metrics:
+        DataFrame with one row per node metric entry (may be empty when the
+        source database has no ``metrics`` table).
+    health:
+        Health-check dictionary extracted from the ``meta`` table (key
+        ``"health"``).  Empty dict when absent.
+    graphlets:
+        Graphlet summary extracted from the ``meta`` table (key
+        ``"graphlets"``).  Empty dict when absent.
+    metadata:
+        Catch-all dict with remaining ``meta`` key/value pairs (excludes
+        ``"health"`` and ``"graphlets"``).
+    """
+
+    nodes: pd.DataFrame
+    edges: pd.DataFrame
+    embeddings: pd.DataFrame
+    metrics: pd.DataFrame
+    health: dict[str, object] = field(default_factory=dict)
+    graphlets: dict[str, object] = field(default_factory=dict)
+    metadata: dict[str, object] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Internal table loaders
+# ---------------------------------------------------------------------------
+
+_PROPERTY_COLUMNS: list[str] = [
+    "name",
+    "filePath",
+    "startLine",
+    "endLine",
+    "language",
+    "isExported",
+    "visibility",
+    "parameterCount",
+    "level",
+    "returnType",
+    "isStatic",
+    "isReadonly",
+    "isAbstract",
+    "isAsync",
+    "keywords",
+    "description",
+    "heuristicLabel",
+    "cohesion",
+    "symbolCount",
+]
+"""Columns expected inside the ``properties`` JSON blob of the ``nodes`` table."""
+
+
+def _load_nodes(cursor: sqlite3.Cursor) -> pd.DataFrame:
+    """Load the ``nodes`` table, expanding its ``properties`` JSON column.
+
+    Returns an empty DataFrame with the expected columns when the table does
+    not exist.
+    """
+    if not _table_exists(cursor, "nodes"):
+        cols = ["id", "label"] + _PROPERTY_COLUMNS
+        return pd.DataFrame(columns=cols)
+
+    cursor.execute("SELECT id, label, properties FROM nodes")
+    rows: list[tuple[str, str, dict[str, object]]] = []
+    for node_id, label, raw_props in cursor.fetchall():
+        props: dict[str, object] = json.loads(raw_props) if raw_props else {}
+        rows.append((node_id, label, props))
+
+    if not rows:
+        cols = ["id", "label"] + _PROPERTY_COLUMNS
+        return pd.DataFrame(columns=cols)
+
+    df = pd.DataFrame(rows, columns=["id", "label", "properties"])
+    props_df = pd.json_normalize(df["properties"]).reindex(
+        columns=_PROPERTY_COLUMNS
+    )
+    df = pd.concat(
+        [df.drop(columns=["properties"]), props_df],
+        axis=1,
+    )
+    return df
+
+
+def _load_edges(cursor: sqlite3.Cursor) -> pd.DataFrame:
+    """Load the ``relationships`` table as a DataFrame."""
+    if not _table_exists(cursor, "relationships"):
+        return pd.DataFrame(
+            columns=[
+                "id",
+                "source_id",
+                "target_id",
+                "type",
+                "confidence",
+                "reason",
+                "step",
+                "evidence",
+            ]
+        )
+
+    cursor.execute(
+        "SELECT id, source_id, target_id, type, confidence, reason, step, evidence "
+        "FROM relationships"
+    )
+    records = cursor.fetchall()
+    if not records:
+        return pd.DataFrame(
+            columns=[
+                "id",
+                "source_id",
+                "target_id",
+                "type",
+                "confidence",
+                "reason",
+                "step",
+                "evidence",
+            ]
+        )
+
+    df = pd.DataFrame(
+        records,
+        columns=[
+            "id",
+            "source_id",
+            "target_id",
+            "type",
+            "confidence",
+            "reason",
+            "step",
+            "evidence",
+        ],
+    )
+    return df
+
+
+def _load_embeddings(cursor: sqlite3.Cursor) -> pd.DataFrame:
+    """Load the ``embeddings`` table, decoding BLOB vectors to float32 arrays."""
+    if not _table_exists(cursor, "embeddings"):
+        return pd.DataFrame(
+            columns=["node_id", "hash", "vector", "dims", "indexed_at"]
+        )
+
+    cursor.execute(
+        "SELECT node_id, hash, vector, dims, indexed_at FROM embeddings"
+    )
+    rows = cursor.fetchall()
+    if not rows:
+        return pd.DataFrame(
+            columns=["node_id", "hash", "vector", "dims", "indexed_at"]
+        )
+
+    decoded: list[tuple[str, str, np.ndarray, int, int]] = []
+    for node_id, hash_val, blob, dims, indexed_at in rows:
+        vec = np.frombuffer(blob, dtype=np.float32) if blob else np.array([], dtype=np.float32)
+        decoded.append((node_id, hash_val, vec, dims, indexed_at))
+
+    df = pd.DataFrame(
+        decoded,
+        columns=["node_id", "hash", "vector", "dims", "indexed_at"],
+    )
+    return df
+
+
+def _load_metrics(cursor: sqlite3.Cursor) -> pd.DataFrame:
+    """Load the ``metrics`` table (optional — may not exist)."""
+    if not _table_exists(cursor, "metrics"):
+        return pd.DataFrame()
+
+    cursor.execute("SELECT * FROM metrics")
+    rows = cursor.fetchall()
+    if not rows:
+        return pd.DataFrame()
+
+    col_names = [desc[0] for desc in cursor.description]
+    return pd.DataFrame(rows, columns=col_names)
+
+
+def _load_meta(cursor: sqlite3.Cursor) -> dict[str, object]:
+    """Load the ``meta`` table into a plain dict."""
+    if not _table_exists(cursor, "meta"):
+        return {}
+
+    cursor.execute("SELECT key, value FROM meta")
+    raw: dict[str, str] = dict(cursor.fetchall())
+
+    parsed: dict[str, object] = {}
+    for key, value in raw.items():
+        try:
+            parsed[key] = json.loads(value)
+        except (json.JSONDecodeError, TypeError):
+            parsed[key] = value
+    return parsed
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def _open_connection(db_path: str | Path) -> sqlite3.Connection:
+    """Open a SQLite connection with WAL journal mode.
+
+    Parameters
+    ----------
+    db_path:
+        Path to the ``.db`` file.
+
+    Returns
+    -------
+    sqlite3.Connection
+        An open connection with ``PRAGMA journal_mode`` set to ``WAL``.
+    """
+    path = Path(db_path).resolve()
+    conn = sqlite3.connect(str(path))
+    conn.execute("PRAGMA journal_mode=WAL")
+    return conn
+
+
+def load_graph(db_path: str | Path) -> CodeGraph:
+    """Load a single Astrolabe SQLite database into a :class:`CodeGraph`.
+
+    Missing tables are handled gracefully — the corresponding DataFrame will
+    be empty (or the dict empty for health/graphlets/metadata).
+
+    Parameters
+    ----------
+    db_path:
+        Filesystem path to the ``.db`` file produced by ``astrolabe analyze``.
+
+    Returns
+    -------
+    CodeGraph
+        A fully-populated graph data object.
+
+    Raises
+    ------
+    FileNotFoundError
+        When *db_path* does not point to an existing file.
+    sqlite3.OperationalError
+        When the file is not a valid SQLite database.
+    """
+    path = Path(db_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Database not found: {path}")
+
+    conn = _open_connection(path)
+    try:
+        cursor = conn.cursor()
+
+        nodes = _load_nodes(cursor)
+        edges = _load_edges(cursor)
+        embeddings = _load_embeddings(cursor)
+        metrics = _load_metrics(cursor)
+
+        meta = _load_meta(cursor)
+        health: dict[str, object] = meta.pop("health", {}) or {}
+        graphlets: dict[str, object] = meta.pop("graphlets", {}) or {}
+
+        return CodeGraph(
+            nodes=nodes,
+            edges=edges,
+            embeddings=embeddings,
+            metrics=metrics,
+            health=health,
+            graphlets=graphlets,
+            metadata=meta,
+        )
+    finally:
+        conn.close()
+
+
+def load_graphs(db_paths: list[str | Path]) -> list[CodeGraph]:
+    """Load multiple Astrolabe SQLite databases into a list of :class:`CodeGraph` objects.
+
+    Each path is loaded independently; a failure on one path will **not**
+    prevent the remaining paths from being loaded.  Paths that raise an
+    exception are silently skipped — callers should verify the returned list
+    length if strictness is required.
+
+    Parameters
+    ----------
+    db_paths:
+        Iterable of filesystem paths to ``.db`` files.
+
+    Returns
+    -------
+    list[CodeGraph]
+        One :class:`CodeGraph` per successfully loaded database, preserving
+        the input order.
+    """
+    graphs: list[CodeGraph] = []
+    for path in db_paths:
+        try:
+            graphs.append(load_graph(path))
+        except (FileNotFoundError, sqlite3.OperationalError):
+            continue
+    return graphs
+
+
+def list_available_graphs(db_path: str | Path) -> dict[str, object]:
+    """Return metadata about a graph database without loading full DataFrames.
+
+    This is a lightweight inspection function that reads only the ``meta``
+    table and counts rows in the main tables, making it suitable for
+    cataloguing large collections of databases.
+
+    Parameters
+    ----------
+    db_path:
+        Filesystem path to the ``.db`` file.
+
+    Returns
+    -------
+    dict[str, object]
+        A dictionary with the following keys:
+
+        - ``"meta"`` — all key/value pairs from the ``meta`` table.
+        - ``"tables"`` — mapping of table name → row count for every
+          user table found in the database.
+        - ``"path"`` — resolved absolute path of the database file.
+
+    Raises
+    ------
+    FileNotFoundError
+        When *db_path* does not point to an existing file.
+    """
+    path = Path(db_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Database not found: {path}")
+
+    conn = _open_connection(path)
+    try:
+        cursor = conn.cursor()
+
+        # Table row counts
+        cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+        )
+        table_names = [row[0] for row in cursor.fetchall()]
+        tables: dict[str, int] = {}
+        for tbl in table_names:
+            try:
+                cursor.execute(f'SELECT COUNT(*) FROM "{tbl}"')
+                tables[tbl] = cursor.fetchone()[0]
+            except sqlite3.OperationalError:
+                tables[tbl] = 0
+
+        meta = _load_meta(cursor)
+
+        return {
+            "meta": meta,
+            "tables": tables,
+            "path": str(path.resolve()),
+        }
+    finally:
+        conn.close()

--- a/packages/astrolabe-datasets/astrolabe_datasets/cugraph_backend.py
+++ b/packages/astrolabe-datasets/astrolabe_datasets/cugraph_backend.py
@@ -1,0 +1,759 @@
+"""NVIDIA RAPIDS cuGraph GPU backend for Astrolabe knowledge graphs.
+
+This module provides :class:`CugraphBackend`, a GPU-accelerated graph analytics
+backend that wraps `cuGraph <https://docs.rapids.ai/api/cugraph/stable/>`_
+algorithms around Astrolabe knowledge-graph DataFrames.
+
+All ``cudf`` / ``cugraph`` imports are deferred to function level so the module
+can be imported safely on CPU-only machines.  Calling any GPU method without the
+required packages raises :class:`ImportError` with installation instructions.
+
+Typical usage
+-------------
+::
+
+    from astrolabe_datasets.core import load_graph
+    from astrolabe_datasets.cugraph_backend import CugraphBackend
+
+    cg = load_graph("path/to/graph.db")
+    backend = CugraphBackend(nodes_df=cg.nodes, edges_df=cg.edges,
+                             embeddings_df=cg.embeddings, metrics_df=cg.metrics)
+
+    pr = backend.pagerank()
+    communities = backend.leiden(resolution=1.5)
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pandas as pd
+
+if TYPE_CHECKING:
+    import cudf
+    import cugraph
+
+# ---------------------------------------------------------------------------
+# Availability guard helper
+# ---------------------------------------------------------------------------
+
+_CUGRAPH_INSTALL_MSG = (
+    "cuGraph/cuDF is not installed. "
+    "Install with:  pip install cudf>=24.0 cugraph>=24.0  "
+    "(requires NVIDIA GPU + RAPIDS environment). "
+    "See https://rapids.ai/ for setup instructions."
+)
+
+
+def _require_cugraph() -> None:
+    """Raise ImportError if ``cudf`` or ``cugraph`` is not available."""
+    try:
+        import cudf  # noqa: F401
+        import cugraph  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(_CUGRAPH_INSTALL_MSG) from exc
+
+
+# ---------------------------------------------------------------------------
+# Backend class
+# ---------------------------------------------------------------------------
+
+
+class CugraphBackend:
+    """GPU-accelerated cuGraph backend for an Astrolabe knowledge graph.
+
+    Wraps a collection of ``pandas`` DataFrames (nodes, edges, embeddings,
+    metrics) and exposes cuGraph analytics as methods that return ``cudf``
+    objects.
+
+    Parameters
+    ----------
+    nodes_df:
+        DataFrame with one row per graph node.  Expected columns include
+        ``id``, ``label``, ``name``, ``filePath``, ``startLine``, ``endLine``,
+        ``language``, ``isExported``, ``visibility``, ``parameterCount``,
+        ``isAsync``, ``isStatic``.
+    edges_df:
+        DataFrame with one row per directed edge.  Expected columns include
+        ``id``, ``source_id``, ``target_id``, ``type``, ``confidence``,
+        ``reason``, ``step``.
+    embeddings_df:
+        Optional DataFrame with one row per embedded node.  Expected columns:
+        ``node_id``, ``hash``, ``vector``, ``dims``.
+    metrics_df:
+        Optional DataFrame with one row per node metric entry.  Expected
+        columns: ``node_id``, ``pagerank``, ``betweenness``, ``community_id``,
+        ``cohesion``.
+
+    Notes
+    -----
+    Construction does **not** require a GPU — DataFrames are stored as regular
+    ``pandas`` objects and only converted to ``cudf`` when a GPU method is
+    called.
+    """
+
+    def __init__(
+        self,
+        nodes_df: pd.DataFrame,
+        edges_df: pd.DataFrame,
+        embeddings_df: pd.DataFrame | None = None,
+        metrics_df: pd.DataFrame | None = None,
+    ) -> None:
+        self._nodes_df: pd.DataFrame = nodes_df.reset_index(drop=True)
+        self._edges_df: pd.DataFrame = edges_df.reset_index(drop=True)
+        self._embeddings_df: pd.DataFrame | None = (
+            embeddings_df.reset_index(drop=True) if embeddings_df is not None else None
+        )
+        self._metrics_df: pd.DataFrame | None = (
+            metrics_df.reset_index(drop=True) if metrics_df is not None else None
+        )
+
+        # Build a stable mapping from string node IDs to integer indices.
+        # cuGraph requires integer vertex identifiers.
+        self._node_id_map: dict[str, int] = {}
+        self._int_to_node_id: dict[int, str] = {}
+        self._build_id_map()
+
+        # Lazily-constructed cuGraph graph (rebuilt after mutations).
+        self._graph: cugraph.Graph | None = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _build_id_map(self) -> None:
+        """Create bi-directional string↔int ID mapping from the nodes DataFrame."""
+        if self._nodes_df.empty or "id" not in self._nodes_df.columns:
+            return
+        for idx, node_id in enumerate(self._nodes_df["id"].astype(str)):
+            self._node_id_map[str(node_id)] = idx
+            self._int_to_node_id[idx] = str(node_id)
+
+    def _ensure_id_columns(self) -> None:
+        """Guarantee that ``src`` and ``dst`` integer columns exist on the edge DataFrame."""
+        if "src" in self._edges_df.columns and "dst" in self._edges_df.columns:
+            return
+        if self._edges_df.empty:
+            self._edges_df = self._edges_df.copy()
+            self._edges_df["src"] = pd.Series(dtype="int32")
+            self._edges_df["dst"] = pd.Series(dtype="int32")
+            return
+
+        src_col = self._edges_df["source_id"].astype(str).map(self._node_id_map)
+        dst_col = self._edges_df["target_id"].astype(str).map(self._node_id_map)
+
+        # Edges referencing unknown nodes are dropped.
+        valid_mask = src_col.notna() & dst_col.notna()
+        self._edges_df = self._edges_df.loc[valid_mask].copy()
+        self._edges_df["src"] = src_col.loc[valid_mask].astype("int32")
+        self._edges_df["dst"] = dst_col.loc[valid_mask].astype("int32")
+
+    def _vertices_cudf(self) -> cudf.DataFrame:
+        """Return a ``cudf`` DataFrame of vertices with a ``NODETYPE`` column."""
+        import cudf as cudf_mod
+
+        if self._nodes_df.empty:
+            return cudf_mod.DataFrame({"vertex": pd.Series(dtype="int32")})
+
+        df = self._nodes_df.copy()
+        df["vertex"] = df["id"].astype(str).map(self._node_id_map)
+        df = df.dropna(subset=["vertex"])
+        df["vertex"] = df["vertex"].astype("int32")
+
+        # NODETYPE column — uses the ``label`` column if present.
+        if "label" in df.columns:
+            df = df.rename(columns={"label": "NODETYPE"})
+        else:
+            df["NODETYPE"] = pd.Series(dtype="str")
+
+        keep_cols = ["vertex", "NODETYPE"] + [
+            c for c in ["name", "filePath", "startLine", "endLine", "language"]
+            if c in df.columns
+        ]
+        return cudf_mod.DataFrame(df[keep_cols])
+
+    def _edges_cudf(self) -> cudf.DataFrame:
+        """Return a ``cudf`` DataFrame of edges with ``src``, ``dst``, and ``EDGETYPE``."""
+        import cudf as cudf_mod
+
+        self._ensure_id_columns()
+
+        if self._edges_df.empty:
+            return cudf_mod.DataFrame({
+                "src": pd.Series(dtype="int32"),
+                "dst": pd.Series(dtype="int32"),
+                "EDGETYPE": pd.Series(dtype="str"),
+            })
+
+        df = self._edges_df[["src", "dst"]].copy()
+
+        # EDGETYPE column — uses the ``type`` column if present.
+        if "type" in self._edges_df.columns:
+            df["EDGETYPE"] = self._edges_df["type"].values
+        else:
+            df["EDGETYPE"] = pd.Series(dtype="str", index=df.index)
+
+        return cudf_mod.DataFrame(df)
+
+    # ------------------------------------------------------------------
+    # Graph construction
+    # ------------------------------------------------------------------
+
+    def to_cugraph(self) -> cugraph.Graph:
+        """Build a ``cugraph.Graph`` property graph from the stored DataFrames.
+
+        The returned graph has:
+
+        * **Vertex properties** — a ``NODETYPE`` column derived from the
+          ``label`` column of the nodes DataFrame.
+        * **Edge properties** — an ``EDGETYPE`` column derived from the
+          ``type`` column of the edges DataFrame.
+
+        The graph is cached and reused on subsequent calls unless the
+        underlying DataFrames have been mutated (in which case call this
+        method again to rebuild).
+
+        Returns
+        -------
+        cugraph.Graph
+            A directed property graph suitable for cuGraph algorithms.
+
+        Raises
+        ------
+        ImportError
+            If ``cudf`` or ``cugraph`` is not installed.
+        """
+        _require_cugraph()
+        import cugraph as cugraph_mod
+
+        if self._graph is not None:
+            return self._graph
+
+        verts = self._vertices_cudf()
+        edgs = self._edges_cudf()
+
+        g = cugraph_mod.Graph(directed=True)
+        g.from_cudf_edgelist(
+            edgs,
+            source="src",
+            destination="dst",
+            edge_attr="EDGETYPE" if "EDGETYPE" in edgs.columns else None,
+        )
+
+        # Add isolated vertices that have no edges.
+        if not verts.empty and "vertex" in verts.columns:
+            existing = set(g.nodes().to_arrow().to_pylist()) if g.number_of_nodes() > 0 else set()
+            all_verts = set(verts["vertex"].to_arrow().to_pylist())
+            isolated = all_verts - existing
+            if isolated:
+                import cudf as cudf_mod
+
+                iso_df = cudf_mod.DataFrame({
+                    "src": list(isolated),
+                    "dst": list(isolated),
+                })
+                g.add_edge_list(iso_df)
+
+        self._graph = g
+        return g
+
+    # ------------------------------------------------------------------
+    # Community detection
+    # ------------------------------------------------------------------
+
+    def leiden(self, resolution: float = 1.0) -> cudf.Series:
+        """Leiden community detection on the knowledge graph.
+
+        Parameters
+        ----------
+        resolution:
+            Resolution parameter controlling community granularity.
+            Higher values produce more, smaller communities.
+
+        Returns
+        -------
+        cudf.Series
+            Community partition assignment indexed by vertex integer ID.
+
+        Raises
+        ------
+        ImportError
+            If ``cudf`` or ``cugraph`` is not installed.
+        ValueError
+            If the graph has fewer than two vertices.
+        """
+        _require_cugraph()
+        import cugraph as cugraph_mod
+
+        g = self.to_cugraph()
+        if g.number_of_nodes() < 2:
+            import cudf as cudf_mod
+
+            return cudf_mod.Series(dtype="int32")
+
+        parts = cugraph_mod.leiden(g, resolution=resolution)
+        return parts.sort_values("vertex").set_index("vertex")["partition"]
+
+    def louvain(self, resolution: float = 1.0) -> cudf.Series:
+        """Louvain community detection on the knowledge graph.
+
+        Parameters
+        ----------
+        resolution:
+            Resolution parameter controlling community granularity.
+            Higher values produce more, smaller communities.
+
+        Returns
+        -------
+        cudf.Series
+            Community partition assignment indexed by vertex integer ID.
+
+        Raises
+        ------
+        ImportError
+            If ``cudf`` or ``cugraph`` is not installed.
+        ValueError
+            If the graph has fewer than two vertices.
+        """
+        _require_cugraph()
+        import cugraph as cugraph_mod
+
+        g = self.to_cugraph()
+        if g.number_of_nodes() < 2:
+            import cudf as cudf_mod
+
+            return cudf_mod.Series(dtype="int32")
+
+        parts, _mod = cugraph_mod.louvain(g, resolution=resolution)
+        return parts.sort_values("vertex").set_index("vertex")["partition"]
+
+    # ------------------------------------------------------------------
+    # Centrality
+    # ------------------------------------------------------------------
+
+    def pagerank(
+        self,
+        damping: float = 0.85,
+        max_iter: int = 100,
+    ) -> cudf.Series:
+        """PageRank centrality on the knowledge graph.
+
+        Parameters
+        ----------
+        damping:
+            Damping (teleportation) factor.  Typical value is 0.85.
+        max_iter:
+            Maximum number of iterations.
+
+        Returns
+        -------
+        cudf.Series
+            PageRank scores indexed by vertex integer ID.
+
+        Raises
+        ------
+        ImportError
+            If ``cudf`` or ``cugraph`` is not installed.
+        """
+        _require_cugraph()
+        import cugraph as cugraph_mod
+
+        g = self.to_cugraph()
+        if g.number_of_nodes() == 0:
+            import cudf as cudf_mod
+
+            return cudf_mod.Series(dtype="float64")
+
+        pr = cugraph_mod.pagerank(g, damping=damping, max_iter=max_iter)
+        return pr.sort_values("vertex").set_index("vertex")["pagerank"]
+
+    def katz_centrality(self, alpha: float = 0.1) -> cudf.Series:
+        """Katz centrality on the knowledge graph.
+
+        Parameters
+        ----------
+        alpha:
+            Attenuation factor.  Must be smaller than the reciprocal of the
+            largest eigenvalue of the adjacency matrix.
+
+        Returns
+        -------
+        cudf.Series
+            Katz centrality scores indexed by vertex integer ID.
+
+        Raises
+        ------
+        ImportError
+            If ``cudf`` or ``cugraph`` is not installed.
+        """
+        _require_cugraph()
+        import cugraph as cugraph_mod
+
+        g = self.to_cugraph()
+        if g.number_of_nodes() == 0:
+            import cudf as cudf_mod
+
+            return cudf_mod.Series(dtype="float64")
+
+        kc = cugraph_mod.katz_centrality(g, alpha=alpha)
+        return kc.sort_values("vertex").set_index("vertex")["katz_centrality"]
+
+    def hits(
+        self,
+        max_iter: int = 100,
+    ) -> tuple[cudf.Series, cudf.Series]:
+        """HITS (Hyperlink-Induced Topic Search) hubs and authorities.
+
+        Parameters
+        ----------
+        max_iter:
+            Maximum number of iterations.
+
+        Returns
+        -------
+        tuple[cudf.Series, cudf.Series]
+            ``(hubs, authorities)`` — each indexed by vertex integer ID.
+
+        Raises
+        ------
+        ImportError
+            If ``cudf`` or ``cugraph`` is not installed.
+        """
+        _require_cugraph()
+        import cugraph as cugraph_mod
+
+        g = self.to_cugraph()
+        if g.number_of_nodes() == 0:
+            import cudf as cudf_mod
+
+            empty = cudf_mod.Series(dtype="float64")
+            return empty, empty
+
+        hubs_df, auth_df = cugraph_mod.hits(g, max_iter=max_iter)
+        hubs = hubs_df.sort_values("vertex").set_index("vertex")["hits_hub"]
+        auth = auth_df.sort_values("vertex").set_index("vertex")["hits_auth"]
+        return hubs, auth
+
+    # ------------------------------------------------------------------
+    # Shortest path
+    # ------------------------------------------------------------------
+
+    def sssp(self, source: int | str) -> cudf.DataFrame:
+        """Single-source shortest path from *source*.
+
+        Parameters
+        ----------
+        source:
+            Source vertex.  Pass either an integer vertex ID or a string
+            node identifier (which is mapped to the internal integer index).
+
+        Returns
+        -------
+        cudf.DataFrame
+            DataFrame with columns ``vertex``, ``distance``, ``predecessor``.
+
+        Raises
+        ------
+        ImportError
+            If ``cudf`` or ``cugraph`` is not installed.
+        KeyError
+            If *source* is a string that does not map to a known node ID.
+        """
+        _require_cugraph()
+        import cugraph as cugraph_mod
+
+        g = self.to_cugraph()
+        if g.number_of_nodes() == 0:
+            import cudf as cudf_mod
+
+            return cudf_mod.DataFrame({
+                "vertex": pd.Series(dtype="int32"),
+                "distance": pd.Series(dtype="float64"),
+                "predecessor": pd.Series(dtype="int32"),
+            })
+
+        src_int = self._resolve_vertex(source)
+        return cugraph_mod.sssp(g, source=src_int)
+
+    # ------------------------------------------------------------------
+    # Link prediction
+    # ------------------------------------------------------------------
+
+    def jaccard(self, pairs: cudf.DataFrame | None = None) -> cudf.DataFrame:
+        """Jaccard similarity coefficient for link prediction.
+
+        Parameters
+        ----------
+        pairs:
+            Optional ``cudf`` DataFrame with ``first`` and ``second`` columns
+            specifying vertex pairs.  When ``None``, Jaccard is computed for
+            all vertex pairs connected by at least one edge in the graph.
+
+        Returns
+        -------
+        cudf.DataFrame
+            DataFrame with columns ``first``, ``second``, ``jaccard_coeff``.
+
+        Raises
+        ------
+        ImportError
+            If ``cudf`` or ``cugraph`` is not installed.
+        """
+        _require_cugraph()
+        import cugraph as cugraph_mod
+
+        g = self.to_cugraph()
+        if g.number_of_nodes() < 2:
+            import cudf as cudf_mod
+
+            return cudf_mod.DataFrame({
+                "first": pd.Series(dtype="int32"),
+                "second": pd.Series(dtype="int32"),
+                "jaccard_coeff": pd.Series(dtype="float64"),
+            })
+
+        if pairs is not None:
+            return cugraph_mod.jaccard(g, input_df=pairs)
+
+        return cugraph_mod.jaccard(g)
+
+    # ------------------------------------------------------------------
+    # Random walks
+    # ------------------------------------------------------------------
+
+    def node2vec(
+        self,
+        start_vertices: list[int] | list[str],
+        max_depth: int = 5,
+        walk_length: int = 100,
+    ) -> cudf.DataFrame:
+        """Node2Vec-biased random walks for graph embedding.
+
+        Parameters
+        ----------
+        start_vertices:
+            List of starting vertices (integer IDs or string node identifiers).
+        max_depth:
+            Maximum walk depth.
+        walk_length:
+            Number of steps per walk.
+
+        Returns
+        -------
+        cudf.DataFrame
+            DataFrame with one row per walk, columns ``vertex``, ``path``.
+
+        Raises
+        ------
+        ImportError
+            If ``cudf`` or ``cugraph`` is not installed.
+        KeyError
+            If any start vertex string does not map to a known node ID.
+        """
+        _require_cugraph()
+        import cudf as cudf_mod
+        import cugraph as cugraph_mod
+
+        g = self.to_cugraph()
+        if g.number_of_nodes() == 0:
+            return cudf_mod.DataFrame({
+                "vertex": pd.Series(dtype="int32"),
+                "path": pd.Series(dtype="object"),
+            })
+
+        resolved = [self._resolve_vertex(v) for v in start_vertices]
+        starts = cudf_mod.Series(resolved, dtype="int32")
+
+        return cugraph_mod.node2vec(
+            g,
+            start_vertices=starts,
+            max_depth=max_depth,
+            walk_length=walk_length,
+        )
+
+    # ------------------------------------------------------------------
+    # PyG integration
+    # ------------------------------------------------------------------
+
+    def to_pyg_feature_store(self) -> object:
+        """Create a ``cugraph_pyg`` FeatureStore + GraphStore for PyG training.
+
+        Returns an object with ``feature_store`` and ``graph_store`` attributes
+        suitable for use with PyTorch-Geometric data loading pipelines.
+
+        Returns
+        -------
+        object
+            A namespace with ``feature_store`` and ``graph_store`` attributes.
+
+        Raises
+        ------
+        ImportError
+            If ``cugraph_pyg``, ``cudf``, or ``cugraph`` is not installed.
+        """
+        try:
+            import cugraph_pyg  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "cugraph_pyg is not installed. "
+                "Install with:  pip install cugraph-pyg>=24.0  "
+                "(requires NVIDIA GPU + RAPIDS environment). "
+                "See https://docs.rapids.ai/api/cugraph/stable/pyg.html"
+            ) from exc
+
+        _require_cugraph()
+
+        import cugraph_pyg as cugraph_pyg_mod
+        import cudf as cudf_mod
+
+        g = self.to_cugraph()
+
+        # Build the PyG GraphStore from the cuGraph graph.
+        graph_store = cugraph_pyg_mod.GraphStore()
+        graph_store.add_cugraph_graph(g)
+
+        # Build the FeatureStore from the embeddings DataFrame if available.
+        feature_store = cugraph_pyg_mod.FeatureStore()
+
+        if self._embeddings_df is not None and not self._embeddings_df.empty:
+            emb_df = self._embeddings_df.copy()
+            if "node_id" in emb_df.columns and "vector" in emb_df.columns:
+                emb_df["vertex"] = (
+                    emb_df["node_id"].astype(str).map(self._node_id_map)
+                )
+                emb_df = emb_df.dropna(subset=["vertex"])
+                emb_df["vertex"] = emb_df["vertex"].astype("int32")
+
+                # Stack vector arrays into a 2-D tensor representation.
+                vectors = np.stack(emb_df["vector"].values)
+                feat_gdf = cudf_mod.DataFrame(vectors)
+                feat_gdf["vertex"] = emb_df["vertex"].values
+                feature_store.add_data(
+                    feat_gdf,
+                    type_name="node",
+                    feat_name="embedding",
+                )
+
+        class _PyGBundle:
+            """Simple namespace returned by :meth:`to_pyg_feature_store`."""
+
+            __slots__ = ("feature_store", "graph_store")
+
+            def __init__(
+                self,
+                feature_store: object,
+                graph_store: object,
+            ) -> None:
+                self.feature_store = feature_store
+                self.graph_store = graph_store
+
+        return _PyGBundle(feature_store=feature_store, graph_store=graph_store)
+
+    # ------------------------------------------------------------------
+    # Vertex resolution helper
+    # ------------------------------------------------------------------
+
+    def _resolve_vertex(self, vertex: int | str) -> int:
+        """Map a string node ID or integer to the internal integer index.
+
+        Parameters
+        ----------
+        vertex:
+            Integer vertex index (returned as-is) or string node identifier
+            looked up in ``_node_id_map``.
+
+        Returns
+        -------
+        int
+            The integer vertex index used by cuGraph.
+
+        Raises
+        ------
+        KeyError
+            If *vertex* is a string with no mapping.
+        """
+        if isinstance(vertex, int):
+            return vertex
+        if isinstance(vertex, str):
+            if vertex not in self._node_id_map:
+                raise KeyError(f"Unknown node ID: {vertex!r}")
+            return self._node_id_map[vertex]
+        msg = f"vertex must be int or str, got {type(vertex).__name__}"
+        raise TypeError(msg)
+
+    # ------------------------------------------------------------------
+    # Convenience: translate integer IDs back to string IDs
+    # ------------------------------------------------------------------
+
+    def int_to_node_id(self, vertex: int) -> str | None:
+        """Return the original string node ID for an integer vertex index.
+
+        Parameters
+        ----------
+        vertex:
+            Integer vertex index as used internally by cuGraph.
+
+        Returns
+        -------
+        str | None
+            Original string node ID, or ``None`` if the integer has no mapping.
+        """
+        return self._int_to_node_id.get(vertex)
+
+    def node_id_to_int(self, node_id: str) -> int | None:
+        """Return the integer vertex index for a string node ID.
+
+        Parameters
+        ----------
+        node_id:
+            Original string node identifier.
+
+        Returns
+        -------
+        int | None
+            Integer index, or ``None`` if the node ID has no mapping.
+        """
+        return self._node_id_map.get(node_id)
+
+
+# ---------------------------------------------------------------------------
+# Convenience loader
+# ---------------------------------------------------------------------------
+
+
+def from_sqlite(db_path: str | Path) -> CugraphBackend:
+    """Load an Astrolabe SQLite database into a :class:`CugraphBackend`.
+
+    This is a convenience function that reads the database via
+    :func:`astrolabe_datasets.core.load_graph` and wraps the result.
+
+    Parameters
+    ----------
+    db_path:
+        Filesystem path to the ``.db`` file produced by ``astrolabe analyze``.
+
+    Returns
+    -------
+    CugraphBackend
+        A backend instance ready for GPU-accelerated graph analytics.
+
+    Raises
+    ------
+    FileNotFoundError
+        When *db_path* does not point to an existing file.
+    ImportError
+        If ``cudf`` or ``cugraph`` is not available (raised lazily when a
+        GPU method is called, not at construction time).
+    """
+    from astrolabe_datasets.core import load_graph
+
+    cg = load_graph(db_path)
+    return CugraphBackend(
+        nodes_df=cg.nodes,
+        edges_df=cg.edges,
+        embeddings_df=cg.embeddings if not cg.embeddings.empty else None,
+        metrics_df=cg.metrics if not cg.metrics.empty else None,
+    )

--- a/packages/astrolabe-datasets/astrolabe_datasets/exporters.py
+++ b/packages/astrolabe-datasets/astrolabe_datasets/exporters.py
@@ -1,0 +1,397 @@
+"""Export functions for Astrolabe knowledge graphs to multiple formats.
+
+Supports OGB dict format (.npz), GraphML, GML, and flat CSV exports.
+Optional dependencies (networkx) are imported at function level to keep
+the core installation lightweight.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Collection
+
+import numpy as np
+import pandas as pd
+
+# Re-use canonical constants from core so OGB node_type / edge_type
+# integers are consistent with the same label/type ordering.
+from astrolabe_datasets.core import NODE_LABELS, RELATIONSHIP_TYPES
+
+__all__ = [
+    "export_ogb",
+    "export_graphml",
+    "export_gml",
+    "export_node_csv",
+    "export_edge_csv",
+    "export_all",
+]
+
+
+# ---------------------------------------------------------------------------
+# Helper — label / type → integer index
+# ---------------------------------------------------------------------------
+
+_NODE_LABEL_INDEX: dict[str, int] = {label: idx for idx, label in enumerate(NODE_LABELS)}
+_EDGE_TYPE_INDEX: dict[str, int] = {rtype: idx for idx, rtype in enumerate(RELATIONSHIP_TYPES)}
+
+
+# ---------------------------------------------------------------------------
+# OGB export
+# ---------------------------------------------------------------------------
+
+
+def export_ogb(
+    nodes_df: pd.DataFrame,
+    edges_df: pd.DataFrame,
+    embeddings_df: pd.DataFrame,
+    metrics_df: pd.DataFrame,
+    output_dir: str | Path,
+) -> Path:
+    """Export graph data to OGB dict format saved as ``.npz``.
+
+    The resulting file contains an OGB-compatible dictionary with the
+    following keys:
+
+    - ``node_feat`` – concatenated node feature matrix ``(N, F)``
+    - ``edge_feat`` – concatenated edge feature matrix ``(E, D)``
+    - ``edge_index`` – 2×E int64 array of source/target indices
+    - ``num_nodes`` – integer node count
+    - ``node_type`` – int32 label indices per node
+    - ``edge_type`` – int32 relationship type indices per edge
+
+    Parameters
+    ----------
+    nodes_df:
+        Nodes DataFrame (columns: id, label, …).
+    edges_df:
+        Edges DataFrame (columns: id, source_id, target_id, type, …).
+    embeddings_df:
+        Embeddings DataFrame (columns: node_id, hash, vector, dims).
+    metrics_df:
+        Metrics DataFrame (columns: node_id, pagerank, betweenness, …).
+    output_dir:
+        Directory to write the ``astrolabe_ogb.npz`` file into.
+
+    Returns
+    -------
+    Path
+        Path to the written ``.npz`` file.
+    """
+    # --- node index mapping ---------------------------------------------------
+    node_ids: list[str] = nodes_df["id"].tolist()
+    node_id_to_idx: dict[str, int] = {nid: idx for idx, nid in enumerate(node_ids)}
+
+    # --- node_type ------------------------------------------------------------
+    node_type = np.array(
+        [_NODE_LABEL_INDEX.get(label, 0) for label in nodes_df["label"]],
+        dtype=np.int32,
+    )
+
+    # --- node_feat (embeddings) -----------------------------------------------
+    emb_sorted = embeddings_df.set_index("node_id").reindex(node_ids)
+    vecs = emb_sorted["vector"].tolist()
+    # Handle missing embeddings — replace with zero vector
+    first_valid_dim: int = 0
+    for v in vecs:
+        if isinstance(v, np.ndarray) and v.size > 0:
+            first_valid_dim = v.shape[0]
+            break
+    if first_valid_dim == 0:
+        first_valid_dim = 1
+
+    node_feat_list: list[np.ndarray] = []
+    for v in vecs:
+        if isinstance(v, np.ndarray) and v.size > 0:
+            node_feat_list.append(v.astype(np.float32))
+        else:
+            node_feat_list.append(np.zeros(first_valid_dim, dtype=np.float32))
+    node_feat = np.stack(node_feat_list) if node_feat_list else np.empty((0, 0), dtype=np.float32)
+
+    # --- edge_index -----------------------------------------------------------
+    src_indices = edges_df["source_id"].map(node_id_to_idx)
+    tgt_indices = edges_df["target_id"].map(node_id_to_idx)
+
+    # Drop edges whose endpoints are not in the node set
+    valid_mask = src_indices.notna() & tgt_indices.notna()
+    src_arr = src_indices[valid_mask].to_numpy(dtype=np.int64)
+    tgt_arr = tgt_indices[valid_mask].to_numpy(dtype=np.int64)
+    edge_index = np.vstack([src_arr, tgt_arr])
+
+    # --- edge_type ------------------------------------------------------------
+    edge_type = np.array(
+        [_EDGE_TYPE_INDEX.get(t, 0) for t in edges_df.loc[valid_mask, "type"]],
+        dtype=np.int32,
+    )
+
+    # --- edge_feat (confidence + step) ----------------------------------------
+    confidence = edges_df.loc[valid_mask, "confidence"].fillna(0.0).to_numpy(dtype=np.float32)
+    step = edges_df.loc[valid_mask, "step"].fillna(0).to_numpy(dtype=np.float32)
+    # One-hot encode edge type
+    type_one_hot = np.zeros((len(edge_type), len(RELATIONSHIP_TYPES)), dtype=np.float32)
+    for row_idx, tidx in enumerate(edge_type):
+        type_one_hot[row_idx, tidx] = 1.0
+    edge_feat = np.hstack([
+        confidence.reshape(-1, 1),
+        step.reshape(-1, 1),
+        type_one_hot,
+    ])
+
+    # --- assemble & save ------------------------------------------------------
+    out_path = Path(output_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+    npz_path = out_path / "astrolabe_ogb.npz"
+
+    np.savez(
+        npz_path,
+        node_feat=node_feat,
+        edge_feat=edge_feat,
+        edge_index=edge_index,
+        num_nodes=np.array([len(node_ids)], dtype=np.int64),
+        node_type=node_type,
+        edge_type=edge_type,
+    )
+    return npz_path
+
+
+# ---------------------------------------------------------------------------
+# GraphML export
+# ---------------------------------------------------------------------------
+
+
+def export_graphml(
+    nodes_df: pd.DataFrame,
+    edges_df: pd.DataFrame,
+    output_path: str | Path,
+) -> Path:
+    """Export graph data to GraphML format via NetworkX.
+
+    NetworkX is imported lazily so that callers who do not need GraphML
+    do not have to install it.
+
+    Parameters
+    ----------
+    nodes_df:
+        Nodes DataFrame (columns: id, label, …).
+    edges_df:
+        Edges DataFrame (columns: id, source_id, target_id, type, …).
+    output_path:
+        Destination file path (should end with ``.graphml``).
+
+    Returns
+    -------
+    Path
+        Path to the written GraphML file.
+
+    Raises
+    ------
+    ImportError
+        When ``networkx`` is not installed.
+    """
+    import networkx as nx  # noqa: PLC0415 — lazy import
+
+    G = nx.DiGraph()
+
+    for _, row in nodes_df.iterrows():
+        attrs = {k: v for k, v in row.items() if k != "id" and pd.notna(v)}
+        G.add_node(str(row["id"]), **attrs)
+
+    for _, row in edges_df.iterrows():
+        attrs = {k: v for k, v in row.items() if k not in ("id", "source_id", "target_id") and pd.notna(v)}
+        G.add_edge(str(row["source_id"]), str(row["target_id"]), **attrs)
+
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    nx.write_graphml(G, str(out))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# GML export
+# ---------------------------------------------------------------------------
+
+
+def export_gml(
+    nodes_df: pd.DataFrame,
+    edges_df: pd.DataFrame,
+    output_path: str | Path,
+) -> Path:
+    """Export graph data to GML format via NetworkX.
+
+    NetworkX is imported lazily so that callers who do not need GML
+    do not have to install it.
+
+    GML has limitations on attribute keys (must be valid Python
+    identifiers).  Non-conforming keys are silently skipped.
+
+    Parameters
+    ----------
+    nodes_df:
+        Nodes DataFrame (columns: id, label, …).
+    edges_df:
+        Edges DataFrame (columns: id, source_id, target_id, type, …).
+    output_path:
+        Destination file path (should end with ``.gml``).
+
+    Returns
+    -------
+    Path
+        Path to the written GML file.
+
+    Raises
+    ------
+    ImportError
+        When ``networkx`` is not installed.
+    """
+    import networkx as nx  # noqa: PLC0415 — lazy import
+
+    G = nx.DiGraph()
+
+    for _, row in nodes_df.iterrows():
+        # GML allows only simple scalar attributes; filter accordingly.
+        attrs: dict[str, object] = {}
+        for k, v in row.items():
+            if k == "id" or pd.isna(v):
+                continue
+            if isinstance(v, (bool, int, float, str)):
+                attrs[str(k)] = v
+        G.add_node(str(row["id"]), **attrs)
+
+    for _, row in edges_df.iterrows():
+        attrs: dict[str, object] = {}  # type: ignore[no-redef]
+        for k, v in row.items():
+            if k in ("id", "source_id", "target_id") or pd.isna(v):
+                continue
+            if isinstance(v, (bool, int, float, str)):
+                attrs[str(k)] = v
+        G.add_edge(str(row["source_id"]), str(row["target_id"]), **attrs)
+
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    nx.write_gml(G, str(out))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# CSV exports
+# ---------------------------------------------------------------------------
+
+
+def export_node_csv(
+    nodes_df: pd.DataFrame,
+    output_path: str | Path,
+) -> Path:
+    """Export node data to a CSV file.
+
+    Parameters
+    ----------
+    nodes_df:
+        Nodes DataFrame.
+    output_path:
+        Destination file path (should end with ``.csv``).
+
+    Returns
+    -------
+    Path
+        Path to the written CSV file.
+    """
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    nodes_df.to_csv(out, index=False)
+    return out
+
+
+def export_edge_csv(
+    edges_df: pd.DataFrame,
+    output_path: str | Path,
+) -> Path:
+    """Export edge data to a CSV file.
+
+    Parameters
+    ----------
+    edges_df:
+        Edges DataFrame.
+    output_path:
+        Destination file path (should end with ``.csv``).
+
+    Returns
+    -------
+    Path
+        Path to the written CSV file.
+    """
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    edges_df.to_csv(out, index=False)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Multi-format export
+# ---------------------------------------------------------------------------
+
+_DEFAULT_FORMATS: tuple[str, ...] = ("ogb", "graphml", "gml", "node_csv", "edge_csv")
+
+
+def export_all(
+    nodes_df: pd.DataFrame,
+    edges_df: pd.DataFrame,
+    embeddings_df: pd.DataFrame,
+    metrics_df: pd.DataFrame,
+    output_dir: str | Path,
+    formats: Collection[str] | None = None,
+) -> dict[str, Path]:
+    """Export graph data to multiple formats in a single call.
+
+    Parameters
+    ----------
+    nodes_df:
+        Nodes DataFrame.
+    edges_df:
+        Edges DataFrame.
+    embeddings_df:
+        Embeddings DataFrame.
+    metrics_df:
+        Metrics DataFrame.
+    output_dir:
+        Directory to write all output files into.
+    formats:
+        Iterable of format names to export.  Supported values are
+        ``"ogb"``, ``"graphml"``, ``"gml"``, ``"node_csv"``, and
+        ``"edge_csv"``.  Defaults to all five.
+
+    Returns
+    -------
+    dict[str, Path]
+        Mapping from format name to the written file path.
+
+    Raises
+    ------
+    ImportError
+        When ``networkx`` is required but not installed (GraphML / GML).
+    ValueError
+        When an unsupported format name is requested.
+    """
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    if formats is None:
+        formats = _DEFAULT_FORMATS
+
+    results: dict[str, Path] = {}
+    for fmt in formats:
+        if fmt == "ogb":
+            results[fmt] = export_ogb(nodes_df, edges_df, embeddings_df, metrics_df, out)
+        elif fmt == "graphml":
+            results[fmt] = export_graphml(nodes_df, edges_df, out / "astrolabe.graphml")
+        elif fmt == "gml":
+            results[fmt] = export_gml(nodes_df, edges_df, out / "astrolabe.gml")
+        elif fmt == "node_csv":
+            results[fmt] = export_node_csv(nodes_df, out / "nodes.csv")
+        elif fmt == "edge_csv":
+            results[fmt] = export_edge_csv(edges_df, out / "edges.csv")
+        else:
+            raise ValueError(
+                f"Unsupported export format: {fmt!r}. "
+                f"Supported: {', '.join(_DEFAULT_FORMATS)}"
+            )
+    return results

--- a/packages/astrolabe-datasets/astrolabe_datasets/feature_engineering.py
+++ b/packages/astrolabe-datasets/astrolabe_datasets/feature_engineering.py
@@ -1,0 +1,431 @@
+"""Feature encoding and engineering for Astrolabe knowledge graph ML pipelines.
+
+Provides one-hot and ordinal encodings for node types, edge types,
+languages, and visibility, plus utilities to build full node/edge
+feature matrices suitable for downstream graph neural networks.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+__all__ = [
+    "SUPPORTED_LANGUAGES",
+    "NODE_LABELS",
+    "EDGE_TYPES",
+    "encode_node_type",
+    "encode_visibility",
+    "encode_language",
+    "build_node_features",
+    "build_edge_features",
+    "degree_features",
+    "normalize_features",
+]
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+SUPPORTED_LANGUAGES: list[str] = [
+    "typescript",
+    "javascript",
+    "tsx",
+    "python",
+    "java",
+    "go",
+    "rust",
+    "csharp",
+    "php",
+    "ruby",
+    "swift",
+    "c",
+    "cpp",
+    "dart",
+    "kotlin",
+    "scala",
+    "html",
+]
+"""Programming languages recognised by the Astrolabe engine."""
+
+NODE_LABELS: list[str] = [
+    "Project",
+    "Package",
+    "Module",
+    "Folder",
+    "File",
+    "Section",
+    "Class",
+    "Function",
+    "Method",
+    "Variable",
+    "Interface",
+    "Enum",
+    "Decorator",
+    "Import",
+    "Type",
+    "CodeElement",
+    "Struct",
+    "Constructor",
+    "Community",
+    "Process",
+    "Macro",
+    "Typedef",
+    "Union",
+    "Namespace",
+    "Trait",
+    "Impl",
+    "TypeAlias",
+    "Const",
+    "Static",
+    "Property",
+]
+"""Canonical node labels (30 classes) for one-hot encoding."""
+
+EDGE_TYPES: list[str] = [
+    "CONTAINS",
+    "CALLS",
+    "EXTENDS",
+    "METHOD_OVERRIDES",
+    "METHOD_IMPLEMENTS",
+    "IMPORTS",
+    "USES",
+    "DEFINES",
+    "DECORATES",
+    "IMPLEMENTS",
+    "HAS_METHOD",
+    "HAS_PROPERTY",
+    "ACCESSES",
+    "MEMBER_OF",
+    "STEP_IN_PROCESS",
+    "HANDLES_ROUTE",
+    "FETCHES",
+    "HANDLES_TOOL",
+    "ENTRY_POINT_OF",
+    "WRAPS",
+    "QUERIES",
+    "USES_FRAMEWORK",
+    "RETURNS_TYPE",
+    "DECLARES_TYPE",
+    "CHAINABLE_TO",
+]
+"""Canonical directed-edge types (25 types) for one-hot encoding."""
+
+# Pre-computed lookup maps for fast encoding
+_NODE_LABEL_INDEX: dict[str, int] = {label: idx for idx, label in enumerate(NODE_LABELS)}
+_EDGE_TYPE_INDEX: dict[str, int] = {etype: idx for idx, etype in enumerate(EDGE_TYPES)}
+_LANGUAGE_INDEX: dict[str, int] = {lang: idx for idx, lang in enumerate(SUPPORTED_LANGUAGES)}
+
+_VISIBILITY_ORDINAL: dict[str, int] = {"public": 0, "protected": 1, "private": 2}
+
+
+# ---------------------------------------------------------------------------
+# Encoding functions
+# ---------------------------------------------------------------------------
+
+
+def encode_node_type(label_series: pd.Series) -> np.ndarray:
+    """One-hot encode node labels into a ``(N, 30)`` float32 array.
+
+    Unknown labels are encoded as an all-zeros vector.
+
+    Parameters
+    ----------
+    label_series:
+        Series of node label strings (e.g. ``"Class"``, ``"Method"``).
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``(N, 30)`` float32 one-hot matrix.
+    """
+    n = len(label_series)
+    out = np.zeros((n, len(NODE_LABELS)), dtype=np.float32)
+    for i, label in enumerate(label_series):
+        idx = _NODE_LABEL_INDEX.get(label)
+        if idx is not None:
+            out[i, idx] = 1.0
+    return out
+
+
+def encode_visibility(visibility_series: pd.Series) -> np.ndarray:
+    """Ordinal-encode visibility into a ``(N,)`` int8 array.
+
+    Mapping: ``public`` → 0, ``protected`` → 1, ``private`` → 2.
+    Unrecognised or missing values default to ``0`` (public).
+
+    Parameters
+    ----------
+    visibility_series:
+        Series of visibility strings.
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``(N,)`` int8 ordinal array.
+    """
+    return visibility_series.fillna("public").map(
+        lambda v: _VISIBILITY_ORDINAL.get(v, 0)
+    ).to_numpy(dtype=np.int8)
+
+
+def encode_language(language_series: pd.Series) -> np.ndarray:
+    """One-hot encode programming languages into a ``(N, 17)`` float32 array.
+
+    Unknown languages are encoded as an all-zeros vector.
+
+    Parameters
+    ----------
+    language_series:
+        Series of language strings (e.g. ``"typescript"``, ``"python"``).
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``(N, 17)`` float32 one-hot matrix.
+    """
+    n = len(language_series)
+    out = np.zeros((n, len(SUPPORTED_LANGUAGES)), dtype=np.float32)
+    for i, lang in enumerate(language_series):
+        idx = _LANGUAGE_INDEX.get(lang)
+        if idx is not None:
+            out[i, idx] = 1.0
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Degree computation
+# ---------------------------------------------------------------------------
+
+
+def degree_features(
+    nodes_df: pd.DataFrame,
+    edges_df: pd.DataFrame,
+) -> np.ndarray:
+    """Compute in-degree, out-degree, and total degree for each node.
+
+    Parameters
+    ----------
+    nodes_df:
+        Nodes DataFrame with an ``id`` column.
+    edges_df:
+        Edges DataFrame with ``source_id`` and ``target_id`` columns.
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``(N, 3)`` float32 array with columns
+        ``[in_degree, out_degree, total_degree]``.
+    """
+    node_ids = nodes_df["id"].tolist()
+    n = len(node_ids)
+    node_id_to_idx = {nid: idx for idx, nid in enumerate(node_ids)}
+
+    in_deg = np.zeros(n, dtype=np.float32)
+    out_deg = np.zeros(n, dtype=np.float32)
+
+    for _, row in edges_df.iterrows():
+        src_idx = node_id_to_idx.get(row["source_id"])
+        tgt_idx = node_id_to_idx.get(row["target_id"])
+        if src_idx is not None:
+            out_deg[src_idx] += 1.0
+        if tgt_idx is not None:
+            in_deg[tgt_idx] += 1.0
+
+    total = in_deg + out_deg
+    return np.column_stack([in_deg, out_deg, total])
+
+
+# ---------------------------------------------------------------------------
+# Composite feature builders
+# ---------------------------------------------------------------------------
+
+
+def build_node_features(
+    nodes_df: pd.DataFrame,
+    include_embeddings: bool = True,
+    embeddings_df: pd.DataFrame | None = None,
+) -> np.ndarray:
+    """Build a combined node feature matrix.
+
+    The feature vector for each node is the horizontal concatenation of:
+
+    1. Node type one-hot encoding ``(N, 30)``
+    2. Degree features ``(N, 3)``
+    3. Visibility ordinal ``(N, 1)``
+    4. Language one-hot encoding ``(N, 17)``
+    5. Numeric scalar features ``(N, S)`` — extracted from columns
+       ``parameterCount``, ``level``, ``isExported``, ``isStatic``,
+       ``isReadonly``, ``isAbstract``, ``isAsync``.  Boolean columns are
+       cast to ``float32``.  NaN values are filled with ``0``.
+    6. Optional embedding vectors ``(N, D)`` when *include_embeddings* is
+       ``True`` and *embeddings_df* is provided.
+
+    Parameters
+    ----------
+    nodes_df:
+        Nodes DataFrame.
+    include_embeddings:
+        Whether to append embedding vectors.
+    embeddings_df:
+        Embeddings DataFrame with ``node_id`` and ``vector`` columns.
+        Ignored when *include_embeddings* is ``False``.
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``(N, F)`` float32 feature matrix.
+    """
+    # 1. Type encoding
+    type_enc = encode_node_type(nodes_df["label"])
+
+    # 2. Degree features — build from empty edges if we only have nodes
+    #    Caller can compute degree separately if edges are available.
+    #    Here we provide a zero-filled placeholder of shape (N, 3).
+    #    For a real graph, pass edges through degree_features() separately
+    #    or call this after constructing edges.
+    deg = np.zeros((len(nodes_df), 3), dtype=np.float32)
+
+    # 3. Visibility
+    vis = encode_visibility(nodes_df.get("visibility", pd.Series(["public"] * len(nodes_df)))).reshape(-1, 1)
+
+    # 4. Language
+    lang = encode_language(nodes_df.get("language", pd.Series([None] * len(nodes_df))))
+
+    # 5. Numeric scalar features
+    _BOOL_COLS = ["isExported", "isStatic", "isReadonly", "isAbstract", "isAsync"]
+    _NUM_COLS = ["parameterCount", "level"]
+
+    scalar_parts: list[np.ndarray] = []
+    for col in _NUM_COLS:
+        if col in nodes_df.columns:
+            vals = nodes_df[col].fillna(0).to_numpy(dtype=np.float32)
+        else:
+            vals = np.zeros(len(nodes_df), dtype=np.float32)
+        scalar_parts.append(vals.reshape(-1, 1))
+
+    for col in _BOOL_COLS:
+        if col in nodes_df.columns:
+            vals = nodes_df[col].fillna(False).astype(float).to_numpy(dtype=np.float32)
+        else:
+            vals = np.zeros(len(nodes_df), dtype=np.float32)
+        scalar_parts.append(vals.reshape(-1, 1))
+
+    scalars = np.hstack(scalar_parts) if scalar_parts else np.empty((len(nodes_df), 0), dtype=np.float32)
+
+    # Assemble non-embedding features
+    parts: list[np.ndarray] = [type_enc, deg, vis, lang, scalars]
+
+    # 6. Embeddings
+    if include_embeddings and embeddings_df is not None and not embeddings_df.empty:
+        emb_sorted = embeddings_df.set_index("node_id").reindex(nodes_df["id"])
+        vecs = emb_sorted["vector"].tolist()
+
+        first_valid_dim = 0
+        for v in vecs:
+            if isinstance(v, np.ndarray) and v.size > 0:
+                first_valid_dim = v.shape[0]
+                break
+        if first_valid_dim == 0:
+            first_valid_dim = 1
+
+        emb_matrix_list: list[np.ndarray] = []
+        for v in vecs:
+            if isinstance(v, np.ndarray) and v.size > 0:
+                emb_matrix_list.append(v.astype(np.float32))
+            else:
+                emb_matrix_list.append(np.zeros(first_valid_dim, dtype=np.float32))
+        emb_matrix = np.stack(emb_matrix_list)
+        parts.append(emb_matrix)
+
+    return np.hstack(parts)
+
+
+def build_edge_features(edges_df: pd.DataFrame) -> np.ndarray:
+    """Build a combined edge feature matrix.
+
+    The feature vector for each edge is the horizontal concatenation of:
+
+    1. Confidence score ``(E, 1)``
+    2. Step number ``(E, 1)``
+    3. Edge type one-hot encoding ``(E, 25)``
+
+    NaN values in *confidence* and *step* are filled with ``0``.
+
+    Parameters
+    ----------
+    edges_df:
+        Edges DataFrame with ``confidence``, ``step``, and ``type`` columns.
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``(E, 27)`` float32 feature matrix.
+    """
+    confidence = edges_df["confidence"].fillna(0.0).to_numpy(dtype=np.float32).reshape(-1, 1)
+    step = edges_df["step"].fillna(0).to_numpy(dtype=np.float32).reshape(-1, 1)
+
+    # One-hot encode edge type
+    n = len(edges_df)
+    type_one_hot = np.zeros((n, len(EDGE_TYPES)), dtype=np.float32)
+    for i, etype in enumerate(edges_df["type"]):
+        idx = _EDGE_TYPE_INDEX.get(etype)
+        if idx is not None:
+            type_one_hot[i, idx] = 1.0
+
+    return np.hstack([confidence, step, type_one_hot])
+
+
+# ---------------------------------------------------------------------------
+# Normalization
+# ---------------------------------------------------------------------------
+
+
+def normalize_features(
+    features: np.ndarray,
+    method: str = "standard",
+) -> np.ndarray:
+    """Normalize feature matrix along the feature (column) axis.
+
+    Parameters
+    ----------
+    features:
+        Shape ``(N, F)`` feature matrix.
+    method:
+        Normalization strategy.  ``"standard"`` subtracts the mean and
+        divides by the standard deviation (z-score).  ``"minmax"`` scales
+        each column to ``[0, 1]``.  Columns with zero variance are left
+        unchanged (set to ``0``).
+
+    Returns
+    -------
+    np.ndarray
+        Normalized copy of *features* with the same shape and dtype.
+
+    Raises
+    ------
+    ValueError
+        When *method* is not ``"standard"`` or ``"minmax"``.
+    """
+    out = features.astype(np.float32, copy=True)
+
+    if method == "standard":
+        mean = out.mean(axis=0)
+        std = out.std(axis=0)
+        # Avoid division by zero on constant columns
+        std[std == 0] = 1.0
+        out = (out - mean) / std
+    elif method == "minmax":
+        col_min = out.min(axis=0)
+        col_max = out.max(axis=0)
+        denom = col_max - col_min
+        denom[denom == 0] = 1.0
+        out = (out - col_min) / denom
+    else:
+        raise ValueError(
+            f"Unsupported normalization method: {method!r}. "
+            f"Supported: 'standard', 'minmax'"
+        )
+
+    return out

--- a/packages/astrolabe-datasets/astrolabe_datasets/lazy.py
+++ b/packages/astrolabe-datasets/astrolabe_datasets/lazy.py
@@ -1,0 +1,208 @@
+"""Iterator-based lazy loaders for large Astrolabe SQLite databases.
+
+Provides memory-efficient batch iterators over nodes, relationships (edges),
+and embeddings stored in Astrolabe SQLite knowledge-graph databases.  Each
+public function opens its own connection with WAL journaling and yields
+results in configurable batch sizes so that arbitrarily large databases can
+be processed without loading an entire table into memory.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Iterator
+
+import numpy as np
+import pandas as pd
+
+
+def _connect(db_path: str | Path) -> sqlite3.Connection:
+    """Open a SQLite connection with WAL journaling enabled."""
+    con = sqlite3.connect(str(db_path))
+    con.row_factory = sqlite3.Row
+    con.execute("PRAGMA journal_mode=WAL")
+    return con
+
+
+def _table_exists(con: sqlite3.Connection, table_name: str) -> bool:
+    """Return *True* when *table_name* is present in the database."""
+    row = con.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (table_name,),
+    ).fetchone()
+    return row is not None
+
+
+def _rows_to_dataframe(rows: list[sqlite3.Row]) -> pd.DataFrame:
+    """Convert a list of :class:`sqlite3.Row` to a :class:`~pandas.DataFrame`."""
+    if not rows:
+        return pd.DataFrame()
+    columns = rows[0].keys()
+    data = [tuple(r) for r in rows]
+    return pd.DataFrame(data, columns=columns)
+
+
+def iter_nodes(
+    db_path: str | Path,
+    batch_size: int = 10_000,
+    *,
+    label: str | None = None,
+) -> Iterator[pd.DataFrame]:
+    """Yield batches of nodes from an Astrolabe SQLite database.
+
+    Each yielded DataFrame has columns ``id``, ``label``, and ``properties``
+    (the JSON string is parsed into a Python dict per batch).
+
+    Args:
+        db_path: Path to the ``.db`` file.
+        batch_size: Rows per yielded DataFrame.
+        label: When given, only nodes whose ``label`` column matches are
+            returned.
+
+    Yields:
+        :class:`~pandas.DataFrame` batches of node records.
+    """
+    con = _connect(db_path)
+    try:
+        if not _table_exists(con, "nodes"):
+            return
+
+        query = "SELECT * FROM nodes"
+        params: tuple[str, ...] = ()
+        if label is not None:
+            query += " WHERE label = ?"
+            params = (label,)
+
+        cur = con.execute(query, params)
+        while True:
+            rows = cur.fetchmany(batch_size)
+            if not rows:
+                break
+            df = _rows_to_dataframe(rows)
+            df["properties"] = df["properties"].apply(json.loads)
+            yield df
+    finally:
+        con.close()
+
+
+def iter_edges(
+    db_path: str | Path,
+    batch_size: int = 10_000,
+    *,
+    type: str | None = None,
+) -> Iterator[pd.DataFrame]:
+    """Yield batches of relationships (edges) from an Astrolabe SQLite database.
+
+    Each yielded DataFrame has columns ``id``, ``source_id``, ``target_id``,
+    ``type``, ``confidence``, ``reason``, ``step``, and ``evidence``.
+
+    Args:
+        db_path: Path to the ``.db`` file.
+        batch_size: Rows per yielded DataFrame.
+        type: When given, only edges whose ``type`` column matches are
+            returned.
+
+    Yields:
+        :class:`~pandas.DataFrame` batches of edge records.
+    """
+    con = _connect(db_path)
+    try:
+        if not _table_exists(con, "relationships"):
+            return
+
+        query = "SELECT * FROM relationships"
+        params: tuple[str, ...] = ()
+        if type is not None:
+            query += " WHERE type = ?"
+            params = (type,)
+
+        cur = con.execute(query, params)
+        while True:
+            rows = cur.fetchmany(batch_size)
+            if not rows:
+                break
+            yield _rows_to_dataframe(rows)
+    finally:
+        con.close()
+
+
+def iter_embeddings(
+    db_path: str | Path,
+    batch_size: int = 1_000,
+) -> Iterator[pd.DataFrame]:
+    """Yield batches of embeddings with decoded float32 vectors.
+
+    Each yielded DataFrame has columns ``node_id``, ``hash``, ``vector``
+    (decoded as :class:`~numpy.ndarray` of ``float32``), ``dims``, and
+    ``indexed_at``.
+
+    Args:
+        db_path: Path to the ``.db`` file.
+        batch_size: Rows per yielded DataFrame.
+
+    Yields:
+        :class:`~pandas.DataFrame` batches of embedding records.
+    """
+    con = _connect(db_path)
+    try:
+        if not _table_exists(con, "embeddings"):
+            return
+
+        cur = con.execute("SELECT * FROM embeddings")
+        while True:
+            rows = cur.fetchmany(batch_size)
+            if not rows:
+                break
+            df = _rows_to_dataframe(rows)
+            df["vector"] = df["vector"].apply(
+                lambda blob: np.frombuffer(blob, dtype=np.float32),
+            )
+            yield df
+    finally:
+        con.close()
+
+
+def stream_graph(db_path: str | Path) -> Iterator[dict]:
+    """Yield individual node and edge records as plain dicts.
+
+    Nodes are streamed first, then edges.  Every record includes a
+    ``_kind`` key (``"node"`` or ``"edge"``) so callers can discriminate
+    between the two.
+
+    Node records have their ``properties`` column parsed from JSON; edge
+    records are returned as-is.
+
+    Args:
+        db_path: Path to the ``.db`` file.
+
+    Yields:
+        Individual graph records as :class:`dict` objects.
+    """
+    con = _connect(db_path)
+    try:
+        if _table_exists(con, "nodes"):
+            cur = con.execute("SELECT * FROM nodes")
+            while True:
+                rows = cur.fetchmany(1_000)
+                if not rows:
+                    break
+                for row in rows:
+                    record = dict(row)
+                    record["properties"] = json.loads(record["properties"])
+                    record["_kind"] = "node"
+                    yield record
+
+        if _table_exists(con, "relationships"):
+            cur = con.execute("SELECT * FROM relationships")
+            while True:
+                rows = cur.fetchmany(1_000)
+                if not rows:
+                    break
+                for row in rows:
+                    record = dict(row)
+                    record["_kind"] = "edge"
+                    yield record
+    finally:
+        con.close()

--- a/packages/astrolabe-datasets/astrolabe_datasets/pandas_backends.py
+++ b/packages/astrolabe-datasets/astrolabe_datasets/pandas_backends.py
@@ -1,0 +1,796 @@
+"""Conversions between Astrolabe DataFrames and graph libraries.
+
+This module provides bidirectional conversion functions for three popular
+Python graph libraries:
+
+- **igraph** — fast C-core library with rich community detection algorithms.
+- **graph-tool** — efficient C++-backed library with stochastic block models.
+- **NetworkX** — pure-Python library with the broadest algorithm coverage.
+
+All library imports are deferred to function level so this module can be
+imported safely on machines where one or more of these libraries are not
+installed.  Calling a function that wraps a missing library raises
+:class:`ImportError` with installation instructions.
+
+Typical usage
+-------------
+::
+
+    from astrolabe_datasets.core import load_graph
+    from astrolabe_datasets.pandas_backends import (
+        to_igraph, from_igraph,
+        to_networkx, from_networkx,
+    )
+
+    cg = load_graph("path/to/graph.db")
+    ig = to_igraph(cg.nodes, cg.edges)
+    communities = detect_communities_igraph(cg.nodes, cg.edges, method="leiden")
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+if TYPE_CHECKING:
+    import graph_tool as gt
+    import igraph as ig
+    import networkx as nx
+
+# ---------------------------------------------------------------------------
+# Availability guard helpers
+# ---------------------------------------------------------------------------
+
+_IGRAPH_INSTALL_MSG = (
+    "python-igraph is not installed. "
+    "Install with:  pip install python-igraph"
+)
+
+_GRAPHTOOL_INSTALL_MSG = (
+    "graph-tool is not installed. "
+    "Install with:  pip install graph-tool  "
+    "(or see https://graph-tool.skewed.de/ for conda-based installs)."
+)
+
+_NETWORKX_INSTALL_MSG = (
+    "NetworkX is not installed. "
+    "Install with:  pip install networkx"
+)
+
+
+def _require_igraph() -> None:
+    """Raise :class:`ImportError` if ``igraph`` is not available."""
+    try:
+        import igraph  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(_IGRAPH_INSTALL_MSG) from exc
+
+
+def _require_graphtool() -> None:
+    """Raise :class:`ImportError` if ``graph_tool`` is not available."""
+    try:
+        import graph_tool  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(_GRAPHTOOL_INSTALL_MSG) from exc
+
+
+def _require_networkx() -> None:
+    """Raise :class:`ImportError` if ``networkx`` is not available."""
+    try:
+        import networkx  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(_NETWORKX_INSTALL_MSG) from exc
+
+
+# ---------------------------------------------------------------------------
+# Community result dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CommunityResult:
+    """Immutable result container for community detection algorithms.
+
+    Attributes
+    ----------
+    membership:
+        List mapping each node index to its community identifier.
+        The *i*-th element gives the community id of node *i*.
+    modularity:
+        Modularity score of the partition (higher is better; ranges
+        approximately from −0.5 to 1.0 for unweighted graphs).
+    method:
+        Human-readable name of the community detection method used
+        (e.g. ``"leiden"``, ``"louvain"``, ``"walktrap"``, ``"sbm"``).
+    num_communities:
+        Number of distinct communities found.
+    """
+
+    membership: list[int]
+    modularity: float
+    method: str
+    num_communities: int
+
+
+# ---------------------------------------------------------------------------
+# igraph conversions
+# ---------------------------------------------------------------------------
+
+
+def to_igraph(
+    nodes_df: pd.DataFrame,
+    edges_df: pd.DataFrame,
+    directed: bool = True,
+) -> ig.Graph:
+    """Build an :class:`igraph.Graph` from Astrolabe DataFrames.
+
+    The ``id`` column of *nodes_df* is mapped to igraph vertex names
+    (the ``name`` vertex attribute).  All remaining columns in
+    *nodes_df* are added as vertex attributes.  All columns in
+    *edges_df* except ``source_id`` and ``target_id`` are added as edge
+    attributes.
+
+    Parameters
+    ----------
+    nodes_df:
+        DataFrame with one row per node.  Must contain an ``id`` column.
+        Other columns become vertex attributes.
+    edges_df:
+        DataFrame with one row per edge.  Must contain ``source_id`` and
+        ``target_id`` columns referencing node ids present in *nodes_df*.
+    directed:
+        Whether the graph should be directed.  Defaults to ``True``.
+
+    Returns
+    -------
+    igraph.Graph
+        A graph object with vertex and edge attributes populated from
+        the input DataFrames.
+
+    Raises
+    ------
+    ImportError
+        If ``python-igraph`` is not installed.
+    KeyError
+        If required columns are missing from the input DataFrames.
+    """
+    _require_igraph()
+    import igraph as ig_mod
+
+    # Build vertex list preserving the order of nodes_df.
+    node_ids: list[str] = nodes_df["id"].astype(str).tolist()
+    vertex_attrs: dict[str, list[object]] = {"name": list(node_ids)}
+
+    # Add all other node columns as vertex attributes.
+    for col in nodes_df.columns:
+        if col == "id":
+            continue
+        vertex_attrs[col] = nodes_df[col].tolist()
+
+    n_vertices = len(node_ids)
+
+    # Map string node IDs to 0-based indices for edge construction.
+    id_to_index: dict[str, int] = {nid: idx for idx, nid in enumerate(node_ids)}
+
+    # Build edge list — skip edges referencing unknown nodes.
+    sources: list[int] = []
+    targets: list[int] = []
+    edge_attrs: dict[str, list[object]] = {}
+    edge_attr_cols: list[str] = [
+        col for col in edges_df.columns if col not in ("source_id", "target_id")
+    ]
+    for col in edge_attr_cols:
+        edge_attrs[col] = []
+
+    for row_idx, row in edges_df.iterrows():
+        src = str(row["source_id"])
+        tgt = str(row["target_id"])
+        if src not in id_to_index or tgt not in id_to_index:
+            continue
+        sources.append(id_to_index[src])
+        targets.append(id_to_index[tgt])
+        for col in edge_attr_cols:
+            edge_attrs[col].append(row[col])
+
+    edges = list(zip(sources, targets))
+
+    graph = ig_mod.Graph(
+        n=n_vertices,
+        edges=edges,
+        directed=directed,
+        vertex_attrs=vertex_attrs,
+        edge_attrs=edge_attrs if edge_attrs else None,
+    )
+
+    return graph
+
+
+def from_igraph(graph: ig.Graph) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Convert an :class:`igraph.Graph` back to Astrolabe DataFrames.
+
+    The returned DataFrames conform to the Astrolabe schema:
+
+    - **nodes** — columns ``id``, ``label``, ``name``, etc.  The igraph
+      ``name`` vertex attribute (if present) is mapped to ``id``; otherwise
+      string representations of vertex indices are used.
+    - **edges** — columns ``id``, ``source_id``, ``target_id``, ``type``,
+      etc.  Edge ids are generated from igraph edge indices.
+
+    Parameters
+    ----------
+    graph:
+        An :class:`igraph.Graph` instance (directed or undirected).
+
+    Returns
+    -------
+    tuple[pd.DataFrame, pd.DataFrame]
+        ``(nodes_df, edges_df)`` matching the Astrolabe DataFrame schema.
+
+    Raises
+    ------
+    ImportError
+        If ``python-igraph`` is not installed.
+    """
+    _require_igraph()
+    import igraph as ig_mod
+
+    # --- Vertices ---
+    n_vertices = graph.vcount()
+    vertex_data: dict[str, list[object]] = {}
+    vertex_attrs = graph.vertex_attributes()
+
+    # Determine the id column: prefer "name" attribute, fall back to index.
+    if "name" in vertex_attrs:
+        vertex_data["id"] = [str(v["name"]) for v in graph.vs]
+    else:
+        vertex_data["id"] = [str(v.index) for v in graph.vs]
+
+    for attr in vertex_attrs:
+        if attr == "name":
+            continue
+        vertex_data[attr] = [v[attr] for v in graph.vs]
+
+    # Ensure "label" column exists — default to "Unknown" if absent.
+    if "label" not in vertex_data:
+        vertex_data["label"] = ["Unknown"] * n_vertices
+
+    nodes_df = pd.DataFrame(vertex_data)
+
+    # --- Edges ---
+    n_edges = graph.ecount()
+    edge_data: dict[str, list[object]] = {}
+    edge_attrs = graph.edge_attributes()
+
+    edge_data["id"] = [str(e.index) for e in graph.es]
+
+    # Resolve source_id and target_id from vertex names or indices.
+    if "name" in vertex_attrs:
+        edge_data["source_id"] = [str(graph.es[e.index].source_vertex["name"]) for e in graph.es]
+        edge_data["target_id"] = [str(graph.es[e.index].target_vertex["name"]) for e in graph.es]
+    else:
+        edge_data["source_id"] = [str(e.source) for e in graph.es]
+        edge_data["target_id"] = [str(e.target) for e in graph.es]
+
+    for attr in edge_attrs:
+        edge_data[attr] = [e[attr] for e in graph.es]
+
+    # Ensure "type" column exists — default to "UNKNOWN" if absent.
+    if "type" not in edge_data:
+        edge_data["type"] = ["UNKNOWN"] * n_edges
+
+    edges_df = pd.DataFrame(edge_data)
+
+    return nodes_df, edges_df
+
+
+# ---------------------------------------------------------------------------
+# graph-tool conversions
+# ---------------------------------------------------------------------------
+
+
+def to_graphtool(
+    nodes_df: pd.DataFrame,
+    edges_df: pd.DataFrame,
+    directed: bool = True,
+) -> gt.Graph:
+    """Build a :class:`graph_tool.Graph` from Astrolabe DataFrames.
+
+    All columns from *nodes_df* are added as vertex property maps
+    (``vprop``) and all columns from *edges_df* (except ``source_id``
+    and ``target_id``) are added as edge property maps (``eprop``).
+
+    The ``id`` column of *nodes_df* is stored as the ``name`` vertex
+    property so that string-based node identifiers can be recovered later.
+
+    Parameters
+    ----------
+    nodes_df:
+        DataFrame with one row per node.  Must contain an ``id`` column.
+    edges_df:
+        DataFrame with one row per edge.  Must contain ``source_id`` and
+        ``target_id`` columns.
+    directed:
+        Whether the graph should be directed.  Defaults to ``True``.
+
+    Returns
+    -------
+    graph_tool.Graph
+        A graph object with property maps for all attributes.
+
+    Raises
+    ------
+    ImportError
+        If ``graph-tool`` is not installed.
+    """
+    _require_graphtool()
+    import graph_tool as gt_mod
+
+    g = gt_mod.Graph(directed=directed)
+
+    node_ids: list[str] = nodes_df["id"].astype(str).tolist()
+    n_vertices = len(node_ids)
+
+    # Create vertices in order.
+    vlist = [g.add_vertex() for _ in range(n_vertices)]
+    id_to_vertex: dict[str, gt_mod.Vertex] = {
+        nid: v for nid, v in zip(node_ids, vlist)
+    }
+
+    # Add vertex property maps.
+    for col in nodes_df.columns:
+        values = nodes_df[col].tolist()
+        # Determine the property type from the first non-null value.
+        sample = next((v for v in values if v is not None and not (isinstance(v, float) and pd.isna(v))), "")
+        if isinstance(sample, (int, bool)):
+            prop = g.new_vp("int")
+        elif isinstance(sample, float):
+            prop = g.new_vp("double")
+        else:
+            prop = g.new_vp("string")
+
+        for idx, val in enumerate(values):
+            if val is None or (isinstance(val, float) and pd.isna(val)):
+                continue
+            prop[vlist[idx]] = val
+
+        # Store id column as "name" for identity, all others by their column name.
+        prop_name = "name" if col == "id" else col
+        g.vp[prop_name] = prop
+
+    # Add edges and their property maps.
+    edge_attr_cols: list[str] = [
+        col for col in edges_df.columns if col not in ("source_id", "target_id")
+    ]
+
+    # Pre-create edge property maps.
+    eprop_objects: dict[str, gt_mod.PropertyMap] = {}
+    for col in edge_attr_cols:
+        values = edges_df[col].tolist()
+        sample = next((v for v in values if v is not None and not (isinstance(v, float) and pd.isna(v))), "")
+        if isinstance(sample, (int, bool)):
+            eprop_objects[col] = g.new_ep("int")
+        elif isinstance(sample, float):
+            eprop_objects[col] = g.new_ep("double")
+        else:
+            eprop_objects[col] = g.new_ep("string")
+
+    for row_idx, row in edges_df.iterrows():
+        src_id = str(row["source_id"])
+        tgt_id = str(row["target_id"])
+        if src_id not in id_to_vertex or tgt_id not in id_to_vertex:
+            continue
+        e = g.add_edge(id_to_vertex[src_id], id_to_vertex[tgt_id])
+        for col in edge_attr_cols:
+            val = row[col]
+            if val is None or (isinstance(val, float) and pd.isna(val)):
+                continue
+            eprop_objects[col][e] = val
+
+    for col, eprop in eprop_objects.items():
+        g.ep[col] = eprop
+
+    return g
+
+
+def from_graphtool(graph: gt.Graph) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Convert a :class:`graph_tool.Graph` back to Astrolabe DataFrames.
+
+    Vertex property maps become columns of the nodes DataFrame, and edge
+    property maps become columns of the edges DataFrame.  If a ``name``
+    vertex property exists it is used as the ``id`` column; otherwise
+    vertex indices are cast to strings.
+
+    Parameters
+    ----------
+    graph:
+        A :class:`graph_tool.Graph` instance.
+
+    Returns
+    -------
+    tuple[pd.DataFrame, pd.DataFrame]
+        ``(nodes_df, edges_df)`` matching the Astrolabe DataFrame schema.
+
+    Raises
+    ------
+    ImportError
+        If ``graph-tool`` is not installed.
+    """
+    _require_graphtool()
+    import graph_tool as gt_mod
+
+    # --- Vertices ---
+    vertex_data: dict[str, list[object]] = {}
+
+    # Determine the id column: prefer "name" vprop if it exists.
+    if "name" in graph.vp:
+        vertex_data["id"] = [str(graph.vp["name"][v]) for v in graph.vertices()]
+    else:
+        vertex_data["id"] = [str(int(v)) for v in graph.vertices()]
+
+    # Collect all other vertex property maps.
+    for prop_name in graph.vp:
+        if prop_name == "name":
+            continue
+        prop = graph.vp[prop_name]
+        vertex_data[prop_name] = [
+            prop[v] for v in graph.vertices()
+        ]
+
+    # Ensure "label" exists.
+    if "label" not in vertex_data:
+        vertex_data["label"] = ["Unknown"] * graph.num_vertices()
+
+    nodes_df = pd.DataFrame(vertex_data)
+
+    # --- Edges ---
+    edge_data: dict[str, list[object]] = {}
+    edge_data["id"] = [str(int(e)) for e in graph.edges()]
+
+    # Resolve source_id / target_id from vertex "name" vprop or indices.
+    if "name" in graph.vp:
+        edge_data["source_id"] = [
+            str(graph.vp["name"][e.source()]) for e in graph.edges()
+        ]
+        edge_data["target_id"] = [
+            str(graph.vp["name"][e.target()]) for e in graph.edges()
+        ]
+    else:
+        edge_data["source_id"] = [str(int(e.source())) for e in graph.edges()]
+        edge_data["target_id"] = [str(int(e.target())) for e in graph.edges()]
+
+    for prop_name in graph.ep:
+        prop = graph.ep[prop_name]
+        edge_data[prop_name] = [
+            prop[e] for e in graph.edges()
+        ]
+
+    # Ensure "type" exists.
+    if "type" not in edge_data:
+        edge_data["type"] = ["UNKNOWN"] * graph.num_edges()
+
+    edges_df = pd.DataFrame(edge_data)
+
+    return nodes_df, edges_df
+
+
+# ---------------------------------------------------------------------------
+# NetworkX conversions
+# ---------------------------------------------------------------------------
+
+
+def to_networkx(
+    nodes_df: pd.DataFrame,
+    edges_df: pd.DataFrame,
+    directed: bool = True,
+) -> nx.Graph:
+    """Build a NetworkX graph from Astrolabe DataFrames.
+
+    Uses :func:`networkx.from_pandas_edgelist` for the edge structure and
+    then sets node attributes from *nodes_df*.
+
+    Parameters
+    ----------
+    nodes_df:
+        DataFrame with one row per node.  Must contain an ``id`` column.
+        All columns (including ``id``) are attached as node attributes.
+    edges_df:
+        DataFrame with one row per edge.  Must contain ``source_id`` and
+        ``target_id`` columns.  All other columns are attached as edge
+        attributes.
+    directed:
+        Whether to build a :class:`nx.DiGraph` (True) or
+        :class:`nx.Graph` (False).
+
+    Returns
+    -------
+    nx.Graph | nx.DiGraph
+        The constructed NetworkX graph.
+
+    Raises
+    ------
+    ImportError
+        If ``networkx`` is not installed.
+    """
+    _require_networkx()
+    import networkx as nx_mod
+
+    # Determine edge attribute columns.
+    edge_attr_cols: list[str] = [
+        col for col in edges_df.columns
+        if col not in ("source_id", "target_id", "id")
+    ]
+
+    # Build graph from edge list.
+    if edge_attr_cols:
+        graph = nx_mod.from_pandas_edgelist(
+            edges_df,
+            source="source_id",
+            target="target_id",
+            edge_attr=list(edge_attr_cols),
+            create_using=nx_mod.DiGraph if directed else nx_mod.Graph,
+        )
+    else:
+        graph = nx_mod.from_pandas_edgelist(
+            edges_df,
+            source="source_id",
+            target="target_id",
+            edge_attr=True,
+            create_using=nx_mod.DiGraph if directed else nx_mod.Graph,
+        )
+
+    # Attach node attributes from nodes_df.
+    node_ids: set[str] = set(nodes_df["id"].astype(str))
+    for _, row in nodes_df.iterrows():
+        node_id = str(row["id"])
+        if node_id in graph:
+            for col in nodes_df.columns:
+                val = row[col]
+                # Skip NaN values.
+                if isinstance(val, float) and pd.isna(val):
+                    continue
+                graph.nodes[node_id][col] = val
+        else:
+            # Add isolated nodes that have no edges.
+            attrs: dict[str, object] = {}
+            for col in nodes_df.columns:
+                val = row[col]
+                if not (isinstance(val, float) and pd.isna(val)):
+                    attrs[col] = val
+            graph.add_node(node_id, **attrs)
+
+    # Ensure edge "id" attribute is populated from the DataFrame index
+    # if the column exists in edges_df.
+    if "id" in edges_df.columns:
+        edge_id_map: dict[tuple[str, str], str] = {}
+        for _, row in edges_df.iterrows():
+            src = str(row["source_id"])
+            tgt = str(row["target_id"])
+            eid = str(row["id"])
+            edge_id_map[(src, tgt)] = eid
+
+        for u, v, data in graph.edges(data=True):
+            if "id" not in data and (u, v) in edge_id_map:
+                data["id"] = edge_id_map[(u, v)]
+
+    return graph
+
+
+def from_networkx(graph: nx.Graph) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Convert a NetworkX graph back to Astrolabe DataFrames.
+
+    Edges are extracted with :func:`networkx.to_pandas_edgelist`.  Node
+    attributes are collected into the nodes DataFrame.  If the graph
+    does not have a ``label`` node attribute, it defaults to ``"Unknown"``.
+
+    Parameters
+    ----------
+    graph:
+        A :class:`nx.Graph` or :class:`nx.DiGraph` instance.
+
+    Returns
+    -------
+    tuple[pd.DataFrame, pd.DataFrame]
+        ``(nodes_df, edges_df)`` matching the Astrolabe DataFrame schema.
+
+    Raises
+    ------
+    ImportError
+        If ``networkx`` is not installed.
+    """
+    _require_networkx()
+    import networkx as nx_mod
+
+    # --- Nodes ---
+    node_records: list[dict[str, object]] = []
+    for node_id, node_data in graph.nodes(data=True):
+        record: dict[str, object] = {"id": str(node_id)}
+        record.update(node_data)
+        node_records.append(record)
+
+    nodes_df = pd.DataFrame(node_records)
+
+    # Ensure "label" column exists.
+    if "label" not in nodes_df.columns:
+        nodes_df["label"] = "Unknown"
+    elif nodes_df["label"].isna().all():
+        nodes_df["label"] = "Unknown"
+
+    # --- Edges ---
+    edges_df = nx_mod.to_pandas_edgelist(graph, source="source_id", target="target_id")
+
+    # Ensure required columns exist.
+    if "source_id" not in edges_df.columns:
+        edges_df = pd.DataFrame(columns=["source_id", "target_id"])
+    elif "id" not in edges_df.columns:
+        edges_df["id"] = [str(i) for i in range(len(edges_df))]
+
+    if "type" not in edges_df.columns:
+        edges_df["type"] = "UNKNOWN"
+
+    return nodes_df, edges_df
+
+
+# ---------------------------------------------------------------------------
+# Community detection — igraph
+# ---------------------------------------------------------------------------
+
+
+def detect_communities_igraph(
+    nodes_df: pd.DataFrame,
+    edges_df: pd.DataFrame,
+    method: str = "leiden",
+    **kwargs: object,
+) -> CommunityResult:
+    """Run community detection on an igraph graph built from Astrolabe DataFrames.
+
+    Supported methods:
+
+    - ``"leiden"`` — :meth:`igraph.Graph.community_leiden` (default).
+    - ``"louvain"`` — :meth:`igraph.Graph.community_multilevel`.
+    - ``"walktrap"`` — :meth:`igraph.Graph.community_walktrap`.
+    - ``"fastgreedy"`` — :meth:`igraph.Graph.community_fastgreedy`.
+    - ``"betweenness"`` — :meth:`igraph.Graph.community_edge_betweenness`.
+    - ``"infomap"`` — :meth:`igraph.Graph.community_infomap`.
+    - ``"label_propagation"`` — :meth:`igraph.Graph.community_label_propagation`.
+
+    Extra keyword arguments are forwarded to the underlying igraph method.
+
+    Parameters
+    ----------
+    nodes_df:
+        DataFrame with one row per node (must contain ``id``).
+    edges_df:
+        DataFrame with one row per edge (must contain ``source_id`` and
+        ``target_id``).
+    method:
+        Community detection algorithm name.  Defaults to ``"leiden"``.
+    **kwargs:
+        Additional keyword arguments forwarded to the igraph method.
+
+    Returns
+    -------
+    CommunityResult
+        Frozen dataclass with membership, modularity, method name, and
+        community count.
+
+    Raises
+    ------
+    ImportError
+        If ``python-igraph`` is not installed.
+    ValueError
+        If *method* is not recognised.
+    """
+    _require_igraph()
+    import igraph as ig_mod
+
+    graph = to_igraph(nodes_df, edges_df, directed=True)
+
+    method_dispatch = {
+        "leiden": ig_mod.Graph.community_leiden,
+        "louvain": ig_mod.Graph.community_multilevel,
+        "walktrap": ig_mod.Graph.community_walktrap,
+        "fastgreedy": ig_mod.Graph.community_fastgreedy,
+        "betweenness": ig_mod.Graph.community_edge_betweenness,
+        "infomap": ig_mod.Graph.community_infomap,
+        "label_propagation": ig_mod.Graph.community_label_propagation,
+    }
+
+    if method not in method_dispatch:
+        supported = ", ".join(sorted(method_dispatch.keys()))
+        raise ValueError(
+            f"Unknown igraph community method: {method!r}. "
+            f"Supported methods: {supported}"
+        )
+
+    # Some methods return dendrograms that need .as_clustering().
+    clustering_obj = method_dispatch[method](graph, **kwargs)
+
+    # Walktrap and betweenness return VertexDendrogram; call .as_clustering().
+    if hasattr(clustering_obj, "as_clustering"):
+        membership = list(clustering_obj.as_clustering())
+    else:
+        membership = list(clustering_obj.membership)
+
+    modularity: float = graph.modularity(membership)
+    num_communities: int = len(set(membership))
+
+    return CommunityResult(
+        membership=membership,
+        modularity=float(modularity),
+        method=f"igraph_{method}",
+        num_communities=num_communities,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Community detection — graph-tool (SBM)
+# ---------------------------------------------------------------------------
+
+
+def detect_communities_graphtool(
+    nodes_df: pd.DataFrame,
+    edges_df: pd.DataFrame,
+    method: str = "sbm",
+) -> CommunityResult:
+    """Run community detection on a graph-tool graph built from Astrolabe DataFrames.
+
+    The primary method is stochastic block model (SBM) via
+    :func:`graph_tool.inference.minimize_blockmodel_dl`.
+
+    Parameters
+    ----------
+    nodes_df:
+        DataFrame with one row per node (must contain ``id``).
+    edges_df:
+        DataFrame with one row per edge (must contain ``source_id`` and
+        ``target_id``).
+    method:
+        Community detection algorithm.  Currently only ``"sbm"`` (stochastic
+        block model) is supported.  Defaults to ``"sbm"``.
+
+    Returns
+    -------
+    CommunityResult
+        Frozen dataclass with membership, modularity, method name, and
+        community count.
+
+    Raises
+    ------
+    ImportError
+        If ``graph-tool`` is not installed.
+    ValueError
+        If *method* is not recognised.
+    """
+    _require_graphtool()
+    import graph_tool as gt_mod
+    from graph_tool.inference import minimize_blockmodel_dl
+
+    if method != "sbm":
+        raise ValueError(
+            f"Unknown graph-tool community method: {method!r}. "
+            f"Supported methods: sbm"
+        )
+
+    g = to_graphtool(nodes_df, edges_df, directed=True)
+
+    # Minimise the description length to find the optimal partition.
+    state = minimize_blockmodel_dl(g)
+
+    # Extract block membership — state.get_blocks() returns a vertex property map.
+    block_membership = state.get_blocks()
+    membership: list[int] = [int(block_membership[v]) for v in g.vertices()]
+
+    # Compute modularity via graph_tool.inference.modularity.
+    from graph_tool.inference import modularity
+
+    mod_score: float = modularity(g, block_membership)
+    num_communities: int = len(set(membership))
+
+    return CommunityResult(
+        membership=membership,
+        modularity=float(mod_score),
+        method=f"graphtool_{method}",
+        num_communities=num_communities,
+    )

--- a/packages/astrolabe-datasets/astrolabe_datasets/pyg_dataset.py
+++ b/packages/astrolabe-datasets/astrolabe_datasets/pyg_dataset.py
@@ -1,0 +1,924 @@
+"""PyTorch-Geometric InMemoryDataset with HeteroData for Astrolabe knowledge graphs.
+
+This module provides the :class:`CodeGraphDataset` class — a PyG
+``InMemoryDataset`` that loads Astrolabe SQLite databases into
+``HeteroData`` objects suitable for heterogeneous GNN training — along
+with utility functions for converting DataFrames to ``HeteroData``,
+flattening to homogeneous ``Data``, and exporting to OGB format.
+
+**Optional dependencies** — ``torch`` and ``torch_geometric`` are *not*
+required at import time; every public function that needs them performs a
+lazy import and raises a helpful ``ImportError`` if they are missing.
+Install the extras with::
+
+    pip install astrolabe-datasets[pyg]
+"""
+
+from __future__ import annotations
+
+import json
+import pickle
+import sqlite3
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable, Iterator, Optional, Sequence
+
+import numpy as np  # type: ignore[import-untyped]
+import pandas as pd  # type: ignore[import-untyped]
+
+if TYPE_CHECKING:
+    from torch_geometric.data import Data, HeteroData  # type: ignore[import-untyped]
+
+# ---------------------------------------------------------------------------
+# Schema constants — canonical node labels and edge types
+# ---------------------------------------------------------------------------
+
+NODE_LABELS: list[str] = [
+    "Project", "Package", "Module", "Folder", "File", "Section", "Class",
+    "Function", "Method", "Variable", "Interface", "Enum", "Decorator",
+    "Import", "Type", "CodeElement", "Struct", "Constructor", "Community",
+    "Process", "Macro", "Typedef", "Union", "Namespace", "Trait", "Impl",
+    "TypeAlias", "Const", "Static", "Property", "Record", "Delegate",
+    "Annotation", "Template", "Route", "Tool", "Framework",
+]
+
+EDGE_TYPES: list[str] = [
+    "CONTAINS", "CALLS", "EXTENDS", "METHOD_OVERRIDES", "METHOD_IMPLEMENTS",
+    "IMPORTS", "USES", "DEFINES", "DECORATES", "IMPLEMENTS", "HAS_METHOD",
+    "HAS_PROPERTY", "ACCESSES", "MEMBER_OF", "STEP_IN_PROCESS",
+    "HANDLES_ROUTE", "FETCHES", "HANDLES_TOOL", "ENTRY_POINT_OF", "WRAPS",
+    "QUERIES", "USES_FRAMEWORK", "RETURNS_TYPE", "DECLARES_TYPE",
+    "CHAINABLE_TO",
+]
+
+VISIBILITY_VALUES: list[str] = [
+    "public", "private", "protected", "internal", "package", "unknown",
+]
+
+# Base node feature dimension (without embeddings).
+# type_one_hot(37) + degree(1) + visibility_one_hot(6) + parameterCount(1)
+# + is_static(1) + is_async(1) + is_exported(1)
+# + pagerank(1) + betweenness(1) + community_id(1)
+NODE_FEAT_DIM_BASE: int = (
+    len(NODE_LABELS)
+    + 1
+    + len(VISIBILITY_VALUES)
+    + 1
+    + 1
+    + 1
+    + 1
+    + 1
+    + 1
+    + 1
+)
+# = 37 + 1 + 6 + 1 + 1 + 1 + 1 + 1 + 1 + 1 = 51
+
+EDGE_FEAT_DIM: int = 2  # confidence, step
+
+
+# ---------------------------------------------------------------------------
+# Type-encoding helpers
+# ---------------------------------------------------------------------------
+
+
+def _type_one_hot(label: str, labels: Sequence[str]) -> np.ndarray:
+    """Return a one-hot vector of length *len(labels)* for *label*.
+
+    If *label* is not in *labels*, every element is ``0.0``.
+    """
+    vec = np.zeros(len(labels), dtype=np.float32)
+    try:
+        vec[labels.index(label)] = 1.0
+    except ValueError:
+        pass  # unknown type — all zeros
+    return vec
+
+
+def _visibility_one_hot(visibility: object) -> np.ndarray:
+    """Return a one-hot vector for a visibility string.
+
+    Unknown or ``None`` values map to the ``"unknown"`` slot.
+    """
+    vec = np.zeros(len(VISIBILITY_VALUES), dtype=np.float32)
+    vis_str = str(visibility).lower() if visibility is not None else "unknown"
+    if vis_str in VISIBILITY_VALUES:
+        idx = VISIBILITY_VALUES.index(vis_str)
+    else:
+        idx = VISIBILITY_VALUES.index("unknown")
+    vec[idx] = 1.0
+    return vec
+
+
+def _deserialize_vector(raw: object) -> np.ndarray:
+    """Deserialize a vector BLOB from SQLite into a float32 numpy array.
+
+    Tries ``numpy.frombuffer`` first (``tobytes`` encoding), then falls back
+    to ``pickle.loads``.  Returns an empty 0-d array if deserialization fails.
+    """
+    if isinstance(raw, np.ndarray):
+        return raw.astype(np.float32)  # type: ignore[union-attr]
+    if isinstance(raw, bytes):
+        try:
+            return np.frombuffer(raw, dtype=np.float32).copy()
+        except (ValueError, TypeError):
+            pass
+        try:
+            result = pickle.loads(raw)
+            if isinstance(result, np.ndarray):
+                return result.astype(np.float32)  # type: ignore[union-attr]
+        except (pickle.UnpicklingError, TypeError, AttributeError):
+            pass
+    if isinstance(raw, str):
+        try:
+            return np.frombuffer(bytes.fromhex(raw), dtype=np.float32).copy()
+        except (ValueError, TypeError):
+            pass
+    return np.array([], dtype=np.float32)
+
+
+# ---------------------------------------------------------------------------
+# DataFrame → HeteroData conversion
+# ---------------------------------------------------------------------------
+
+
+def graph_to_hetero_data(
+    nodes_df: pd.DataFrame,
+    edges_df: pd.DataFrame,
+    embeddings_df: pd.DataFrame,
+    metrics_df: pd.DataFrame,
+    all_node_types: Sequence[str] | None = None,
+    all_edge_type_triples: Sequence[tuple[str, str, str]] | None = None,
+) -> "HeteroData":
+    """Convert Astrolabe DataFrames into a single ``HeteroData`` object.
+
+    Node features (per type) are assembled from: a type one-hot, degree,
+    visibility one-hot, ``parameterCount``, ``isStatic``, ``isAsync``,
+    ``isExported`` flags, plus computed metrics (``pagerank``,
+    ``betweenness``, ``community_id``).  When an *embeddings_df* with a
+    ``vector`` column is supplied, the embedding vector is concatenated to
+    each node's feature row; nodes without a matching embedding receive a
+    zero-padded vector of the same dimensionality.
+
+    Edge features (per type) are: ``confidence`` and ``step`` (ordinal).
+
+    Parameters
+    ----------
+    nodes_df:
+        DataFrame with columns ``id, label, name, filePath, startLine,
+        endLine, language, isExported, visibility, parameterCount, level,
+        returnType, isStatic, isReadonly, isAbstract, isAsync, keywords``.
+    edges_df:
+        DataFrame with columns ``id, source_id, target_id, type,
+        confidence, reason, step, evidence``.
+    embeddings_df:
+        DataFrame with columns ``node_id, hash, vector, dims,
+        indexed_at``.  May be empty or lack the ``vector`` column.
+    metrics_df:
+        DataFrame with columns ``node_id, pagerank, betweenness,
+        community_id, cohesion``.
+    all_node_types:
+        If supplied, every node type in this list is guaranteed to be
+        present in the result (with empty tensors for absent types).
+        Used to normalise schemas across multiple graphs.
+    all_edge_type_triples:
+        Same idea — ensures every ``(src, rel, dst)`` triple appears in
+        the result even when the current graph has no such edges.
+
+    Returns
+    -------
+    HeteroData
+        A PyG heterogeneous data object.
+
+    Raises
+    ------
+    ImportError
+        If ``torch`` or ``torch_geometric`` is not installed.
+    """
+    try:
+        import torch
+        from torch_geometric.data import HeteroData
+    except ImportError as exc:
+        raise ImportError(
+            "PyTorch and PyTorch-Geometric are required for "
+            "graph_to_hetero_data.  Install them with: "
+            "pip install torch torch-geometric"
+        ) from exc
+
+    # ------------------------------------------------------------------
+    # Build fast look-ups
+    # ------------------------------------------------------------------
+    nid_series = nodes_df["id"].astype(str)
+    label_series = nodes_df["label"].astype(str)
+    node_label_map: dict[str, str] = dict(zip(nid_series, label_series))
+
+    # Degree = in + out edge count per node
+    degree_counts: dict[str, int] = {}
+    for sid in edges_df["source_id"].astype(str):
+        degree_counts[sid] = degree_counts.get(sid, 0) + 1
+    for tid in edges_df["target_id"].astype(str):
+        degree_counts[tid] = degree_counts.get(tid, 0) + 1
+
+    # Embedding look-up: node_id → float32 vector
+    embed_map: dict[str, np.ndarray] = {}
+    embed_dim: int = 0
+    if not embeddings_df.empty and "vector" in embeddings_df.columns:
+        for _, row in embeddings_df.iterrows():
+            vec = _deserialize_vector(row["vector"])
+            nid = str(row["node_id"])
+            if vec.size > 0:
+                embed_map[nid] = vec
+                if embed_dim == 0:
+                    embed_dim = vec.size
+
+    # Metrics look-up: node_id → (pagerank, betweenness, community_id)
+    metrics_map: dict[str, tuple[float, float, float]] = {}
+    if not metrics_df.empty:
+        for _, row in metrics_df.iterrows():
+            nid = str(row["node_id"])
+            pr = float(row.get("pagerank", 0.0) or 0.0)
+            bw = float(row.get("betweenness", 0.0) or 0.0)
+            raw_cid = row.get("community_id", -1)
+            cid = float(raw_cid) if pd.notna(raw_cid) and raw_cid is not None else -1.0
+            metrics_map[nid] = (pr, bw, cid)
+
+    # ------------------------------------------------------------------
+    # Determine the full set of node types
+    # ------------------------------------------------------------------
+    if all_node_types is not None:
+        effective_node_types: list[str] = list(all_node_types)
+    else:
+        present = set(nodes_df["label"].astype(str).unique())
+        effective_node_types = list(present | set(NODE_LABELS))
+
+    # ------------------------------------------------------------------
+    # Build node features per type
+    # ------------------------------------------------------------------
+    hetero = HeteroData()
+    node_id_to_type_idx: dict[str, tuple[str, int]] = {}
+
+    for ntype in effective_node_types:
+        mask = nodes_df["label"].astype(str) == ntype
+        type_nodes = nodes_df.loc[mask]
+        n = len(type_nodes)
+
+        if n == 0:
+            hetero[ntype].x = torch.zeros(
+                (0, NODE_FEAT_DIM_BASE + embed_dim), dtype=torch.float,
+            )
+            hetero[ntype].num_nodes = 0
+            continue
+
+        feat_rows: list[np.ndarray] = []
+        for idx, (local_idx, (_, node)) in enumerate(type_nodes.iterrows()):
+            nid = str(node["id"])
+            node_id_to_type_idx[nid] = (ntype, idx)
+
+            type_enc = _type_one_hot(ntype, NODE_LABELS)
+            deg = np.array(
+                [float(degree_counts.get(nid, 0))], dtype=np.float32,
+            )
+            vis_enc = _visibility_one_hot(node.get("visibility"))
+            param_count = np.array(
+                [
+                    float(
+                        node.get("parameterCount", 0)
+                        if pd.notna(node.get("parameterCount"))
+                        else 0
+                    )
+                ],
+                dtype=np.float32,
+            )
+            is_static = np.array(
+                [float(bool(node.get("isStatic", False)))],
+                dtype=np.float32,
+            )
+            is_async = np.array(
+                [float(bool(node.get("isAsync", False)))],
+                dtype=np.float32,
+            )
+            is_exported = np.array(
+                [float(bool(node.get("isExported", False)))],
+                dtype=np.float32,
+            )
+            pr, bw, cid_val = metrics_map.get(nid, (0.0, 0.0, -1.0))
+            metrics_arr = np.array([pr, bw, cid_val], dtype=np.float32)
+
+            emb_vec = embed_map.get(nid)
+            emb_arr = (
+                emb_vec
+                if emb_vec is not None
+                else np.zeros(embed_dim, dtype=np.float32)
+            )
+
+            feat = np.concatenate([
+                type_enc, deg, vis_enc, param_count,
+                is_static, is_async, is_exported,
+                metrics_arr, emb_arr,
+            ])
+            feat_rows.append(feat)
+
+        feat_tensor = torch.tensor(np.stack(feat_rows), dtype=torch.float)
+        hetero[ntype].x = feat_tensor
+        hetero[ntype].num_nodes = n
+
+    # ------------------------------------------------------------------
+    # Determine the full set of edge type triples
+    # ------------------------------------------------------------------
+    actual_triples: set[tuple[str, str, str]] = set()
+    for _, edge in edges_df.iterrows():
+        sid = str(edge["source_id"])
+        tid = str(edge["target_id"])
+        src_type = node_label_map.get(sid)
+        dst_type = node_label_map.get(tid)
+        if src_type is None or dst_type is None:
+            continue
+        actual_triples.add((src_type, str(edge["type"]), dst_type))
+
+    if all_edge_type_triples is not None:
+        effective_triples: set[tuple[str, str, str]] = (
+            set(all_edge_type_triples) | actual_triples
+        )
+    else:
+        effective_triples = actual_triples
+    effective_triples_sorted = sorted(effective_triples)
+
+    # ------------------------------------------------------------------
+    # Build edge indices and features per triple
+    # ------------------------------------------------------------------
+    edges_by_triple: dict[tuple[str, str, str], list[tuple[int, int, float, float]]] = {
+        t: [] for t in effective_triples_sorted
+    }
+
+    for _, edge in edges_df.iterrows():
+        sid = str(edge["source_id"])
+        tid = str(edge["target_id"])
+        src_type = node_label_map.get(sid)
+        dst_type = node_label_map.get(tid)
+        if src_type is None or dst_type is None:
+            continue
+
+        src_info = node_id_to_type_idx.get(sid)
+        dst_info = node_id_to_type_idx.get(tid)
+        if src_info is None or dst_info is None:
+            continue
+
+        rel = str(edge["type"])
+        triple = (src_type, rel, dst_type)
+
+        raw_conf = edge.get("confidence", 1.0)
+        conf = float(raw_conf) if pd.notna(raw_conf) else 1.0
+        raw_step = edge.get("step", 0)
+        step_val = float(raw_step) if pd.notna(raw_step) else 0.0
+
+        edges_by_triple.setdefault(triple, []).append(
+            (src_info[1], dst_info[1], conf, step_val)
+        )
+
+    for triple in effective_triples_sorted:
+        src_type, rel, dst_type = triple
+        entries = edges_by_triple.get(triple, [])
+
+        if len(entries) == 0:
+            hetero[src_type, rel, dst_type].edge_index = torch.zeros(
+                (2, 0), dtype=torch.long,
+            )
+            hetero[src_type, rel, dst_type].edge_attr = torch.zeros(
+                (0, EDGE_FEAT_DIM), dtype=torch.float,
+            )
+        else:
+            src_idx = [e[0] for e in entries]
+            dst_idx = [e[1] for e in entries]
+            edge_feats = np.array(
+                [[e[2], e[3]] for e in entries], dtype=np.float32,
+            )
+            hetero[src_type, rel, dst_type].edge_index = torch.tensor(
+                [src_idx, dst_idx], dtype=torch.long,
+            )
+            hetero[src_type, rel, dst_type].edge_attr = torch.tensor(
+                edge_feats, dtype=torch.float,
+            )
+
+    return hetero
+
+
+# ---------------------------------------------------------------------------
+# Homogeneous flattening
+# ---------------------------------------------------------------------------
+
+
+def to_homogeneous(hetero: "HeteroData") -> "Data":
+    """Flatten a heterogeneous graph into a homogeneous ``Data`` object.
+
+    Nodes of all types are concatenated in ``node_type`` order.  An extra
+    ``node_type`` attribute (``LongTensor``) stores the type index for
+    each node; ``edge_type`` stores the edge-type index for each edge.
+
+    Node features are aligned across types: if any type has a different
+    feature width the shorter vectors are zero-padded to the maximum width.
+    Edge features are similarly aligned.
+
+    Parameters
+    ----------
+    hetero:
+        A ``HeteroData`` object as produced by :func:`graph_to_hetero_data`.
+
+    Returns
+    -------
+    Data
+        A homogeneous PyG ``Data`` object.
+
+    Raises
+    ------
+    ImportError
+        If ``torch`` or ``torch_geometric`` is not installed.
+    """
+    try:
+        import torch
+        from torch_geometric.data import Data
+    except ImportError as exc:
+        raise ImportError(
+            "PyTorch and PyTorch-Geometric are required for "
+            "to_homogeneous.  Install them with: "
+            "pip install torch torch-geometric"
+        ) from exc
+
+    # Collect node features per type
+    node_features: list[torch.Tensor] = []
+    node_type_ids: list[torch.Tensor] = []
+    node_offsets: dict[str, int] = {}
+    offset = 0
+
+    max_node_feat_dim = 0
+    for ntype in hetero.node_types:
+        x = hetero[ntype].x
+        if x is not None and x.numel() > 0:
+            max_node_feat_dim = max(max_node_feat_dim, x.size(1))
+
+    max_edge_feat_dim = 0
+    for rel_type in hetero.edge_types:
+        ea = hetero[rel_type].edge_attr
+        if ea is not None and ea.numel() > 0:
+            max_edge_feat_dim = max(max_edge_feat_dim, ea.size(1))
+
+    for i, ntype in enumerate(hetero.node_types):
+        x = hetero[ntype].x
+        n = hetero[ntype].num_nodes
+        node_offsets[str(ntype)] = offset
+        offset += n
+
+        if x is not None and x.numel() > 0:
+            # Pad to max_node_feat_dim if needed
+            if x.size(1) < max_node_feat_dim:
+                pad = torch.zeros(
+                    x.size(0), max_node_feat_dim - x.size(1),
+                    dtype=x.dtype,
+                )
+                x = torch.cat([x, pad], dim=1)
+            node_features.append(x)
+            node_type_ids.append(torch.full((n,), i, dtype=torch.long))
+        elif n > 0:
+            placeholder = torch.zeros(n, max_node_feat_dim, dtype=torch.float)
+            node_features.append(placeholder)
+            node_type_ids.append(torch.full((n,), i, dtype=torch.long))
+
+    # Collect edge indices and features per type
+    edge_indices: list[torch.Tensor] = []
+    edge_features: list[torch.Tensor] = []
+    edge_type_ids: list[torch.Tensor] = []
+    edge_key_map: dict[str, int] = {}
+
+    for i, rel_type in enumerate(hetero.edge_types):
+        src_type, rel, dst_type = rel_type
+        key = str(rel_type)
+        edge_key_map[key] = i
+
+        ei = hetero[rel_type].edge_index
+        if ei is None or ei.numel() == 0:
+            continue
+
+        src_offset = node_offsets.get(str(src_type), 0)
+        dst_offset = node_offsets.get(str(dst_type), 0)
+
+        shifted = ei.clone()
+        shifted[0] += src_offset
+        shifted[1] += dst_offset
+
+        edge_indices.append(shifted)
+        edge_type_ids.append(
+            torch.full((ei.size(1),), i, dtype=torch.long)
+        )
+
+        ea = hetero[rel_type].edge_attr
+        if ea is not None and ea.numel() > 0:
+            if ea.size(1) < max_edge_feat_dim:
+                pad = torch.zeros(
+                    ea.size(0), max_edge_feat_dim - ea.size(1),
+                    dtype=ea.dtype,
+                )
+                ea = torch.cat([ea, pad], dim=1)
+            edge_features.append(ea)
+        else:
+            num_edges = ei.size(1)
+            edge_features.append(
+                torch.zeros(num_edges, max_edge_feat_dim, dtype=torch.float)
+            )
+
+    data = Data()
+
+    if node_features:
+        data.x = torch.cat(node_features, dim=0)
+        data.node_type = torch.cat(node_type_ids, dim=0)
+    else:
+        data.x = torch.zeros((0, max_node_feat_dim), dtype=torch.float)
+        data.node_type = torch.zeros((0,), dtype=torch.long)
+
+    if edge_indices:
+        data.edge_index = torch.cat(edge_indices, dim=1)
+        data.edge_type = torch.cat(edge_type_ids, dim=0)
+        data.edge_attr = torch.cat(edge_features, dim=0)
+    else:
+        data.edge_index = torch.zeros((2, 0), dtype=torch.long)
+        data.edge_type = torch.zeros((0,), dtype=torch.long)
+        data.edge_attr = torch.zeros(
+            (0, max(1, max_edge_feat_dim)), dtype=torch.float,
+        )
+
+    data._node_type_names = [
+        str(nt) for nt in hetero.node_types
+    ]
+    data._edge_type_names = [
+        f"{src}__{rel}__{dst}"
+        for src, rel, dst in hetero.edge_types
+    ]
+
+    return data
+
+
+# ---------------------------------------------------------------------------
+# OGB export
+# ---------------------------------------------------------------------------
+
+
+def export_ogb(
+    dataset: CodeGraphDataset,
+    output_dir: str,
+) -> None:
+    """Export a :class:`CodeGraphDataset` to Open Graph Benchmark (OGB) format.
+
+    Creates a directory structure compatible with the ``ogb`` library::
+
+        output_dir/
+        ├── dataset_meta.json
+        ├── raw/
+        │   ├── node-<type>.csv            (per node type)
+        │   └── edge-<src>-<rel>-<dst>.csv  (per edge type)
+        └── processed/
+            └── data.pt
+
+    Parameters
+    ----------
+    dataset:
+        A fully-processed :class:`CodeGraphDataset`.
+    output_dir:
+        Path to the output directory (created if it does not exist).
+
+    Raises
+    ------
+    ImportError
+        If ``torch`` is not installed.
+    """
+    try:
+        import torch
+    except ImportError as exc:
+        raise ImportError(
+            "PyTorch is required for export_ogb. "
+            "Install it with: pip install torch"
+        ) from exc
+
+    out = Path(output_dir)
+    (out / "raw").mkdir(parents=True, exist_ok=True)
+    (out / "processed").mkdir(parents=True, exist_ok=True)
+
+    # Collect all node types and edge types across the dataset
+    all_node_types: set[str] = set()
+    all_edge_triples: set[tuple[str, str, str]] = set()
+    for data in dataset:  # type: ignore[union-attr]
+        all_node_types.update(data.node_types)  # type: ignore[union-attr]
+        all_edge_triples.update(data.edge_types)  # type: ignore[union-attr]
+
+    meta = {
+        "dataset_name": "astrolabe-codegraph",
+        "num_node_types": len(all_node_types),
+        "node_types": sorted(all_node_types),
+        "num_edge_types": len(all_edge_triples),
+        "edge_types": [
+            f"{s}__{r}__{d}" for s, r, d in sorted(all_edge_triples)
+        ],
+        "num_graphs": len(dataset),
+        "node_feat_dim": NODE_FEAT_DIM_BASE,
+        "edge_feat_dim": EDGE_FEAT_DIM,
+    }
+
+    with open(out / "dataset_meta.json", "w", encoding="utf-8") as f:
+        json.dump(meta, f, indent=2)
+
+    # Per-graph raw CSVs
+    for graph_idx, data in enumerate(dataset):  # type: ignore[union-attr]
+        ntype_name_map: dict[str, dict[int, str]] = {}
+
+        for ntype in data.node_types:  # type: ignore[union-attr]
+            x = data[ntype].x  # type: ignore[index]
+            n = data[ntype].num_nodes  # type: ignore[index]
+            feat_cols = {f"feat_{j}": [] for j in range(x.size(1) if x is not None and x.numel() > 0 else 0)}
+            feat_cols["node_idx"] = list(range(n))
+
+            if x is not None and x.numel() > 0:
+                x_np = x.cpu().numpy()
+                for j in range(x_np.shape[1]):
+                    feat_cols[f"feat_{j}"] = x_np[:, j].tolist()
+
+            df = pd.DataFrame(feat_cols)
+            safe_ntype = ntype.replace(" ", "_")
+            df.to_csv(
+                out / "raw" / f"node-{safe_ntype}_graph{graph_idx}.csv",
+                index=False,
+            )
+
+        for rel_type in data.edge_types:  # type: ignore[union-attr]
+            src_type, rel, dst_type = rel_type
+            ei = data[rel_type].edge_index  # type: ignore[index]
+            ea = data[rel_type].edge_attr  # type: ignore[index]
+
+            edge_dict: dict[str, list[int | float]] = {
+                "src_idx": ei[0].cpu().tolist() if ei is not None and ei.numel() > 0 else [],
+                "dst_idx": ei[1].cpu().tolist() if ei is not None and ei.numel() > 0 else [],
+            }
+            if ea is not None and ea.numel() > 0:
+                ea_np = ea.cpu().numpy()
+                for j in range(ea_np.shape[1]):
+                    edge_dict[f"edge_feat_{j}"] = ea_np[:, j].tolist()
+
+            df = pd.DataFrame(edge_dict)
+            safe_key = f"{src_type.replace(' ', '_')}__{rel}__{dst_type.replace(' ', '_')}"
+            df.to_csv(
+                out / "raw" / f"edge-{safe_key}_graph{graph_idx}.csv",
+                index=False,
+            )
+
+    # Save processed data
+    data_list = list(dataset)  # type: ignore[arg-type]
+    torch.save(data_list, out / "processed" / "data.pt")
+
+
+# ---------------------------------------------------------------------------
+# CodeGraphDataset
+# ---------------------------------------------------------------------------
+
+
+class CodeGraphDataset:
+    """PyTorch-Geometric ``InMemoryDataset`` for Astrolabe knowledge graphs.
+
+    Each SQLite database in the ``raw/`` directory represents one graph.
+    The :meth:`process` method loads every ``.db`` file, converts it into a
+    ``HeteroData`` object with a *uniform* node/edge type schema (empty
+    tensors for types that are absent in a particular graph), and saves the
+    resulting list to ``processed/data.pt``.
+
+    Parameters
+    ----------
+    root:
+        Root directory where ``raw/`` and ``processed/`` sub-directories
+        live.
+    transform:
+        A function/transform that takes in a ``HeteroData`` object and
+        returns a transformed version.  Applied every time a graph is
+        accessed.
+    pre_transform:
+        A function/transform that takes in a ``HeteroData`` object and
+        returns a transformed version.  Applied once during
+        :meth:`process`, before saving.
+    pre_filter:
+        A function that takes in a ``HeteroData`` object and returns
+        ``True`` if the graph should be kept.  Applied once during
+        :meth:`process`, before saving.
+
+    Raises
+    ------
+    ImportError
+        On instantiation if ``torch`` or ``torch_geometric`` is not
+        installed.
+    """
+
+    def __init__(
+        self,
+        root: str | Path,
+        transform: Callable | None = None,
+        pre_transform: Callable | None = None,
+        pre_filter: Callable | None = None,
+    ) -> None:
+        try:
+            import torch  # noqa: F401
+            from torch_geometric.data import HeteroData  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "PyTorch and PyTorch-Geometric are required for "
+                "CodeGraphDataset.  Install them with: "
+                "pip install torch torch-geometric"
+            ) from exc
+
+        self._root = Path(root)
+        self._transform = transform
+        self._pre_transform = pre_transform
+        self._pre_filter = pre_filter
+        self._data_list: list | None = None
+
+        # Ensure directories exist
+        (self._root / "raw").mkdir(parents=True, exist_ok=True)
+        (self._root / "processed").mkdir(parents=True, exist_ok=True)
+
+        # If processed data doesn't exist, process raw data
+        processed_path = self._root / "processed" / "data.pt"
+        if not processed_path.exists():
+            self.process()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @property
+    def raw_file_names(self) -> list[str]:
+        """List of ``.db`` files in the ``raw/`` directory."""
+        raw_dir = self._root / "raw"
+        if not raw_dir.exists():
+            return []
+        return sorted(f.name for f in raw_dir.iterdir() if f.suffix == ".db")
+
+    @property
+    def processed_file_names(self) -> list[str]:
+        """List of processed file names (single ``data.pt``)."""
+        return ["data.pt"]
+
+    @property
+    def raw_paths(self) -> list[Path]:
+        """Full paths to ``.db`` files in ``raw/``."""
+        raw_dir = self._root / "raw"
+        if not raw_dir.exists():
+            return []
+        return sorted(raw_dir.glob("*.db"))
+
+    @property
+    def num_graphs(self) -> int:
+        """Number of graphs in the dataset."""
+        return len(self)
+
+    def len(self) -> int:
+        """Number of graphs in the dataset."""
+        if self._data_list is None:
+            self._load()
+        assert self._data_list is not None  # guaranteed after _load()
+        return len(self._data_list)
+
+    def __len__(self) -> int:
+        return self.len()
+
+    def __getitem__(self, idx: int) -> HeteroData:
+        """Return the ``HeteroData`` at *idx*, with ``transform`` applied."""
+        import torch  # noqa: F401
+
+        if self._data_list is None:
+            self._load()
+
+        assert self._data_list is not None  # guaranteed after _load()
+        data = self._data_list[idx]
+
+        if self._transform is not None:
+            data = self._transform(data)
+
+        return data
+
+    def __iter__(self) -> Iterator[HeteroData]:
+        """Iterate over graphs in the dataset."""
+        for i in range(len(self)):
+            yield self[i]
+
+    # ------------------------------------------------------------------
+    # Processing pipeline
+    # ------------------------------------------------------------------
+
+    def process(self) -> None:
+        """Load raw ``.db`` files, convert to ``HeteroData``, and save.
+
+        Two-pass strategy:
+
+        1. **Schema pass** — scan all databases to discover the complete
+           set of node types and edge-type triples across the entire
+           dataset.
+        2. **Conversion pass** — convert each database into a
+           ``HeteroData`` using the unified schema so that every graph
+           has an identical set of node and edge types (with empty
+           tensors for missing types).
+        """
+        import torch
+
+        db_paths = list(self.raw_paths)
+        if not db_paths:
+            raise FileNotFoundError(
+                f"No .db files found in {self._root / 'raw'}. "
+                "Place Astrolabe SQLite databases there before processing."
+            )
+
+        # ---- Pass 1: collect schema ----
+        all_node_types: set[str] = set()
+        all_edge_triples: set[tuple[str, str, str]] = set()
+
+        graph_data: list[tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]] = []
+        for db_path in db_paths:
+            nodes_df, edges_df, emb_df, met_df = self._load_db(db_path)
+            graph_data.append((nodes_df, edges_df, emb_df, met_df))
+
+            all_node_types.update(nodes_df["label"].astype(str).unique().tolist())
+
+            nid_to_label = dict(
+                zip(nodes_df["id"].astype(str), nodes_df["label"].astype(str))
+            )
+            for _, edge in edges_df.iterrows():
+                src_type = nid_to_label.get(str(edge["source_id"]))
+                dst_type = nid_to_label.get(str(edge["target_id"]))
+                if src_type is not None and dst_type is not None:
+                    all_edge_triples.add(
+                        (src_type, str(edge["type"]), dst_type)
+                    )
+
+        # Merge with canonical types
+        all_node_types.update(NODE_LABELS)
+        sorted_node_types = sorted(all_node_types)
+        sorted_edge_triples = sorted(all_edge_triples)
+
+        # ---- Pass 2: convert each graph ----
+        data_list: list = []
+        for nodes_df, edges_df, emb_df, met_df in graph_data:
+            hetero = graph_to_hetero_data(
+                nodes_df=nodes_df,
+                edges_df=edges_df,
+                embeddings_df=emb_df,
+                metrics_df=met_df,
+                all_node_types=sorted_node_types,
+                all_edge_type_triples=sorted_edge_triples,
+            )
+
+            if self._pre_filter is not None and not self._pre_filter(hetero):
+                continue
+
+            if self._pre_transform is not None:
+                hetero = self._pre_transform(hetero)
+
+            data_list.append(hetero)
+
+        # ---- Save ----
+        processed_path = self._root / "processed" / "data.pt"
+        torch.save(data_list, str(processed_path))
+        self._data_list = data_list
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _load(self) -> None:
+        """Load processed data from disk."""
+        import torch
+
+        processed_path = self._root / "processed" / "data.pt"
+        if not processed_path.exists():
+            self.process()
+            return
+        loaded = torch.load(str(processed_path), weights_only=False)
+        self._data_list = loaded if isinstance(loaded, list) else []
+
+    @staticmethod
+    def _load_db(
+        db_path: Path,
+    ) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+        """Read an Astrolabe SQLite database into four DataFrames.
+
+        Returns ``(nodes_df, edges_df, embeddings_df, metrics_df)``.
+        If a table is missing the function returns an empty DataFrame for
+        it rather than raising.
+        """
+        conn = sqlite3.connect(str(db_path))
+        try:
+            nodes_df = pd.read_sql("SELECT * FROM nodes", conn)
+        except Exception:
+            nodes_df = pd.DataFrame()
+        try:
+            edges_df = pd.read_sql("SELECT * FROM edges", conn)
+        except Exception:
+            edges_df = pd.DataFrame()
+        try:
+            embeddings_df = pd.read_sql("SELECT * FROM embeddings", conn)
+        except Exception:
+            embeddings_df = pd.DataFrame()
+        try:
+            metrics_df = pd.read_sql("SELECT * FROM metrics", conn)
+        except Exception:
+            metrics_df = pd.DataFrame()
+        conn.close()
+        return nodes_df, edges_df, embeddings_df, metrics_df

--- a/packages/astrolabe-datasets/astrolabe_datasets/spark_backend.py
+++ b/packages/astrolabe-datasets/astrolabe_datasets/spark_backend.py
@@ -1,0 +1,948 @@
+"""Apache Spark GraphFrames distributed backend for Astrolabe knowledge graphs.
+
+Provides a ``SparkGraphFrameBackend`` that wraps a knowledge graph as a
+distributed GraphFrames object, enabling large-scale graph analytics
+(PageRank, community detection, shortest paths, etc.) on clusters or
+locally via Spark Connect.
+
+All ``pyspark`` and ``graphframes`` imports are guarded at the function
+level so that the module can be imported safely in environments that lack
+Spark — callers will only hit ``ImportError`` when they actually invoke
+a method that needs the distributed runtime.
+
+Node and edge property columns are preserved verbatim as GraphFrame
+vertex/edge properties.  Additionally, *vertex property groups* are
+registered per unique ``label`` value and *edge property groups* per
+unique ``type`` value so that downstream consumers can filter by node
+category or edge category efficiently.
+
+Typical usage::
+
+    from astrolabe_datasets.spark_backend import SparkGraphFrameBackend
+
+    backend = SparkGraphFrameBackend(nodes_df, edges_df)
+    gf = backend.to_graph_frame()
+    pr = backend.pagerank()
+    cc = backend.connected_components()
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+import pandas as pd
+
+if TYPE_CHECKING:
+    from graphframes import GraphFrame
+    from pyspark.sql import DataFrame as SparkDataFrame
+    from pyspark.sql import SparkSession
+
+
+# ---------------------------------------------------------------------------
+# Node / Edge schema constants
+# ---------------------------------------------------------------------------
+
+NODE_COLUMNS: list[str] = [
+    "id",
+    "label",
+    "name",
+    "filePath",
+    "startLine",
+    "endLine",
+    "language",
+    "isExported",
+    "visibility",
+    "parameterCount",
+    "isAsync",
+    "isStatic",
+]
+
+EDGE_COLUMNS: list[str] = [
+    "id",
+    "source_id",
+    "target_id",
+    "type",
+    "confidence",
+    "reason",
+    "step",
+]
+
+NODE_LABELS: list[str] = [
+    "Project",
+    "Package",
+    "Module",
+    "Folder",
+    "File",
+    "Section",
+    "Class",
+    "Function",
+    "Method",
+    "Variable",
+    "Interface",
+    "Enum",
+    "Decorator",
+    "Import",
+    "Type",
+    "CodeElement",
+    "Struct",
+    "Constructor",
+    "Community",
+    "Process",
+    "Macro",
+    "Typedef",
+    "Union",
+    "Namespace",
+    "Trait",
+    "Impl",
+    "TypeAlias",
+    "Const",
+    "Static",
+    "Property",
+    "Record",
+    "Delegate",
+    "Annotation",
+    "Template",
+    "Route",
+    "Tool",
+    "Framework",
+]
+
+EDGE_TYPES: list[str] = [
+    "CONTAINS",
+    "CALLS",
+    "EXTENDS",
+    "METHOD_OVERRIDES",
+    "METHOD_IMPLEMENTS",
+    "IMPORTS",
+    "USES",
+    "DEFINES",
+    "DECORATES",
+    "IMPLEMENTS",
+    "HAS_METHOD",
+    "HAS_PROPERTY",
+    "ACCESSES",
+    "MEMBER_OF",
+    "STEP_IN_PROCESS",
+    "HANDLES_ROUTE",
+    "FETCHES",
+    "HANDLES_TOOL",
+    "ENTRY_POINT_OF",
+    "WRAPS",
+    "QUERIES",
+    "USES_FRAMEWORK",
+    "RETURNS_TYPE",
+    "DECLARES_TYPE",
+    "CHAINABLE_TO",
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_pyspark() -> None:
+    """Raise an actionable ``ImportError`` when ``pyspark`` is missing."""
+    try:
+        import pyspark  # noqa: F401 — availability check
+    except ImportError as exc:
+        raise ImportError(
+            "pyspark is required for the Spark GraphFrames backend.  "
+            "Install it with:  pip install 'astrolabe-datasets[spark]'  "
+            "or  pip install pyspark>=3.5 graphframes>=0.11"
+        ) from exc
+
+
+def _require_graphframes() -> None:
+    """Raise an actionable ``ImportError`` when ``graphframes`` is missing."""
+    try:
+        import graphframes  # noqa: F401 — availability check
+    except ImportError as exc:
+        raise ImportError(
+            "graphframes is required for the Spark GraphFrames backend.  "
+            "Install it with:  pip install 'astrolabe-datasets[spark]'  "
+            "or  pip install graphframes>=0.11"
+        ) from exc
+
+
+def _create_or_get_session(
+    spark_session: Optional[SparkSession] = None,
+) -> SparkSession:
+    """Return an existing ``SparkSession`` or create a local-mode one.
+
+    Supports both classic cluster sessions and Spark Connect (remote)
+    sessions — the caller simply passes whichever session they have.
+
+    Parameters
+    ----------
+    spark_session:
+        An existing ``pyspark.sql.SparkSession``, or ``None`` to create
+        a local-mode session with sensible defaults.
+
+    Returns
+    -------
+    pyspark.sql.SparkSession
+    """
+    _require_pyspark()
+    from pyspark.sql import SparkSession
+
+    if spark_session is not None:
+        return spark_session
+
+    return (
+        SparkSession.builder
+        .appName("astrolabe-graphframes")
+        .master("local[*]")
+        .config("spark.sql.shuffle.partitions", "8")
+        .config("spark.jars.packages", "graphframes:graphframes:0.8.4-spark3.5-s_2.12")
+        .getOrCreate()
+    )
+
+
+def _pandas_to_spark_df(
+    pdf: pd.DataFrame,
+    spark: SparkSession,
+) -> SparkDataFrame:
+    """Convert a pandas DataFrame to a Spark DataFrame.
+
+    Handles nullable integer columns by casting them to ``LongType`` so
+    that Spark does not silently promote to ``DoubleType``.
+
+    Parameters
+    ----------
+    pdf:
+        Source pandas DataFrame.
+    spark:
+        Active ``pyspark.sql.SparkSession``.
+
+    Returns
+    -------
+    pyspark.sql.DataFrame
+    """
+    _require_pyspark()
+    from pyspark.sql.types import LongType
+
+    # Pandas columns that contain NaN in integer columns cause Spark to
+    # infer DoubleType.  Explicitly cast known integer columns.
+    int_cols = [
+        c for c in pdf.columns
+        if pd.api.types.is_integer_dtype(pdf[c])
+        or (pd.api.types.is_float_dtype(pdf[c]) and (pdf[c] % 1 == 0).all())
+    ]
+    sdf = spark.createDataFrame(pdf)
+    for col_name in int_cols:
+        if col_name in sdf.columns:
+            sdf = sdf.withColumn(col_name, sdf[col_name].cast(LongType()))
+    return sdf
+
+
+def _build_vertex_df(
+    nodes_df: pd.DataFrame,
+    spark: SparkSession,
+) -> tuple[SparkDataFrame, dict[str, list[str]]]:
+    """Build the GraphFrames vertex DataFrame and property-group map.
+
+    The vertex DataFrame uses ``id`` as the vertex identifier.  All
+    original columns are preserved as vertex properties.  A *vertex
+    property group* map is returned that maps each node label to the
+    list of columns relevant for that label.
+
+    Parameters
+    ----------
+    nodes_df:
+        Pandas DataFrame with at least an ``id`` and ``label`` column.
+    spark:
+        Active SparkSession.
+
+    Returns
+    -------
+    tuple[pyspark.sql.DataFrame, dict[str, list[str]]]
+        The vertex Spark DataFrame and a mapping of label → property
+        column names.
+    """
+    v_pdf = nodes_df.rename(columns={"id": "id"})
+    v_sdf = _pandas_to_spark_df(v_pdf, spark)
+
+    # Build property groups: for each label, list columns that have
+    # at least one non-null value for that label.
+    property_groups: dict[str, list[str]] = {}
+    for label in v_pdf["label"].unique():
+        subset = v_pdf[v_pdf["label"] == label]
+        cols = [
+            c for c in subset.columns
+            if c != "id" and subset[c].notna().any()
+        ]
+        if cols:
+            property_groups[str(label)] = cols
+
+    return v_sdf, property_groups
+
+
+def _build_edge_df(
+    edges_df: pd.DataFrame,
+    spark: SparkSession,
+) -> tuple[SparkDataFrame, dict[str, list[str]]]:
+    """Build the GraphFrames edge DataFrame and property-group map.
+
+    The edge DataFrame uses ``src`` and ``dst`` as endpoint columns
+    (mapped from ``source_id`` / ``target_id``).  A *edge property
+    group* map is returned that maps each edge type to the list of
+    property columns relevant for that type.
+
+    Parameters
+    ----------
+    edges_df:
+        Pandas DataFrame with at least ``source_id``, ``target_id``,
+        and ``type`` columns.
+    spark:
+        Active SparkSession.
+
+    Returns
+    -------
+    tuple[pyspark.sql.DataFrame, dict[str, list[str]]]
+        The edge Spark DataFrame and a mapping of type → property
+        column names.
+    """
+    _require_pyspark()
+    from pyspark.sql.functions import col
+
+    e_pdf = edges_df.rename(
+        columns={"source_id": "src", "target_id": "dst"}
+    )
+    e_sdf = _pandas_to_spark_df(e_pdf, spark)
+
+    # GraphFrames requires 'src' and 'dst' columns.
+    if "src" not in e_sdf.columns or "dst" not in e_sdf.columns:
+        raise ValueError(
+            "Edge DataFrame must contain 'source_id' and 'target_id' columns "
+            "(renamed to 'src' and 'dst' for GraphFrames)."
+        )
+
+    # Build property groups: for each edge type, list columns that have
+    # at least one non-null value for that type.
+    property_groups: dict[str, list[str]] = {}
+    for etype in e_pdf["type"].unique():
+        subset = e_pdf[e_pdf["type"] == etype]
+        cols = [
+            c
+            for c in subset.columns
+            if c not in ("src", "dst") and subset[c].notna().any()
+        ]
+        if cols:
+            property_groups[str(etype)] = cols
+
+    return e_sdf, property_groups
+
+
+# ---------------------------------------------------------------------------
+# Main class
+# ---------------------------------------------------------------------------
+
+
+class SparkGraphFrameBackend:
+    """Distributed GraphFrames backend for an Astrolabe knowledge graph.
+
+    Wraps node/edge pandas DataFrames as a Spark GraphFrames object
+    and exposes common graph algorithms as methods.  A
+    ``SparkSession`` is created lazily in local mode when none is
+    supplied, making interactive exploration straightforward while
+    still supporting cluster deployment via Spark Connect.
+
+    Parameters
+    ----------
+    nodes_df:
+        Pandas DataFrame of nodes.  Must contain at least ``id`` and
+        ``label`` columns (see :data:`NODE_COLUMNS` for the full
+        schema).
+    edges_df:
+        Pandas DataFrame of edges.  Must contain at least
+        ``source_id``, ``target_id``, and ``type`` columns (see
+        :data:`EDGE_COLUMNS`).
+    embeddings_df:
+        Optional pandas DataFrame of pre-computed node embeddings.
+        Must contain an ``id`` column that matches node IDs.
+    metrics_df:
+        Optional pandas DataFrame of pre-computed node/edge metrics.
+    spark_session:
+        An existing ``pyspark.sql.SparkSession``.  When ``None``, a
+        local-mode session is created on first use.
+
+    Attributes
+    ----------
+    vertex_property_groups:
+        Mapping of node label → list of property column names.
+    edge_property_groups:
+        Mapping of edge type → list of property column names.
+    """
+
+    def __init__(
+        self,
+        nodes_df: pd.DataFrame,
+        edges_df: pd.DataFrame,
+        embeddings_df: Optional[pd.DataFrame] = None,
+        metrics_df: Optional[pd.DataFrame] = None,
+        spark_session: Optional[SparkSession] = None,
+    ) -> None:
+        _require_pyspark()
+        _require_graphframes()
+
+        self._nodes_pdf = nodes_df.copy()
+        self._edges_pdf = edges_df.copy()
+        self._embeddings_pdf = embeddings_df.copy() if embeddings_df is not None else None
+        self._metrics_pdf = metrics_df.copy() if metrics_df is not None else None
+        self._spark = spark_session  # may be None → created lazily
+
+        # Validate minimum schema requirements.
+        if "id" not in self._nodes_pdf.columns:
+            raise ValueError("nodes_df must contain an 'id' column")
+        if "label" not in self._nodes_pdf.columns:
+            raise ValueError("nodes_df must contain a 'label' column")
+        if "source_id" not in self._edges_pdf.columns:
+            raise ValueError("edges_df must contain a 'source_id' column")
+        if "target_id" not in self._edges_pdf.columns:
+            raise ValueError("edges_df must contain a 'target_id' column")
+        if "type" not in self._edges_pdf.columns:
+            raise ValueError("edges_df must contain a 'type' column")
+
+        # Build Spark DataFrames lazily via property.
+        self._vertex_sdf: Optional[SparkDataFrame] = None
+        self._edge_sdf: Optional[SparkDataFrame] = None
+        self.vertex_property_groups: dict[str, list[str]] = {}
+        self.edge_property_groups: dict[str, list[str]] = {}
+
+    # -- lazy Spark session ------------------------------------------------
+
+    @property
+    def spark(self) -> SparkSession:
+        """Return the active ``SparkSession``, creating one if needed."""
+        if self._spark is None:
+            self._spark = _create_or_get_session()
+        return self._spark
+
+    # -- lazy vertex / edge DataFrames ------------------------------------
+
+    def _ensure_dataframes(self) -> None:
+        """Build vertex and edge Spark DataFrames if not yet built."""
+        if self._vertex_sdf is not None and self._edge_sdf is not None:
+            return
+
+        v_sdf, v_groups = _build_vertex_df(self._nodes_pdf, self.spark)
+        e_sdf, e_groups = _build_edge_df(self._edges_pdf, self.spark)
+
+        # Merge embeddings if provided.
+        if self._embeddings_pdf is not None:
+            emb_sdf = _pandas_to_spark_df(self._embeddings_pdf, self.spark)
+            v_sdf = v_sdf.join(emb_sdf, on="id", how="left")
+
+        # Merge metrics if provided.
+        if self._metrics_pdf is not None:
+            met_sdf = _pandas_to_spark_df(self._metrics_pdf, self.spark)
+            # Heuristic: if the metrics DataFrame has an 'id' column,
+            # join on vertices; otherwise treat it as edge metrics.
+            if "id" in self._metrics_pdf.columns:
+                v_sdf = v_sdf.join(met_sdf, on="id", how="left")
+            elif "src" in met_sdf.columns:
+                e_sdf = e_sdf.join(met_sdf, on=["src", "dst"], how="left")
+
+        self._vertex_sdf = v_sdf
+        self._edge_sdf = e_sdf
+        self.vertex_property_groups = v_groups
+        self.edge_property_groups = e_groups
+
+    # -- GraphFrame construction -------------------------------------------
+
+    def to_graph_frame(self) -> GraphFrame:
+        """Build and return a ``GraphFrame`` from the stored data.
+
+        The vertex DataFrame uses ``id`` as the vertex identifier and
+        preserves all node properties as columns.  The edge DataFrame
+        uses ``src`` and ``dst`` for endpoints and preserves all edge
+        properties.
+
+        Vertex property groups (keyed by node ``label``) and edge
+        property groups (keyed by edge ``type``) are populated on the
+        instance for downstream filtering.
+
+        Returns
+        -------
+        graphframes.GraphFrame
+        """
+        _require_graphframes()
+        from graphframes import GraphFrame
+
+        self._ensure_dataframes()
+        assert self._vertex_sdf is not None
+        assert self._edge_sdf is not None
+
+        # Ensure no duplicate vertex IDs — GraphFrame requires uniqueness.
+        from pyspark.sql.functions import col
+
+        v = self._vertex_sdf
+        e = self._edge_sdf
+
+        # Ensure edge endpoints reference valid vertex IDs.
+        vertex_ids = v.select("id").withColumnRenamed("id", "vid")
+        e = e.join(
+            vertex_ids.withColumnRenamed("vid", "src_valid"),
+            e["src"] == col("src_valid"),
+            "left_semi",
+        )
+        e = e.join(
+            vertex_ids.withColumnRenamed("vid", "dst_valid"),
+            e["dst"] == col("dst_valid"),
+            "left_semi",
+        )
+        e = e.drop("src_valid", "dst_valid")
+
+        return GraphFrame(v, e)
+
+    # -- Graph algorithms --------------------------------------------------
+
+    def pagerank(
+        self,
+        reset_probability: float = 0.15,
+        max_iter: int = 20,
+        tol: float = 1e-4,
+    ) -> SparkDataFrame:
+        """Run distributed PageRank on the knowledge graph.
+
+        Parameters
+        ----------
+        reset_probability:
+            Probability of resetting to a random vertex (alpha).
+        max_iter:
+            Maximum number of iterations.
+        tol:
+            Convergence tolerance.
+
+        Returns
+        -------
+        pyspark.sql.DataFrame
+            DataFrame with columns ``id`` and ``pagerank``.
+        """
+        gf = self.to_graph_frame()
+        return gf.pageRank(
+            resetProbability=reset_probability,
+            maxIter=max_iter,
+            tol=tol,
+        ).vertices.select("id", "pagerank")
+
+    def connected_components(self) -> SparkDataFrame:
+        """Compute connected components of the knowledge graph.
+
+        Uses the GraphFrames connected components algorithm which is
+        based on iterative label propagation.
+
+        Returns
+        -------
+        pyspark.sql.DataFrame
+            DataFrame with columns ``id`` and ``component``.
+        """
+        gf = self.to_graph_frame()
+        return gf.connectedComponents().select("id", "component")
+
+    def label_propagation(self, max_iter: int = 20) -> SparkDataFrame:
+        """Run label propagation community detection.
+
+        Each vertex is initially assigned its own label; at each step
+        vertices adopt the most frequent label among their neighbours.
+
+        Parameters
+        ----------
+        max_iter:
+            Maximum number of iterations.
+
+        Returns
+        -------
+        pyspark.sql.DataFrame
+            DataFrame with columns ``id`` and ``label`` (community
+            label, not the original node label).
+        """
+        gf = self.to_graph_frame()
+        result = gf.labelPropagation(maxIter=max_iter)
+        return result.select("id", "label")
+
+    def bfs(
+        self,
+        from_expr: str,
+        to_expr: str,
+        max_path_length: int = 10,
+    ) -> SparkDataFrame:
+        """Breadth-first search for shortest paths.
+
+        Finds the shortest path between vertices matching ``from_expr``
+        and vertices matching ``to_expr`` using GraphFrames BFS.
+
+        Parameters
+        ----------
+        from_expr:
+            SQL expression identifying the starting vertices,
+            e.g. ``"id = 'module:auth'"`` or ``"label = 'Function'"``.
+        to_expr:
+            SQL expression identifying the destination vertices,
+            e.g. ``"id = 'module:db'"`` or ``"name = 'connect'"``.
+        max_path_length:
+            Upper bound on path length to explore.
+
+        Returns
+        -------
+        pyspark.sql.DataFrame
+            DataFrame where each row is a path with columns ``from``
+            and ``to`` plus intermediate edge columns.
+        """
+        from pyspark.sql.functions import col
+
+        gf = self.to_graph_frame()
+        return gf.bfs(
+            fromExpr=from_expr,
+            toExpr=to_expr,
+            maxPathLength=max_path_length,
+        )
+
+    def shortest_paths(self, landmarks: list[str]) -> SparkDataFrame:
+        """Compute shortest-path distances to a set of landmark vertices.
+
+        Parameters
+        ----------
+        landmarks:
+            List of vertex IDs to use as landmarks.
+
+        Returns
+        -------
+        pyspark.sql.DataFrame
+            DataFrame with columns ``id`` and ``distances`` (a map
+            from landmark ID to distance).
+        """
+        gf = self.to_graph_frame()
+        return gf.shortestPaths(landmarks=landmarks)
+
+    def triangle_count(self) -> SparkDataFrame:
+        """Count the number of triangles passing through each vertex.
+
+        Returns
+        -------
+        pyspark.sql.DataFrame
+            DataFrame with columns ``id`` and ``triangle_count``.
+        """
+        gf = self.to_graph_frame()
+        result = gf.triangleCount()
+        return result.select("id", "triangle_count")
+
+    def k_core(self, k: int) -> GraphFrame:
+        """Compute the k-core decomposition of the graph.
+
+        A k-core is the maximal subgraph in which every vertex has at
+        least ``k`` neighbours *within the subgraph*.  The method
+        iteratively prunes vertices with degree less than ``k``.
+
+        Parameters
+        ----------
+        k:
+            Core number.
+
+        Returns
+        -------
+        graphframes.GraphFrame
+            A new GraphFrame containing only the k-core subgraph.
+        """
+        _require_graphframes()
+        from graphframes import GraphFrame
+        from pyspark.sql.functions import col, lit, size
+
+        gf = self.to_graph_frame()
+        v = gf.vertices
+        e = gf.edges
+
+        # Iteratively prune vertices with degree < k until stable.
+        for _ in range(100):  # safety bound
+            # Compute degree.
+            out_deg = e.groupBy("src").count().withColumnRenamed("count", "out_deg")
+            in_deg = e.groupBy("dst").count().withColumnRenamed("count", "in_deg")
+            deg = (
+                out_deg.join(in_deg, out_deg["src"] == in_deg["dst"], "full_outer")
+                .select(
+                    col("src").alias("id"),
+                    (col("out_deg").fillna(0) + col("in_deg").fillna(0)).alias("degree"),
+                )
+            )
+            # Identify valid vertices (degree >= k).
+            valid_ids = deg.filter(col("degree") >= k).select("id")
+            # Prune vertices.
+            v_new = v.join(valid_ids, on="id", how="inner")
+            # Prune edges to only reference remaining vertices.
+            valid_src = valid_ids.withColumnRenamed("id", "valid_src")
+            valid_dst = valid_ids.withColumnRenamed("id", "valid_dst")
+            e_new = (
+                e.join(valid_src, e["src"] == col("valid_src"), "inner")
+                 .join(valid_dst, e["dst"] == col("valid_dst"), "inner")
+                 .drop("valid_src", "valid_dst")
+            )
+            # Check convergence.
+            if v_new.count() == v.count():
+                break
+            v = v_new
+            e = e_new
+
+        return GraphFrame(v, e)
+
+    def random_walk_embeddings(
+        self,
+        walk_length: int = 10,
+        num_walks: int = 100,
+        vector_size: int = 128,
+        window_size: int = 5,
+        min_count: int = 1,
+    ) -> SparkDataFrame:
+        """Generate node embeddings via random walks + Word2Vec.
+
+        Performs ``num_walks`` random walks of length ``walk_length``
+        starting from each vertex, then trains Spark ML Word2Vec on
+        the resulting corpus of walks.
+
+        Parameters
+        ----------
+        walk_length:
+            Length of each random walk.
+        num_walks:
+            Number of walks per vertex.
+        vector_size:
+            Dimensionality of the resulting embedding vectors.
+        window_size:
+            Context window size for Word2Vec.
+        min_count:
+            Minimum frequency for a word (node ID) to be included.
+
+        Returns
+        -------
+        pyspark.sql.DataFrame
+            DataFrame with columns ``id`` and ``embedding`` (vector).
+        """
+        from pyspark.sql.functions import col, collect_list, explode, lit, rand, sequence, size
+        from pyspark.sql.types import ArrayType, StringType
+        from pyspark.ml.feature import Word2Vec
+
+        gf = self.to_graph_frame()
+
+        # ------------------------------------------------------------------
+        # Build adjacency list for random walk sampling.
+        # ------------------------------------------------------------------
+        edges = gf.edges.select("src", "dst")
+        adj = edges.groupBy("src").agg(collect_list("dst").alias("neighbours"))
+
+        # Also include reverse direction (undirected walks).
+        rev = edges.select(col("src").alias("rev_src"), col("dst").alias("rev_dst"))
+        rev_adj = rev.groupBy("rev_dst").agg(collect_list("rev_src").alias("rev_neighbours"))
+        rev_adj = rev_adj.withColumnRenamed("rev_dst", "src")
+
+        # Merge forward and reverse adjacency.
+        adj = adj.join(rev_adj, on="src", how="full_outer")
+        from pyspark.sql.functions import array_distinct, concat, when
+
+        adj = adj.withColumn(
+            "neighbours",
+            array_distinct(
+                concat(
+                    col("neighbours"),
+                    when(col("rev_neighbours").isNotNull(), col("rev_neighbours")).otherwise(
+                        lit([])
+                    ),
+                )
+            ),
+        ).select("src", "neighbours")
+
+        vertices = gf.vertices.select("id")
+
+        # ------------------------------------------------------------------
+        # Random walk simulation using Spark iteration.
+        # ------------------------------------------------------------------
+        # For each vertex, generate num_walks walks of walk_length steps.
+        # We use a cross-join + iterative approach.
+        from pyspark.sql.types import StructField, StructType
+
+        # Seed: (vertex_id, walk_index, current_position, walk_so_far)
+        seed = vertices.crossJoin(
+            self.spark.range(0, num_walks).withColumnRenamed("id", "walk_idx")
+        ).select(
+            col("id").alias("start_id"),
+            col("walk_idx"),
+            col("id").alias("current"),
+            col("id").alias("walk_step_0"),
+        )
+
+        # We will iteratively extend walks.  For efficiency we collect
+        # walk steps as an array.
+        from pyspark.sql.functions import array, size as arr_size
+
+        current = vertices.crossJoin(
+            self.spark.range(0, num_walks).withColumnRenamed("id", "walk_idx")
+        ).withColumn("walk", array(col("id"))).withColumn("current", col("id"))
+        current = current.select("current", "walk_idx", "walk")
+
+        for _step in range(walk_length):
+            # Join current positions with adjacency list.
+            current = current.join(
+                adj.withColumnRenamed("src", "current").withColumnRenamed(
+                    "neighbours", "nbrs"
+                ),
+                on="current",
+                how="left",
+            )
+            # Sample a random neighbour.
+            from pyspark.sql.functions import element_at, floor, size as arr_size2
+
+            current = current.withColumn(
+                "nbr_count",
+                when(col("nbrs").isNotNull(), arr_size2(col("nbrs"))).otherwise(lit(0)),
+            )
+            # If a vertex has neighbours, pick a random one; otherwise stay.
+            current = current.withColumn(
+                "rand_idx",
+                when(col("nbr_count") > 0, floor(rand() * col("nbr_count")) + 1).otherwise(
+                    lit(1)
+                ),
+            )
+            current = current.withColumn(
+                "next",
+                when(
+                    col("nbr_count") > 0,
+                    element_at(col("nbrs"), col("rand_idx").cast("int")),
+                ).otherwise(col("current")),
+            )
+            # Append to walk array.
+            current = current.withColumn(
+                "walk",
+                when(col("next").isNotNull(), concat(col("walk"), array(col("next")))).otherwise(
+                    col("walk")
+                ),
+            )
+            # Move to next position.
+            current = current.withColumn("current", col("next")).select(
+                "current", "walk_idx", "walk"
+            )
+
+        # Each row is now a walk (array of node IDs).
+        walks_df = current.select(col("walk").alias("walk"))
+
+        # Cast walk elements to string for Word2Vec.
+        from pyspark.sql.functions import transform as array_transform
+
+        walks_df = walks_df.withColumn(
+            "walk_str",
+            array_transform(col("walk"), lambda x: x.cast("string")),
+        ).select("walk_str")
+
+        # ------------------------------------------------------------------
+        # Train Word2Vec on the walks.
+        # ------------------------------------------------------------------
+        w2v = Word2Vec(
+            vectorSize=vector_size,
+            windowSize=window_size,
+            minCount=min_count,
+            inputCol="walk_str",
+            outputCol="embedding",
+        )
+        model = w2v.fit(walks_df)
+
+        # Retrieve embeddings for each node.
+        embeddings = model.getVectors()
+        # Rename columns to match our convention.
+        embeddings = embeddings.withColumnRenamed("word", "id").withColumnRenamed(
+            "vector", "embedding"
+        )
+
+        return embeddings
+
+    # -- Utility methods ---------------------------------------------------
+
+    def to_pyspark_dataframes(self) -> tuple[SparkDataFrame, SparkDataFrame]:
+        """Return the vertex and edge Spark DataFrames.
+
+        Useful when you want to run custom Spark SQL or DataFrame
+        operations without going through the GraphFrames API.
+
+        Returns
+        -------
+        tuple[pyspark.sql.DataFrame, pyspark.sql.DataFrame]
+            Vertex DataFrame (with ``id`` column) and edge DataFrame
+            (with ``src`` and ``dst`` columns).
+        """
+        self._ensure_dataframes()
+        assert self._vertex_sdf is not None
+        assert self._edge_sdf is not None
+        return self._vertex_sdf, self._edge_sdf
+
+
+# ---------------------------------------------------------------------------
+# Convenience loader
+# ---------------------------------------------------------------------------
+
+
+def from_sqlite(
+    db_path: str | Path,
+    spark_session: Optional[SparkSession] = None,
+) -> SparkGraphFrameBackend:
+    """Load a knowledge graph from an Astrolabe SQLite database.
+
+    Reads the ``nodes`` and ``edges`` tables from the given SQLite
+    file, converts them to pandas DataFrames, and constructs a
+    ``SparkGraphFrameBackend``.
+
+    Parameters
+    ----------
+    db_path:
+        Path to the Astrolabe SQLite database.
+    spark_session:
+        Optional existing SparkSession.
+
+    Returns
+    -------
+    SparkGraphFrameBackend
+        Backend initialised from the database contents.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``db_path`` does not exist.
+    ValueError
+        If the database does not contain the expected tables.
+    """
+    import sqlite3
+
+    db_path = Path(db_path)
+    if not db_path.exists():
+        raise FileNotFoundError(f"SQLite database not found: {db_path}")
+
+    with sqlite3.connect(str(db_path)) as conn:
+        # Verify tables exist.
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        if "nodes" not in tables:
+            raise ValueError(
+                f"SQLite database at {db_path} does not contain a 'nodes' table"
+            )
+        if "edges" not in tables:
+            raise ValueError(
+                f"SQLite database at {db_path} does not contain an 'edges' table"
+            )
+
+        nodes_df = pd.read_sql_query("SELECT * FROM nodes", conn)
+        edges_df = pd.read_sql_query("SELECT * FROM edges", conn)
+
+    # Ensure expected column names.
+    if "id" not in nodes_df.columns and "nodeId" in nodes_df.columns:
+        nodes_df = nodes_df.rename(columns={"nodeId": "id"})
+    if "source_id" not in edges_df.columns and "sourceId" in edges_df.columns:
+        edges_df = edges_df.rename(columns={"sourceId": "source_id"})
+    if "target_id" not in edges_df.columns and "targetId" in edges_df.columns:
+        edges_df = edges_df.rename(columns={"targetId": "target_id"})
+
+    return SparkGraphFrameBackend(
+        nodes_df=nodes_df,
+        edges_df=edges_df,
+        spark_session=spark_session,
+    )

--- a/packages/astrolabe-datasets/pyproject.toml
+++ b/packages/astrolabe-datasets/pyproject.toml
@@ -1,0 +1,79 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.backends"
+
+[project]
+name = "astrolabe-datasets"
+version = "0.1.0"
+description = "Python Graph Dataset API for Astrolabe knowledge graphs — PyG, cuGraph, Spark, and Pandas backends"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.10"
+authors = [
+    { name = "Daniel Perez Rubio" },
+]
+keywords = [
+    "knowledge-graph",
+    "gnn",
+    "pytorch-geometric",
+    "cugraph",
+    "spark",
+    "graph-analytics",
+    "code-analysis",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+    "pandas>=2.0",
+    "numpy>=1.24",
+]
+
+[project.optional-dependencies]
+pyg = [
+    "torch>=2.0",
+    "torch-geometric>=2.4",
+]
+cugraph = [
+    "cudf>=24.0",
+    "cugraph>=24.0",
+    "cugraph-pyg>=24.0",
+]
+spark = [
+    "pyspark>=3.5",
+    "graphframes>=0.11",
+]
+igraph = ["python-igraph>=0.11"]
+graph-tool = ["graph-tool>=2.70"]
+networkx = ["networkx>=3.0"]
+export = []
+all = [
+    "torch>=2.0",
+    "torch-geometric>=2.4",
+    "pyspark>=3.5",
+    "graphframes>=0.11",
+    "python-igraph>=0.11",
+    "networkx>=3.0",
+]
+dev = [
+    "pytest>=7.0",
+    "pytest-cov>=4.0",
+]
+
+[project.urls]
+Repository = "https://github.com/danielperezr88/astrolabe"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+markers = [
+    "slow: marks tests as slow",
+    "gpu: marks tests requiring GPU",
+    "spark: marks tests requiring Spark",
+]

--- a/packages/astrolabe-datasets/tests/conftest.py
+++ b/packages/astrolabe-datasets/tests/conftest.py
@@ -1,0 +1,253 @@
+"""Tests for astrolabe_datasets — shared fixtures and test utilities."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import tempfile
+from pathlib import Path
+from typing import Generator
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Constants matching the real Astrolabe schema
+# ---------------------------------------------------------------------------
+
+NODE_LABELS = [
+    "Project", "Package", "Module", "Folder", "File", "Section",
+    "Class", "Function", "Method", "Variable", "Interface", "Enum",
+    "Decorator", "Import", "Type", "CodeElement", "Struct", "Constructor",
+    "Community", "Process",
+    "Macro", "Typedef", "Union", "Namespace", "Trait", "Impl",
+    "TypeAlias", "Const", "Static", "Property",
+    "Record", "Delegate", "Annotation", "Template", "Route", "Tool", "Framework",
+]
+
+EDGE_TYPES = [
+    "CONTAINS", "CALLS", "EXTENDS", "METHOD_OVERRIDES", "METHOD_IMPLEMENTS",
+    "IMPORTS", "USES", "DEFINES", "DECORATES", "IMPLEMENTS",
+    "HAS_METHOD", "HAS_PROPERTY", "ACCESSES", "MEMBER_OF",
+    "STEP_IN_PROCESS", "HANDLES_ROUTE", "FETCHES", "HANDLES_TOOL",
+    "ENTRY_POINT_OF", "WRAPS", "QUERIES", "USES_FRAMEWORK",
+    "RETURNS_TYPE", "DECLARES_TYPE", "CHAINABLE_TO",
+]
+
+
+# ---------------------------------------------------------------------------
+# Fixture: synthetic SQLite database
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def sample_db(tmp_path: Path) -> Path:
+    """Create a minimal Astrolabe SQLite database with test data."""
+    db_path = tmp_path / "test_graph.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode = WAL")
+
+    # -- nodes --
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS nodes (
+            id         TEXT PRIMARY KEY,
+            label      TEXT NOT NULL,
+            properties TEXT NOT NULL DEFAULT '{}'
+        )
+    """)
+    nodes = [
+        ("src/index.ts:AuthService", "Class", json.dumps({
+            "name": "AuthService", "filePath": "src/index.ts",
+            "startLine": 10, "endLine": 50, "language": "typescript",
+            "isExported": True, "visibility": "public",
+            "parameterCount": 0, "level": 0, "isStatic": False, "isAsync": False,
+        })),
+        ("src/index.ts:authenticate", "Method", json.dumps({
+            "name": "authenticate", "filePath": "src/index.ts",
+            "startLine": 15, "endLine": 30, "language": "typescript",
+            "isExported": False, "visibility": "public",
+            "parameterCount": 2, "level": 1, "isStatic": False, "isAsync": True,
+            "returnType": "Promise<boolean>",
+        })),
+        ("src/index.ts:login", "Function", json.dumps({
+            "name": "login", "filePath": "src/index.ts",
+            "startLine": 55, "endLine": 70, "language": "typescript",
+            "isExported": True, "visibility": "public",
+            "parameterCount": 1, "level": 0, "isStatic": False, "isAsync": True,
+        })),
+        ("src/utils.ts:hashPassword", "Function", json.dumps({
+            "name": "hashPassword", "filePath": "src/utils.ts",
+            "startLine": 5, "endLine": 15, "language": "typescript",
+            "isExported": True, "visibility": "public",
+            "parameterCount": 1, "level": 0, "isStatic": False, "isAsync": False,
+        })),
+    ]
+    conn.executemany("INSERT INTO nodes (id, label, properties) VALUES (?, ?, ?)", nodes)
+
+    # -- relationships --
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS relationships (
+            id          TEXT   PRIMARY KEY,
+            source_id   TEXT   NOT NULL,
+            target_id   TEXT   NOT NULL,
+            type        TEXT   NOT NULL,
+            confidence  REAL   NOT NULL DEFAULT 1.0,
+            reason      TEXT   NOT NULL DEFAULT '',
+            step        INTEGER,
+            evidence    TEXT
+        )
+    """)
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_rel_source ON relationships(source_id)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_rel_target ON relationships(target_id)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_rel_type   ON relationships(type)")
+
+    edges = [
+        ("src/index.ts:AuthService-HAS_METHOD-src/index.ts:authenticate",
+         "src/index.ts:AuthService", "src/index.ts:authenticate", "HAS_METHOD",
+         0.95, "Class defines method", None, None),
+        ("src/index.ts:login-CALLS-src/index.ts:authenticate",
+         "src/index.ts:login", "src/index.ts:authenticate", "CALLS",
+         0.9, "Direct call", None, json.dumps([{"kind": "ast-parser", "weight": 0.9}])),
+        ("src/index.ts:authenticate-CALLS-src/utils.ts:hashPassword",
+         "src/index.ts:authenticate", "src/utils.ts:hashPassword", "CALLS",
+         0.85, "Calls utility", None, None),
+        ("src/index.ts:AuthService-CONTAINS-src/index.ts:authenticate",
+         "src/index.ts:AuthService", "src/index.ts:authenticate", "CONTAINS",
+         1.0, "Structural containment", None, None),
+    ]
+    conn.executemany(
+        "INSERT INTO relationships (id, source_id, target_id, type, confidence, reason, step, evidence) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        edges,
+    )
+
+    # -- embeddings --
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS embeddings (
+            node_id    TEXT    PRIMARY KEY,
+            hash       TEXT    NOT NULL,
+            vector     BLOB    NOT NULL,
+            dims       INTEGER NOT NULL DEFAULT 384,
+            indexed_at INTEGER NOT NULL
+        )
+    """)
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_embeddings_hash ON embeddings(hash)")
+
+    dims = 384
+    rng = np.random.default_rng(42)
+    for i, (nid, _, _) in enumerate(nodes):
+        vec = rng.standard_normal(dims).astype(np.float32)
+        conn.execute(
+            "INSERT INTO embeddings (node_id, hash, vector, dims, indexed_at) VALUES (?, ?, ?, ?, ?)",
+            (nid, f"sha1_{i}", vec.tobytes(), dims, 1700000000000 + i),
+        )
+
+    # -- meta --
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS meta (
+            key   TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        )
+    """)
+    conn.execute("INSERT INTO meta (key, value) VALUES (?, ?)", ("schema_version", "1"))
+    conn.execute("INSERT INTO meta (key, value) VALUES (?, ?)", (
+        "health", json.dumps({"overallScore": 0.78, "cohesion": 0.82, "modularity": 0.71,
+                               "complexity": 0.45, "antiPatterns": []}),
+    ))
+    conn.execute("INSERT INTO meta (key, value) VALUES (?, ?)", (
+        "graphlets", json.dumps({"threeNode": {"motif_1": 12, "motif_2": 5},
+                                  "fourNode": {"motif_1": 3}}),
+    ))
+
+    # -- file_hashes --
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS file_hashes (
+            path       TEXT    PRIMARY KEY,
+            hash       TEXT    NOT NULL,
+            indexed_at INTEGER NOT NULL
+        )
+    """)
+    conn.execute("INSERT INTO file_hashes (path, hash, indexed_at) VALUES (?, ?, ?)",
+                 ("src/index.ts", "hash_idx", 1700000000000))
+    conn.execute("INSERT INTO file_hashes (path, hash, indexed_at) VALUES (?, ?, ?)",
+                 ("src/utils.ts", "hash_util", 1700000000001))
+
+    # -- fts_nodes --
+    conn.execute("""
+        CREATE VIRTUAL TABLE IF NOT EXISTS fts_nodes USING fts5(
+            node_id, label, name, filePath, keywords,
+            tokenize='porter unicode61'
+        )
+    """)
+    fts_rows = [
+        ("src/index.ts:AuthService", "Class", "AuthService", "src/index.ts", "auth login"),
+        ("src/index.ts:authenticate", "Method", "authenticate", "src/index.ts", "auth verify"),
+        ("src/index.ts:login", "Function", "login", "src/index.ts", "login session"),
+        ("src/utils.ts:hashPassword", "Function", "hashPassword", "src/utils.ts", "hash password"),
+    ]
+    conn.executemany("INSERT INTO fts_nodes (node_id, label, name, filePath, keywords) VALUES (?, ?, ?, ?, ?)", fts_rows)
+
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+@pytest.fixture
+def sample_nodes_df() -> pd.DataFrame:
+    """Minimal nodes DataFrame matching core.py output schema."""
+    return pd.DataFrame({
+        "id": ["n1", "n2", "n3"],
+        "label": ["Class", "Method", "Function"],
+        "name": ["AuthService", "authenticate", "login"],
+        "filePath": ["src/index.ts", "src/index.ts", "src/index.ts"],
+        "startLine": [10, 15, 55],
+        "endLine": [50, 30, 70],
+        "language": ["typescript", "typescript", "typescript"],
+        "isExported": [True, False, True],
+        "visibility": ["public", "public", "public"],
+        "parameterCount": [0, 2, 1],
+        "level": [0, 1, 0],
+        "isStatic": [False, False, False],
+        "isAsync": [False, True, True],
+    })
+
+
+@pytest.fixture
+def sample_edges_df() -> pd.DataFrame:
+    """Minimal edges DataFrame matching core.py output schema."""
+    return pd.DataFrame({
+        "id": ["e1", "e2", "e3"],
+        "source_id": ["n1", "n3", "n2"],
+        "target_id": ["n2", "n2", "n3"],
+        "type": ["HAS_METHOD", "CALLS", "CALLS"],
+        "confidence": [0.95, 0.9, 0.85],
+        "reason": ["Class defines method", "Direct call", "Calls utility"],
+        "step": [None, None, None],
+    })
+
+
+@pytest.fixture
+def sample_embeddings_df() -> pd.DataFrame:
+    """Minimal embeddings DataFrame with vector as numpy arrays."""
+    rng = np.random.default_rng(42)
+    vecs = [rng.standard_normal(8).astype(np.float32) for _ in range(3)]
+    return pd.DataFrame({
+        "node_id": ["n1", "n2", "n3"],
+        "hash": ["sha1_0", "sha1_1", "sha1_2"],
+        "vector": vecs,
+        "dims": [8, 8, 8],
+        "indexed_at": [1700000000000, 1700000000001, 1700000000002],
+    })
+
+
+@pytest.fixture
+def sample_metrics_df() -> pd.DataFrame:
+    """Minimal metrics DataFrame."""
+    return pd.DataFrame({
+        "node_id": ["n1", "n2", "n3"],
+        "pagerank": [0.35, 0.25, 0.40],
+        "betweenness": [0.1, 0.3, 0.2],
+        "community_id": [0, 0, 1],
+        "cohesion": [0.8, 0.8, 0.9],
+    })

--- a/packages/astrolabe-datasets/tests/test_core.py
+++ b/packages/astrolabe-datasets/tests/test_core.py
@@ -1,0 +1,138 @@
+"""Tests for astrolabe_datasets.core — CodeGraph dataclass and SQLite loader."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from astrolabe_datasets.core import (
+    NODE_LABELS,
+    RELATIONSHIP_TYPES,
+    CodeGraph,
+    load_graph,
+    load_graphs,
+    list_available_graphs,
+)
+
+
+# ---------------------------------------------------------------------------
+# CodeGraph dataclass
+# ---------------------------------------------------------------------------
+
+class TestCodeGraph:
+    """Tests for the CodeGraph dataclass."""
+
+    def test_construct_with_minimal_fields(self) -> None:
+        nodes = pd.DataFrame({"id": ["n1"], "label": ["Class"]})
+        edges = pd.DataFrame({"id": [], "source_id": [], "target_id": [], "type": []})
+        embeddings = pd.DataFrame({"node_id": [], "vector": []})
+        metrics = pd.DataFrame({"node_id": [], "pagerank": []})
+        g = CodeGraph(
+            nodes=nodes, edges=edges, embeddings=embeddings,
+            metrics=metrics, health={}, graphlets={}, metadata={},
+        )
+        assert len(g.nodes) == 1
+        assert len(g.edges) == 0
+
+    def test_node_labels_constant(self) -> None:
+        assert "Class" in NODE_LABELS
+        assert "Function" in NODE_LABELS
+        assert len(NODE_LABELS) >= 30
+
+    def test_relationship_types_constant(self) -> None:
+        assert "CALLS" in RELATIONSHIP_TYPES
+        assert "CONTAINS" in RELATIONSHIP_TYPES
+        assert len(RELATIONSHIP_TYPES) >= 25
+
+
+# ---------------------------------------------------------------------------
+# load_graph
+# ---------------------------------------------------------------------------
+
+class TestLoadGraph:
+    """Tests for load_graph SQLite loader."""
+
+    def test_load_from_valid_db(self, sample_db: Path) -> None:
+        graph = load_graph(sample_db)
+        assert isinstance(graph, CodeGraph)
+        assert len(graph.nodes) == 4
+        assert len(graph.edges) == 4
+        assert len(graph.embeddings) == 4
+        assert graph.health.get("overallScore") is not None
+        assert graph.graphlets is not None
+
+    def test_nodes_have_flattened_properties(self, sample_db: Path) -> None:
+        graph = load_graph(sample_db)
+        # Properties should be flattened into DataFrame columns
+        assert "name" in graph.nodes.columns
+        assert "filePath" in graph.nodes.columns
+        assert "language" in graph.nodes.columns
+
+    def test_embeddings_vector_decoded(self, sample_db: Path) -> None:
+        graph = load_graph(sample_db)
+        # Vector column should contain numpy arrays
+        first_vec = graph.embeddings.iloc[0]["vector"]
+        assert isinstance(first_vec, np.ndarray)
+        assert first_vec.dtype == np.float32
+
+    def test_metadata_loaded(self, sample_db: Path) -> None:
+        graph = load_graph(sample_db)
+        assert "schema_version" in graph.metadata
+
+    def test_load_nonexistent_path_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            load_graph(tmp_path / "nonexistent.db")
+
+    def test_load_db_missing_tables(self, tmp_path: Path) -> None:
+        """DB file exists but has no Astrolabe tables — should return empty DataFrames."""
+        db_path = tmp_path / "empty.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.commit()
+        conn.close()
+        graph = load_graph(db_path)
+        assert len(graph.nodes) == 0
+        assert len(graph.edges) == 0
+
+    def test_edge_confidence_is_float(self, sample_db: Path) -> None:
+        graph = load_graph(sample_db)
+        assert graph.edges["confidence"].dtype in (np.float64, np.float32)
+
+
+# ---------------------------------------------------------------------------
+# load_graphs
+# ---------------------------------------------------------------------------
+
+class TestLoadGraphs:
+    """Tests for load_graphs multi-DB loader."""
+
+    def test_load_multiple(self, sample_db: Path) -> None:
+        graphs = load_graphs([sample_db, sample_db])
+        assert len(graphs) == 2
+        assert all(isinstance(g, CodeGraph) for g in graphs)
+
+    def test_load_empty_list(self) -> None:
+        graphs = load_graphs([])
+        assert graphs == []
+
+
+# ---------------------------------------------------------------------------
+# list_available_graphs
+# ---------------------------------------------------------------------------
+
+class TestListAvailableGraphs:
+    """Tests for list_available_graphs metadata query."""
+
+    def test_returns_metadata(self, sample_db: Path) -> None:
+        info = list_available_graphs(sample_db)
+        assert isinstance(info, dict)
+        assert "node_count" in info or "nodes" in info
+
+    def test_returns_schema_version(self, sample_db: Path) -> None:
+        info = list_available_graphs(sample_db)
+        # Should include metadata from the meta table
+        assert "schema_version" in info or "metadata" in info

--- a/packages/astrolabe-datasets/tests/test_lazy.py
+++ b/packages/astrolabe-datasets/tests/test_lazy.py
@@ -1,0 +1,82 @@
+"""Tests for astrolabe_datasets.lazy — Iterator-based lazy loaders."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from astrolabe_datasets.lazy import iter_nodes, iter_edges, iter_embeddings, stream_graph
+
+
+class TestIterNodes:
+    """Tests for iter_nodes batched node loader."""
+
+    def test_yields_all_nodes(self, sample_db: Path) -> None:
+        batches = list(iter_nodes(sample_db, batch_size=2))
+        total = sum(len(b) for b in batches)
+        assert total == 4  # 4 nodes in fixture
+
+    def test_batch_size_respected(self, sample_db: Path) -> None:
+        batches = list(iter_nodes(sample_db, batch_size=2))
+        # All batches except possibly the last should have <= batch_size rows
+        for b in batches[:-1]:
+            assert len(b) <= 2
+
+    def test_filter_by_label(self, sample_db: Path) -> None:
+        batches = list(iter_nodes(sample_db, batch_size=100, label="Class"))
+        total = sum(len(b) for b in batches)
+        assert total == 1  # Only 1 Class node
+
+    def test_returns_dataframes(self, sample_db: Path) -> None:
+        for batch in iter_nodes(sample_db, batch_size=100):
+            assert isinstance(batch, pd.DataFrame)
+            break
+
+
+class TestIterEdges:
+    """Tests for iter_edges batched edge loader."""
+
+    def test_yields_all_edges(self, sample_db: Path) -> None:
+        batches = list(iter_edges(sample_db, batch_size=2))
+        total = sum(len(b) for b in batches)
+        assert total == 4  # 4 edges in fixture
+
+    def test_filter_by_type(self, sample_db: Path) -> None:
+        batches = list(iter_edges(sample_db, batch_size=100, edge_type="CALLS"))
+        total = sum(len(b) for b in batches)
+        assert total == 2  # 2 CALLS edges
+
+
+class TestIterEmbeddings:
+    """Tests for iter_embeddings batched embedding loader."""
+
+    def test_yields_all_embeddings(self, sample_db: Path) -> None:
+        batches = list(iter_embeddings(sample_db, batch_size=2))
+        total = sum(len(b) for b in batches)
+        assert total == 4
+
+    def test_vector_decoded(self, sample_db: Path) -> None:
+        import numpy as np
+        for batch in iter_embeddings(sample_db, batch_size=100):
+            vec = batch.iloc[0]["vector"]
+            assert isinstance(vec, np.ndarray)
+            assert vec.dtype == np.float32
+            break
+
+
+class TestStreamGraph:
+    """Tests for stream_graph single-record iterator."""
+
+    def test_yields_dicts(self, sample_db: Path) -> None:
+        records = list(stream_graph(sample_db))
+        assert len(records) > 0
+        assert isinstance(records[0], dict)
+
+    def test_contains_node_and_edge_records(self, sample_db: Path) -> None:
+        records = list(stream_graph(sample_db))
+        record_types = {r.get("record_type") or r.get("kind") for r in records}
+        # Should have both node and edge records
+        assert "node" in record_types or "Node" in record_types
+        assert "edge" in record_types or "Edge" in record_types or "relationship" in record_types


### PR DESCRIPTION
Closes #804

## Summary

New \strolabe-datasets\ Python package that exposes Astrolabe knowledge graph data as rich graph datasets consumable by major Data Science and ML frameworks.

### Package Structure (5,522 lines, 13 files)

\\\
astrolabe-datasets/
├── pyproject.toml
├── astrolabe_datasets/
│   ├── __init__.py
│   ├── core.py              # CodeGraph dataclass, SQLite loader, load_graph/load_graphs
│   ├── lazy.py              # Iterator-based batch loaders (iter_nodes, iter_edges, iter_embeddings, stream_graph)
│   ├── pyg_dataset.py       # PyG InMemoryDataset + HeteroData, graph_to_hetero_data, to_homogeneous, export_ogb
│   ├── cugraph_backend.py   # cuGraph GPU backend (Leiden, Louvain, PageRank, HITS, SSSP, Node2Vec)
│   ├── spark_backend.py     # Spark GraphFrames backend (PageRank, connected components, BFS, random walks)
│   ├── pandas_backends.py   # igraph, graph-tool, NetworkX conversions + community detection
│   ├── exporters.py         # OGB, GraphML, GML, CSV exporters
│   └── feature_engineering.py  # One-hot encoding, degree features, normalization
└── tests/
    ├── conftest.py           # Shared fixtures (synthetic SQLite DB)
    ├── test_core.py           # Core loader tests
    └── test_lazy.py           # Lazy loader tests
\\\

### Key Features

- **CodeGraph dataclass** with flattened node properties, decoded embedding vectors, and metadata extraction
- **PyG backend**: HeteroData with 37 node label types, 25 edge types, full feature matrix, schema normalization
- **cuGraph backend**: GPU-accelerated community detection, centrality, shortest paths, Node2Vec
- **Spark backend**: Distributed algorithms via GraphFrames + random walk embeddings
- **Pandas backends**: igraph, graph-tool, NetworkX conversions with community detection
- **Exporters**: OGB, GraphML, GML, CSV multi-format export
- **Feature engineering**: Node type encoding, visibility encoding, degree features, normalization
- **Lazy loading**: Memory-efficient batch iterators for large databases (cursor-based fetchmany)
- **All optional deps guarded**: Package imports without torch/cudf/pyspark/igraph installed

### Backends

| Backend | Install Extra | Key Capabilities |
|---------|--------------|-------------------|
| PyTorch-Geometric | \[pyg]\ | HeteroData, InMemoryDataset, OGB export |
| cuGraph | \[cugraph]\ | GPU Leiden/Louvain, PageRank, HITS, SSSP, Node2Vec |
| Spark GraphFrames | \[spark]\ | Distributed PageRank, BFS, label propagation |
| igraph | \[igraph]\ | Leiden/Louvain, Graph.DataFrame round-trip |
| graph-tool | \[graph-tool]\ | SBM community detection |
| NetworkX | \[networkx]\ | from_pandas_edgelist, general graph algorithms |