### PR TITLE
feat: architecture anti-pattern detection via graph topology (#808)

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -32,6 +32,7 @@ import {
   generateWiki,
   startEvalServer,
   countGraphlets, buildAdjacencyMap, detectPatterns, scoreArchitectureHealth,
+  detectAntiPatterns,
   migrateFromGitNexus,
 } from '@astrolabe-dev/core';
 // #463: Coverage report parser
@@ -1102,6 +1103,75 @@ program
       for (const ap of health.antiPatterns) console.log(`  [${ap.severity}] ${ap.name}: ${ap.description}`);
     }
     console.log();
+  });
+
+// ── detect-smells ──────────────────────────────────────────────────────────
+program
+  .command('detect-smells [repoPath]')
+  .description('Detect architecture smells in the knowledge graph (cycles, god modules, unstable deps, meshes)')
+  .option('-d, --db <path>', 'Database path', '.astrolabe/astrolabe.db')
+  .option('--json', 'Output as JSON')
+  .option('--fan-in <number>', 'Fan-in threshold for hub detection')
+  .option('--fan-out <number>', 'Fan-out threshold for hub detection')
+  .option('--density <number>', 'Density threshold for mesh detection (0-1)')
+  .action((repoPath: string | undefined, opts: { db: string; json?: boolean; fanIn?: string; fanOut?: string; density?: string }) => {
+    const dbPath = repoPath ? join(repoPath, '.astrolabe', 'astrolabe.db') : opts.db;
+    if (!existsSync(dbPath)) {
+      console.log('No knowledge graph found. Run `astrolabe analyze` first.');
+      return;
+    }
+    const store = createSqliteStore(dbPath);
+    const graph = store.loadGraph();
+    store.close();
+    const options: any = {};
+    if (opts.fanIn) options.fanInThreshold = Number(opts.fanIn);
+    if (opts.fanOut) options.fanOutThreshold = Number(opts.fanOut);
+    if (opts.density) options.densityThreshold = Number(opts.density);
+    const results = detectAntiPatterns(graph, options);
+    if (opts.json) {
+      console.log(JSON.stringify(results, null, 2));
+      return;
+    }
+    console.log('\n=== Architecture Smells ===\n');
+    if (results.sccs?.length) {
+      console.log(`Cyclic Dependencies: ${results.sccs.length} cycle(s) found`);
+      for (const scc of results.sccs) {
+        console.log(`  Cycle #${scc.id}: ${scc.size} nodes — ${scc.nodeIds.slice(0, 5).join(', ')}${scc.nodeIds.length > 5 ? '...' : ''}`);
+      }
+      console.log();
+    }
+    if (results.hubs?.length) {
+      console.log(`Hub-like Modules: ${results.hubs.length} detected`);
+      for (const hub of results.hubs) {
+        console.log(`  ${hub.nodeId} — fanIn: ${hub.fanIn}, fanOut: ${hub.fanOut}, classification: ${hub.classification}`);
+      }
+      console.log();
+    }
+    if (results.meshes?.length) {
+      console.log(`Dependency Meshes: ${results.meshes.length} detected`);
+      for (const mesh of results.meshes) {
+        console.log(`  Mesh: ${mesh.nodeIds.length} nodes, density: ${mesh.density.toFixed(3)}, anchors: ${mesh.acyclicAnchors.length}`);
+      }
+      console.log();
+    }
+    if (results.cutVertices?.length) {
+      console.log(`Cut Vertices (SPoF): ${results.cutVertices.length} detected`);
+      for (const cv of results.cutVertices) {
+        console.log(`  ${cv.nodeId} — would split graph into ${cv.componentCountAfterRemoval} components`);
+      }
+      console.log();
+    }
+    if (results.bridges?.length) {
+      console.log(`Bridge Edges: ${results.bridges.length} detected`);
+      for (const bridge of results.bridges.slice(0, 10)) {
+        console.log(`  ${bridge.sourceId} → ${bridge.targetId}`);
+      }
+      if (results.bridges.length > 10) console.log(`  ... and ${results.bridges.length - 10} more`);
+      console.log();
+    }
+    if (!results.sccs?.length && !results.hubs?.length && !results.meshes?.length) {
+      console.log('No architecture smells detected.');
+    }
   });
 
 // ── ingest-coverage (#463) ──────────────────────────────────────────────────

--- a/packages/core/src/analysis/anti-pattern/detect.ts
+++ b/packages/core/src/analysis/anti-pattern/detect.ts
@@ -1,0 +1,72 @@
+/**
+ * Architecture anti-pattern detection for Astrolabe.
+ *
+ * Provides `detectAntiPatterns` which builds a `CALLS` / `IMPORTS`
+ * adjacency list from a KnowledgeGraph and runs the full architecture-smells
+ * analysis (Tarjan SCC, hub detection, Martin metrics, mesh detection,
+ * bridge edge detection, cut-vertex detection).
+ */
+
+import { architectureSmells, type ArchitectureSmellsResult } from '../../core/graph-algorithms.js';
+import type { KnowledgeGraph } from '@astrolabe-dev/shared';
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Detect architecture anti-patterns in a KnowledgeGraph.
+ *
+ * Builds a `CALLS` + `IMPORTS` adjacency list (skipping
+ * `STEP_IN_PROCESS`, `MEMBER_OF`, `ENTRY_POINT_OF` edges) and feeds it
+ * through the graph-algorithms architectureSmells orchestrator.
+ *
+ * @param graph   Populated knowledge graph.
+ * @param options Optional thresholds forwarded to the underlying detectors.
+ * @returns Aggregated architecture smells report with raw graph node IDs.
+ */
+export function detectAntiPatterns(
+  graph: KnowledgeGraph,
+  options?: {
+    fanInThreshold?: number;
+    fanOutThreshold?: number;
+    densityThreshold?: number;
+  },
+): ArchitectureSmellsResult {
+  const adjList = new Map<string, string[]>();
+
+  // Seed every node so the algorithm sees it
+  for (const node of graph.iterNodes()) {
+    if (!adjList.has(node.id)) adjList.set(node.id, []);
+  }
+
+  for (const rel of graph.iterRelationships()) {
+    // Skip non-dependency edges
+    if (rel.type === 'STEP_IN_PROCESS' || rel.type === 'MEMBER_OF' || rel.type === 'ENTRY_POINT_OF') continue;
+    if (rel.type !== 'CALLS' && rel.type !== 'IMPORTS') continue;
+
+    let targets = adjList.get(rel.sourceId);
+    if (!targets) {
+      targets = [];
+      adjList.set(rel.sourceId, targets);
+    }
+    targets.push(rel.targetId);
+
+    // Ensure target has an entry too
+    if (!adjList.has(rel.targetId)) {
+      adjList.set(rel.targetId, []);
+    }
+  }
+
+  return architectureSmells(adjList, options);
+}
+
+// ── Re-exports ──────────────────────────────────────────────────────────────
+
+export type {
+  ArchitectureSmellsResult,
+  SccResult,
+  CutVertexResult,
+  BridgeResult,
+  HubResult,
+  MartinMetricsResult,
+  MeshResult,
+} from '../../core/graph-algorithms.js';

--- a/packages/core/src/analysis/anti-pattern/index.ts
+++ b/packages/core/src/analysis/anti-pattern/index.ts
@@ -1,0 +1,10 @@
+export { detectAntiPatterns } from './detect.js';
+export type {
+  ArchitectureSmellsResult,
+  SccResult,
+  HubResult,
+  MartinMetricsResult,
+  MeshResult,
+  BridgeResult,
+  CutVertexResult,
+} from './detect.js';

--- a/packages/core/src/core/graph-algorithms.ts
+++ b/packages/core/src/core/graph-algorithms.ts
@@ -1,13 +1,74 @@
 /**
  * Graph algorithms for architecture analysis.
  *
- * PageRank, betweenness centrality, and shortest-path on the dependency
- * adjacency list derived from CALLS / IMPORTS edges.
+ * PageRank, betweenness centrality, shortest-path, and architecture
+ * anti-pattern detection (Tarjan SCC, hub detection, Martin dependency
+ * metrics, bridge edges, mesh detection) on the dependency adjacency
+ * list derived from CALLS / IMPORTS / EXTENDS / IMPLEMENTS edges.
  */
 
 export interface GraphAlgorithmResult {
   nodeId: string;
   score: number;
+}
+
+// ── Architecture Anti-Pattern Result Types ───────────────────────────────────
+
+/** A strongly connected component detected by Tarjan's algorithm. */
+export interface SccResult {
+  id: number;
+  nodeIds: string[];
+  size: number;
+}
+
+/** A cut vertex (articulation point) whose removal disconnects the graph. */
+export interface CutVertexResult {
+  nodeId: string;
+  componentCountAfterRemoval: number;
+  affectedSubtreeSize: number;
+}
+
+/** A bridge edge whose removal disconnects the graph. */
+export interface BridgeResult {
+  sourceId: string;
+  targetId: string;
+}
+
+/** Hub-like / god module detection result. */
+export interface HubResult {
+  nodeId: string;
+  fanIn: number;       // afferent coupling (Ca)
+  fanOut: number;      // efferent coupling (Ce)
+  instability: number; // I = Ce / (Ca + Ce), 0..1
+  classification: 'god-module' | 'hub' | 'dependent' | 'isolated';
+}
+
+/** Martin dependency metrics per node. */
+export interface MartinMetricsResult {
+  nodeId: string;
+  afferentCoupling: number;   // Ca — incoming dependency count
+  efferentCoupling: number;   // Ce — outgoing dependency count
+  instability: number;        // I = Ce / (Ca + Ce)
+  abstractness: number;       // A = abstract / total (0..1)
+  distance: number;           // D = |A + I - 1| — 0 = balanced, 1 = pain zone
+}
+
+/** Dependency mesh detection result. */
+export interface MeshResult {
+  nodeIds: string[];
+  edgeCount: number;
+  density: number;     // E / (V * (V-1))
+  acyclicAnchors: string[];
+}
+
+/** Aggregated architecture smells report. */
+export interface ArchitectureSmellsResult {
+  sccs: SccResult[];
+  cutVertices: CutVertexResult[];
+  bridges: BridgeResult[];
+  hubs: HubResult[];
+  martinMetrics: MartinMetricsResult[];
+  meshes: MeshResult[];
 }
 
 // ── PageRank ────────────────────────────────────────────────────────────────
@@ -261,4 +322,488 @@ function hasTarget(adjList: Map<string, string[]>, nodeId: string): boolean {
     if (neighbors.includes(nodeId)) return true;
   }
   return false;
+}
+
+// ── Tarjan's SCC ────────────────────────────────────────────────────────────
+
+/**
+ * Tarjan's strongly connected components algorithm.
+ *
+ * Classic DFS-based algorithm using discovery index and lowlink values.
+ * Handles single-node components (self-loops are SCCs).
+ * Returns SCCs sorted by size descending with sequential IDs.
+ * O(V+E) time complexity.
+ */
+export function tarjanSCC(adjList: Map<string, string[]>): SccResult[] {
+  const nodes = Array.from(adjList.keys());
+  if (nodes.length === 0) return [];
+
+  const index = new Map<string, number>();
+  const lowlink = new Map<string, number>();
+  const onStack = new Set<string>();
+  const stack: string[] = [];
+  const sccs: string[][] = [];
+  let currentIndex = 0;
+
+  function strongconnect(v: string): void {
+    index.set(v, currentIndex);
+    lowlink.set(v, currentIndex);
+    currentIndex++;
+    stack.push(v);
+    onStack.add(v);
+
+    const neighbors = adjList.get(v) ?? [];
+    for (const w of neighbors) {
+      if (index.get(w) === undefined) {
+        strongconnect(w);
+        lowlink.set(v, Math.min(lowlink.get(v)!, lowlink.get(w)!));
+      } else if (onStack.has(w)) {
+        lowlink.set(v, Math.min(lowlink.get(v)!, index.get(w)!));
+      }
+    }
+
+    if (lowlink.get(v) === index.get(v)) {
+      const component: string[] = [];
+      let w: string;
+      do {
+        w = stack.pop()!;
+        onStack.delete(w);
+        component.push(w);
+      } while (w !== v);
+      sccs.push(component);
+    }
+  }
+
+  for (const node of nodes) {
+    if (index.get(node) === undefined) {
+      strongconnect(node);
+    }
+  }
+
+  return sccs
+    .sort((a, b) => b.length - a.length)
+    .map((nodeIds, i) => ({
+      id: i,
+      nodeIds,
+      size: nodeIds.length,
+    }));
+}
+
+// ── Hub Detection ───────────────────────────────────────────────────────────
+
+/**
+ * Detects hub-like nodes based on fan-in / fan-out coupling.
+ *
+ * Classifies nodes as god-module, hub, dependent, or isolated using
+ * configurable thresholds.  Computes instability I = fanOut / (fanIn + fanOut).
+ * Includes nodes that only appear as targets (not source keys).
+ * Results sorted by total coupling (fanIn + fanOut) descending.
+ */
+export function detectHubs(
+  adjList: Map<string, string[]>,
+  fanInThreshold: number = 3,
+  fanOutThreshold: number = 3,
+): HubResult[] {
+  const nodes = Array.from(adjList.keys());
+
+  // Build reverse adjacency for fan-in computation
+  const reverseAdj = new Map<string, string[]>();
+  for (const node of nodes) reverseAdj.set(node, []);
+  for (const [src, targets] of adjList) {
+    for (const tgt of targets) {
+      let bucket = reverseAdj.get(tgt);
+      if (!bucket) {
+        bucket = [];
+        reverseAdj.set(tgt, bucket);
+      }
+      bucket.push(src);
+    }
+  }
+
+  const results: HubResult[] = [];
+
+  for (const node of nodes) {
+    const fanOut = adjList.get(node)?.length ?? 0;
+    const fanIn = reverseAdj.get(node)?.length ?? 0;
+    const total = fanIn + fanOut;
+    const instability = total === 0 ? 0 : fanOut / total;
+
+    let classification: HubResult['classification'];
+    if (total === 0) {
+      classification = 'isolated';
+    } else if (fanIn >= fanInThreshold && fanOut >= fanOutThreshold) {
+      classification = 'god-module';
+    } else if (fanIn >= fanInThreshold) {
+      classification = 'hub';
+    } else if (fanOut >= fanOutThreshold) {
+      classification = 'dependent';
+    } else {
+      classification = 'isolated';
+    }
+
+    results.push({ nodeId: node, fanIn, fanOut, instability, classification });
+  }
+
+  // Include nodes that only appear as targets (not keys in adjList)
+  for (const [node] of reverseAdj) {
+    if (!adjList.has(node)) {
+      const fanIn = reverseAdj.get(node)?.length ?? 0;
+      const fanOut = 0;
+      let classification: HubResult['classification'];
+      if (fanIn >= fanInThreshold) {
+        classification = 'hub';
+      } else {
+        classification = 'isolated';
+      }
+      results.push({
+        nodeId: node,
+        fanIn,
+        fanOut,
+        instability: 0,
+        classification,
+      });
+    }
+  }
+
+  return results.sort((a, b) => b.fanIn + b.fanOut - (a.fanIn + a.fanOut));
+}
+
+// ── Martin Dependency Metrics ──────────────────────────────────────────────
+
+/**
+ * Computes Martin's instability/abstractness metrics per node.
+ *
+ * Ca (afferent coupling)  = incoming dependency count.
+ * Ce (efferent coupling)  = outgoing dependency count.
+ * I (instability)         = Ce / (Ca + Ce), 0 if both zero.
+ * A (abstractness)        = 1.0 if the node's label contains "interface",
+ *                           "abstract", or "abstract class" (case-insensitive);
+ *                           otherwise 0.0.  If nodeLabels is not provided, A = 0.
+ * D (distance)            = |A + I - 1| — 0 = balanced, 1 = pain zone.
+ *
+ * Results sorted by distance descending (most imbalanced first).
+ */
+export function martinDependencyMetrics(
+  adjList: Map<string, string[]>,
+  nodeLabels?: Map<string, string>,
+): MartinMetricsResult[] {
+  const nodes = Array.from(adjList.keys());
+
+  // Build reverse adjacency for afferent coupling (Ca)
+  const reverseAdj = new Map<string, string[]>();
+  for (const node of nodes) reverseAdj.set(node, []);
+  for (const [src, targets] of adjList) {
+    for (const tgt of targets) {
+      let bucket = reverseAdj.get(tgt);
+      if (!bucket) {
+        bucket = [];
+        reverseAdj.set(tgt, bucket);
+      }
+      bucket.push(src);
+    }
+  }
+
+  const results: MartinMetricsResult[] = [];
+  const abstractPattern = /interface|abstract|abstract\s+class/i;
+
+  for (const node of nodes) {
+    const ca = reverseAdj.get(node)?.length ?? 0;
+    const ce = adjList.get(node)?.length ?? 0;
+    const instability = ca + ce === 0 ? 0 : ce / (ca + ce);
+
+    let abstractness = 0;
+    if (nodeLabels) {
+      const label = nodeLabels.get(node) ?? '';
+      if (abstractPattern.test(label)) {
+        abstractness = 1;
+      }
+    }
+
+    const distance = Math.abs(abstractness + instability - 1);
+
+    results.push({
+      nodeId: node,
+      afferentCoupling: ca,
+      efferentCoupling: ce,
+      instability,
+      abstractness,
+      distance,
+    });
+  }
+
+  return results.sort((a, b) => b.distance - a.distance);
+}
+
+// ── Mesh Detection ─────────────────────────────────────────────────────────
+
+/**
+ * Detects dependency meshes — densely-connected strongly connected components.
+ *
+ * Uses tarjanSCC internally.  For each SCC of size ≥ 3, computes edge density
+ * as edgeCount / (nodeCount × (nodeCount - 1)).  A mesh is an SCC whose
+ * density reaches the threshold (default 0.5).
+ *
+ * acyclicAnchors are mesh nodes with the fewest outgoing edges to other
+ * mesh members.
+ *
+ * Results sorted by density descending.
+ */
+export function detectMesh(
+  adjList: Map<string, string[]>,
+  densityThreshold: number = 0.5,
+): MeshResult[] {
+  const sccs = tarjanSCC(adjList);
+  const results: MeshResult[] = [];
+
+  for (const scc of sccs) {
+    if (scc.size < 3) continue;
+
+    const nodeSet = new Set(scc.nodeIds);
+    let edgeCount = 0;
+    const outCounts = new Map<string, number>();
+
+    for (const node of scc.nodeIds) {
+      const targets = adjList.get(node) ?? [];
+      let outToMesh = 0;
+      for (const tgt of targets) {
+        if (nodeSet.has(tgt)) {
+          edgeCount++;
+          outToMesh++;
+        }
+      }
+      outCounts.set(node, outToMesh);
+    }
+
+    const n = scc.size;
+    const density = edgeCount / (n * (n - 1));
+
+    if (density >= densityThreshold) {
+      let minOut = Infinity;
+      for (const count of outCounts.values()) {
+        if (count < minOut) minOut = count;
+      }
+
+      const acyclicAnchors: string[] = [];
+      for (const [node, count] of outCounts) {
+        if (count === minOut) acyclicAnchors.push(node);
+      }
+
+      results.push({
+        nodeIds: scc.nodeIds,
+        edgeCount,
+        density,
+        acyclicAnchors,
+      });
+    }
+  }
+
+  return results.sort((a, b) => b.density - a.density);
+}
+
+// ── Bridge Detection ───────────────────────────────────────────────────────
+
+/**
+ * Tarjan's bridge-finding algorithm treating the graph as undirected.
+ *
+ * A bridge is an edge whose removal increases the number of connected
+ * components.  Uses discovery time and low values in a single DFS pass.
+ * For bridge detection, an edge u→v implies u and v are connected
+ * in both directions.
+ */
+export function detectBridges(adjList: Map<string, string[]>): BridgeResult[] {
+  const nodes = Array.from(adjList.keys());
+  if (nodes.length === 0) return [];
+
+  // Build undirected adjacency (edge u→v means u connected to v and vice versa)
+  const undirected = new Map<string, string[]>();
+  for (const node of nodes) undirected.set(node, []);
+  for (const [u, targets] of adjList) {
+    for (const v of targets) {
+      const uNeighbors = undirected.get(u)!;
+      if (!uNeighbors.includes(v)) uNeighbors.push(v);
+      const vBucket = undirected.get(v);
+      if (vBucket) {
+        if (!vBucket.includes(u)) vBucket.push(u);
+      } else {
+        undirected.set(v, [u]);
+      }
+    }
+  }
+
+  const allNodes = Array.from(undirected.keys());
+  const disc = new Map<string, number>();
+  const low = new Map<string, number>();
+  const parent = new Map<string, string>();
+  const bridges: BridgeResult[] = [];
+  let time = 0;
+
+  function dfs(u: string): void {
+    disc.set(u, time);
+    low.set(u, time);
+    time++;
+
+    const neighbors = undirected.get(u) ?? [];
+    for (const v of neighbors) {
+      if (disc.get(v) === undefined) {
+        parent.set(v, u);
+        dfs(v);
+        low.set(u, Math.min(low.get(u)!, low.get(v)!));
+        if (low.get(v)! > disc.get(u)!) {
+          bridges.push({ sourceId: u, targetId: v });
+        }
+      } else if (v !== (parent.get(u) ?? '')) {
+        low.set(u, Math.min(low.get(u)!, disc.get(v)!));
+      }
+    }
+  }
+
+  for (const node of allNodes) {
+    if (disc.get(node) === undefined) {
+      dfs(node);
+    }
+  }
+
+  return bridges;
+}
+
+// ── Cut Vertex Detection ────────────────────────────────────────────────────
+
+/**
+ * Articulation point (cut-vertex) detection via a single DFS.
+ *
+ * A cut vertex is a node whose removal disconnects the graph.  The graph
+ * is treated as undirected.  For the DFS root, it's a cut vertex if it
+ * has more than one child.  For non-root nodes, node u is a cut vertex
+ * if for any child v, low[v] ≥ disc[u].
+ *
+ * Results sorted by componentCountAfterRemoval descending.
+ */
+export function detectCutVertices(adjList: Map<string, string[]>): CutVertexResult[] {
+  const nodes = Array.from(adjList.keys());
+  if (nodes.length === 0) return [];
+
+  // Build undirected adjacency
+  const undirected = new Map<string, string[]>();
+  for (const node of nodes) undirected.set(node, []);
+  for (const [u, targets] of adjList) {
+    for (const v of targets) {
+      const uNeighbors = undirected.get(u)!;
+      if (!uNeighbors.includes(v)) uNeighbors.push(v);
+      const vBucket = undirected.get(v);
+      if (vBucket) {
+        if (!vBucket.includes(u)) vBucket.push(u);
+      } else {
+        undirected.set(v, [u]);
+      }
+    }
+  }
+
+  const allNodes = Array.from(undirected.keys());
+  const disc = new Map<string, number>();
+  const low = new Map<string, number>();
+  const parent = new Map<string, string>();
+  const subtreeSize = new Map<string, number>();
+  const isCutVertex = new Map<string, boolean>();
+  const cutChildCount = new Map<string, number>();
+  let time = 0;
+
+  function dfs(u: string, isRoot: boolean): void {
+    disc.set(u, time);
+    low.set(u, time);
+    time++;
+
+    let size = 1;
+    let children = 0;
+    let cuts = 0;
+
+    const neighbors = undirected.get(u) ?? [];
+    for (const v of neighbors) {
+      if (disc.get(v) === undefined) {
+        children++;
+        parent.set(v, u);
+        dfs(v, false);
+        size += subtreeSize.get(v)!;
+        low.set(u, Math.min(low.get(u)!, low.get(v)!));
+
+        if (!isRoot && low.get(v)! >= disc.get(u)!) {
+          isCutVertex.set(u, true);
+          cuts++;
+        }
+      } else if (v !== (parent.get(u) ?? '')) {
+        low.set(u, Math.min(low.get(u)!, disc.get(v)!));
+      }
+    }
+
+    subtreeSize.set(u, size);
+
+    if (isRoot && children > 1) {
+      isCutVertex.set(u, true);
+      cuts = children;
+    }
+
+    cutChildCount.set(u, cuts);
+  }
+
+  for (const node of allNodes) {
+    if (disc.get(node) === undefined) {
+      dfs(node, true);
+    }
+  }
+
+  const results: CutVertexResult[] = [];
+  for (const node of allNodes) {
+    if (isCutVertex.get(node)) {
+      const isRoot = parent.get(node) === undefined;
+      const childCount = cutChildCount.get(node) ?? 0;
+      const componentCountAfterRemoval = isRoot ? childCount : childCount + 1;
+
+      let affectedSubtreeSize = 0;
+      const neighbors = undirected.get(node) ?? [];
+      for (const v of neighbors) {
+        if (parent.get(v) === node) {
+          if (isRoot || low.get(v)! >= disc.get(node)!) {
+            affectedSubtreeSize += subtreeSize.get(v)!;
+          }
+        }
+      }
+
+      results.push({
+        nodeId: node,
+        componentCountAfterRemoval,
+        affectedSubtreeSize,
+      });
+    }
+  }
+
+  return results.sort((a, b) => b.componentCountAfterRemoval - a.componentCountAfterRemoval);
+}
+
+// ── Architecture Smells (Orchestrator) ─────────────────────────────────────
+
+/**
+ * Aggregated architecture-smells report.
+ *
+ * Calls all architecture anti-pattern detectors and returns a combined result.
+ * Passes options through to the respective sub-functions:
+ *   fanInThreshold / fanOutThreshold → detectHubs
+ *   densityThreshold → detectMesh
+ *   nodeLabels → martinDependencyMetrics
+ */
+export function architectureSmells(
+  adjList: Map<string, string[]>,
+  options?: {
+    fanInThreshold?: number;
+    fanOutThreshold?: number;
+    densityThreshold?: number;
+    nodeLabels?: Map<string, string>;
+  },
+): ArchitectureSmellsResult {
+  return {
+    sccs: tarjanSCC(adjList),
+    cutVertices: detectCutVertices(adjList),
+    bridges: detectBridges(adjList),
+    hubs: detectHubs(adjList, options?.fanInThreshold, options?.fanOutThreshold),
+    martinMetrics: martinDependencyMetrics(adjList, options?.nodeLabels),
+    meshes: detectMesh(adjList, options?.densityThreshold),
+  };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -79,3 +79,5 @@ export { chat, callLLM, type ChatMessage, type ChatResponse, type LLMConfig } fr
 export { countGraphlets, buildAdjacencyMap, type GraphletProfile } from './analysis/graphlet/index.js';
 export { detectPatterns, type ArchitecturePattern } from './analysis/graphlet/index.js';
 export { scoreArchitectureHealth, type ArchitectureHealth, type CommunityInfo } from './analysis/graphlet/index.js';
+// #808: Architecture anti-pattern detection
+export { detectAntiPatterns, type ArchitectureSmellsResult } from './analysis/anti-pattern/index.js';

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -24,7 +24,7 @@ import { StreamableHttpTransport } from './http-transport.js';
 import { routeMap, toolMap, apiImpact, shapeCheck } from './api-tools.js';
 import { executeTraversal, type TraversalQuery } from './traverse.js';
 import { PhaseTimer } from '../core/phase-timer.js';
-import { pageRank, betweennessCentrality, shortestPath } from '../core/graph-algorithms.js';
+import { pageRank, betweennessCentrality, shortestPath, architectureSmells } from '../core/graph-algorithms.js';
 import { chat as ragChat, type ChatMessage } from '../agent/rag-chat.js';
 import { generateDiagram, generateMarkdownDoc, type DiagramType, type DiagramOptions } from './diagram-generator.js';
 // #461: Graphlet-based structural analysis
@@ -1706,12 +1706,13 @@ Algorithms:
 - pagerank: Identify the most important modules by link structure. Returns nodes sorted by PageRank score.
 - betweenness: Find bridge nodes that connect different communities. High betweenness = critical dependency bottleneck.
 - shortest_path: Find the dependency chain between two modules. Returns the shortest path or null.
+- architecture_smells: Detect architecture anti-patterns (cyclic dependencies, god modules, unstable deps, dependency meshes, cut vertices, bridge edges).
 
 The graph is built from CALLS and IMPORTS relationships (excluding STEP_IN_PROCESS synthetic edges).`,
     inputSchema: {
       type: 'object',
       properties: {
-        algorithm: { type: 'string', enum: ['pagerank', 'betweenness', 'shortest_path'], description: 'Algorithm to run' },
+        algorithm: { type: 'string', enum: ['pagerank', 'betweenness', 'shortest_path', 'architecture_smells'], description: 'Algorithm to run' },
         source: { type: 'string', description: 'Source node ID or name (required for shortest_path)' },
         target: { type: 'string', description: 'Target node ID or name (required for shortest_path)' },
         repo: { type: 'string', description: 'Repository name' },
@@ -1796,6 +1797,27 @@ The graph is built from CALLS and IMPORTS relationships (excluding STEP_IN_PROCE
         });
 
         return { content: [{ type: 'text', text: JSON.stringify({ algorithm: 'shortest_path', source: sourceParam, target: targetParam, path: namedPath, length: path.length - 1 }, null, 2) }] };
+      }
+
+      if (algorithm === 'architecture_smells') {
+        const results = architectureSmells(adjList);
+        const output: any = {
+          algorithm: 'architecture_smells',
+          summary: {
+            cycles: results.sccs?.length ?? 0,
+            cutVertices: results.cutVertices?.length ?? 0,
+            bridges: results.bridges?.length ?? 0,
+            hubs: results.hubs?.length ?? 0,
+            meshes: results.meshes?.length ?? 0,
+          },
+        };
+        if (results.sccs?.length) output.sccs = results.sccs;
+        if (results.hubs?.length) output.hubs = results.hubs;
+        if (results.martinMetrics?.length) output.martinMetrics = results.martinMetrics;
+        if (results.meshes?.length) output.meshes = results.meshes;
+        if (results.cutVertices?.length) output.cutVertices = results.cutVertices;
+        if (results.bridges?.length) output.bridges = results.bridges;
+        return { content: [{ type: 'text', text: JSON.stringify(output, null, 2) }] };
       }
 
       return { content: [{ type: 'text', text: JSON.stringify({ error: `Unknown algorithm: ${algorithm}` }) }] };

--- a/packages/core/tests/analysis/anti-pattern/detect.test.ts
+++ b/packages/core/tests/analysis/anti-pattern/detect.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { createKnowledgeGraph } from '../../../src/core/graph.js';
+import { detectAntiPatterns } from '../../../src/analysis/anti-pattern/detect.js';
+import type { KnowledgeGraph, GraphNode, GraphRelationship } from '@astrolabe-dev/shared';
+
+describe('detectAntiPatterns', () => {
+  it('detects no smells in an empty graph', () => {
+    const graph = createKnowledgeGraph();
+    const result = detectAntiPatterns(graph);
+    expect(result.sccs).toHaveLength(0);
+    expect(result.hubs).toHaveLength(0);
+    expect(result.meshes).toHaveLength(0);
+    expect(result.bridges).toHaveLength(0);
+    expect(result.cutVertices).toHaveLength(0);
+  });
+
+  it('detects a simple 2-node cycle', () => {
+    const graph = createKnowledgeGraph();
+    graph.addNode({ id: 'A', label: 'Class', properties: { name: 'A' } });
+    graph.addNode({ id: 'B', label: 'Class', properties: { name: 'B' } });
+    graph.addRelationship({ id: 'r1', sourceId: 'A', targetId: 'B', type: 'CALLS', confidence: 1, reason: 'test' });
+    graph.addRelationship({ id: 'r2', sourceId: 'B', targetId: 'A', type: 'CALLS', confidence: 1, reason: 'test' });
+    const result = detectAntiPatterns(graph);
+    expect(result.sccs.length).toBeGreaterThan(0);
+  });
+
+  it('detects a god module with high fan-in and fan-out', () => {
+    const graph = createKnowledgeGraph();
+    graph.addNode({ id: 'hub', label: 'Class', properties: { name: 'GodModule' } });
+    for (let i = 0; i < 5; i++) {
+      graph.addNode({ id: `dep${i}`, label: 'Class', properties: { name: `Dep${i}` } });
+      graph.addRelationship({ id: `in${i}`, sourceId: `dep${i}`, targetId: 'hub', type: 'CALLS', confidence: 1, reason: 'test' });
+      graph.addRelationship({ id: `out${i}`, sourceId: 'hub', targetId: `dep${i}`, type: 'CALLS', confidence: 1, reason: 'test' });
+    }
+    const result = detectAntiPatterns(graph, { fanInThreshold: 2, fanOutThreshold: 2 });
+    const hubDetection = result.hubs.find(h => h.nodeId === 'hub');
+    expect(hubDetection).toBeDefined();
+    expect(hubDetection!.classification).toBe('god-module');
+  });
+
+  it('returns Martin metrics for nodes', () => {
+    const graph = createKnowledgeGraph();
+    graph.addNode({ id: 'A', label: 'Class', properties: { name: 'A' } });
+    graph.addNode({ id: 'B', label: 'Class', properties: { name: 'B' } });
+    graph.addRelationship({ id: 'r1', sourceId: 'A', targetId: 'B', type: 'CALLS', confidence: 1, reason: 'test' });
+    const result = detectAntiPatterns(graph);
+    expect(result.martinMetrics.length).toBeGreaterThan(0);
+    const aMetrics = result.martinMetrics.find(m => m.nodeId === 'A');
+    expect(aMetrics).toBeDefined();
+  });
+});


### PR DESCRIPTION
﻿Architecture anti-pattern detection via graph topology.

Implements:
- detectAntiPatterns() wrapper in analysis/anti-pattern/ that builds adjacency list from KnowledgeGraph and calls existing architectureSmells() from graph-algorithms.ts
- MCP graph_algorithms tool extended with architecture_smells algorithm option
- CLI detect-smells command with --json, --fan-in, --fan-out, --density flags
- 4 new tests (empty graph, 2-node cycle, god module, Martin metrics)

All 646 tests pass (48 files, 19 skip).

Closes #808
