### PR TITLE
feat: probabilistic impact analysis with confidence decay (#806)

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -572,7 +572,9 @@ program
   .command('impact <symbol-name>')
   .description('Show code impact analysis for a symbol')
   .option('-d, --db <path>', 'Database path', '.astrolabe/astrolabe.db')
-  .action((symbolName: string, opts: { db: string }) => {
+  .option('--probabilistic', 'Use probabilistic confidence-decay scoring')
+  .option('--decay <schedule>', 'Decay schedule for probabilistic mode', 'linear')
+  .action((symbolName: string, opts: { db: string; probabilistic?: boolean; decay?: string }) => {
     const store = createSqliteStore(opts.db);
     try {
       const graph = store.loadGraph();
@@ -588,19 +590,57 @@ program
         bucket.push({ neighborId: rel.sourceId, type: rel.type, direction: 'incoming' });
       }
 
-      let found = 0;
-      for (const node of graph.iterNodes()) {
-        if (node.properties.name === symbolName) {
-          found++;
-          console.log(`${node.label}: ${node.id}`);
-          const neighbors = adj.get(node.id) ?? [];
-          for (const { neighborId, type, direction } of neighbors) {
+      if (opts.probabilistic) {
+        // #806: Probabilistic mode — simple confidence-decay visualization
+        const decaySchedules: Record<string, (c: number, d: number) => number> = {
+          linear: (c) => c,
+          exponential: (c, d) => c * Math.exp(-0.3 * (d - 1)),
+          logarithmic: (c, d) => c / Math.log2(d + 1),
+        };
+        const schedule = decaySchedules[opts.decay ?? 'linear'] ?? decaySchedules.linear;
+        const EDGE_DECAY: Record<string, number> = {
+          CALLS: 0.9, IMPORTS: 0.7, EXTENDS: 0.8, IMPLEMENTS: 0.85,
+          USES: 0.6, ACCESSES: 0.65, CONTAINS: 0.95, DEFINES: 0.95,
+          QUERIES: 0.75, ROUTES: 0.7, MEMBER_OF: 0.3, ENTRY_POINT_OF: 0.4,
+          HAS_PROPERTY: 0.5, CHAINABLE_TO: 0.7, CO_CHANGES: 0.8, SEMANTICALLY_SIMILAR: 0.6,
+        };
+
+        const nodeScores = new Map<string, { score: number; paths: string[] }>();
+        nodeScores.set(symbolName, { score: 1.0, paths: [] });
+
+        for (const node of graph.iterNodes()) {
+          if (node.properties.name !== symbolName) continue;
+          for (const { neighborId, type } of (adj.get(node.id) ?? [])) {
             const other = graph.getNode(neighborId);
-            console.log(`  ${direction === 'outgoing' ? '→' : '←'} ${type} ${other?.properties.name ?? neighborId}`);
+            if (!other) continue;
+            const decay = EDGE_DECAY[type] ?? 0.7;
+            const score = Math.round(schedule(decay, 1) * 1000) / 1000;
+            nodeScores.set(other.properties.name ?? neighborId, { score, paths: [type] });
           }
         }
+
+        console.log(`Probabilistic impact for "${symbolName}" (decay: ${opts.decay ?? 'linear'}):`);
+        const sorted = [...nodeScores].filter(([k]) => k !== symbolName).sort((a, b) => b[1].score - a[1].score);
+        for (const [name, { score }] of sorted) {
+          const cat = score >= 0.8 ? 'DIRECT' : score >= 0.4 ? 'TRANSITIVE' : 'LOW-RISK';
+          console.log(`  [${cat}] ${name} (confidence: ${score.toFixed(3)})`);
+        }
+        if (sorted.length === 0) console.log('  (no directly connected nodes)');
+      } else {
+        let found = 0;
+        for (const node of graph.iterNodes()) {
+          if (node.properties.name === symbolName) {
+            found++;
+            console.log(`${node.label}: ${node.id}`);
+            const neighbors = adj.get(node.id) ?? [];
+            for (const { neighborId, type, direction } of neighbors) {
+              const other = graph.getNode(neighborId);
+              console.log(`  ${direction === 'outgoing' ? '→' : '←'} ${type} ${other?.properties.name ?? neighborId}`);
+            }
+          }
+        }
+        if (found === 0) console.log(`Symbol "${symbolName}" not found.`);
       }
-      if (found === 0) console.log(`Symbol "${symbolName}" not found.`);
     } finally { store.close(); }
   });
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -33,6 +33,7 @@ import {
   startEvalServer,
   countGraphlets, buildAdjacencyMap, detectPatterns, scoreArchitectureHealth,
   migrateFromGitNexus,
+  EDGE_DECAY_FACTORS, applyDecay, noisyOr,
 } from '@astrolabe-dev/core';
 // #463: Coverage report parser
 import { parseCoverageReport, detectFormat, annotateGraphWithCoverage } from '@astrolabe-dev/core';
@@ -591,41 +592,85 @@ program
       }
 
       if (opts.probabilistic) {
-        // #806: Probabilistic mode — simple confidence-decay visualization
-        const decaySchedules: Record<string, (c: number, d: number) => number> = {
-          linear: (c) => c,
-          exponential: (c, d) => c * Math.exp(-0.3 * (d - 1)),
-          logarithmic: (c, d) => c / Math.log2(d + 1),
-        };
-        const schedule = decaySchedules[opts.decay ?? 'linear'] ?? decaySchedules.linear;
-        const EDGE_DECAY: Record<string, number> = {
-          CALLS: 0.9, IMPORTS: 0.7, EXTENDS: 0.8, IMPLEMENTS: 0.85,
-          USES: 0.6, ACCESSES: 0.65, CONTAINS: 0.95, DEFINES: 0.95,
-          QUERIES: 0.75, ROUTES: 0.7, MEMBER_OF: 0.3, ENTRY_POINT_OF: 0.4,
-          HAS_PROPERTY: 0.5, CHAINABLE_TO: 0.7, CO_CHANGES: 0.8, SEMANTICALLY_SIMILAR: 0.6,
-        };
+        // #806: Probabilistic multi-hop BFS with confidence decay and Noisy-OR fusion
+        const schedule = (opts.decay ?? 'linear') as 'linear' | 'exponential' | 'logarithmic';
+        const maxDepth = 3;
 
-        const nodeScores = new Map<string, { score: number; paths: string[] }>();
-        nodeScores.set(symbolName, { score: 1.0, paths: [] });
-
+        // Find the target node
+        let targetId: string | null = null;
         for (const node of graph.iterNodes()) {
-          if (node.properties.name !== symbolName) continue;
-          for (const { neighborId, type } of (adj.get(node.id) ?? [])) {
-            const other = graph.getNode(neighborId);
-            if (!other) continue;
-            const decay = EDGE_DECAY[type] ?? 0.7;
-            const score = Math.round(schedule(decay, 1) * 1000) / 1000;
-            nodeScores.set(other.properties.name ?? neighborId, { score, paths: [type] });
+          if (node.properties.name === symbolName) { targetId = node.id; break; }
+        }
+        if (!targetId) {
+          console.log(`Symbol "${symbolName}" not found.`);
+          return;
+        }
+
+        // Pre-build adjacency with confidence (incoming + outgoing)
+        const probAdj = new Map<string, Array<{ neighborId: string; type: string; confidence: number; direction: 'outgoing' | 'incoming' }>>();
+        for (const rel of graph.iterRelationships()) {
+          if (rel.type === 'STEP_IN_PROCESS') continue;
+          // outgoing: source → target
+          let bucket = probAdj.get(rel.sourceId);
+          if (!bucket) { bucket = []; probAdj.set(rel.sourceId, bucket); }
+          bucket.push({ neighborId: rel.targetId, type: rel.type, confidence: rel.confidence, direction: 'outgoing' });
+          // incoming: target → source
+          bucket = probAdj.get(rel.targetId);
+          if (!bucket) { bucket = []; probAdj.set(rel.targetId, bucket); }
+          bucket.push({ neighborId: rel.sourceId, type: rel.type, confidence: rel.confidence, direction: 'incoming' });
+        }
+
+        // BFS with confidence decay
+        const nodeScores = new Map<string, { paths: Array<{ via: string; depth: number; confidence: number }>; bestScore: number }>();
+        nodeScores.set(targetId, { paths: [], bestScore: 1.0 });
+        const queue: Array<{ id: string; depth: number }> = [{ id: targetId, depth: 0 }];
+        const visited = new Set<string>([targetId]);
+
+        while (queue.length > 0) {
+          const current = queue.shift()!;
+          if (current.depth >= maxDepth) continue;
+
+          for (const { neighborId, type, confidence } of (probAdj.get(current.id) ?? [])) {
+            if (neighborId === targetId) continue;
+
+            const edgeDecay = EDGE_DECAY_FACTORS[type] ?? 0.7;
+            const parentEntry = nodeScores.get(current.id);
+            const parentConfidence = parentEntry?.bestScore ?? 1.0;
+            let decayedConfidence = parentConfidence * edgeDecay * Math.max(confidence, 0.1);
+            decayedConfidence = applyDecay(decayedConfidence, current.depth + 1, schedule);
+
+            const existing = nodeScores.get(neighborId);
+            const pathEntry = { via: current.id, depth: current.depth + 1, confidence: decayedConfidence };
+
+            if (existing) {
+              existing.paths.push(pathEntry);
+              const allProbs = existing.paths.map((p) => p.confidence);
+              existing.bestScore = noisyOr(allProbs);
+            } else {
+              nodeScores.set(neighborId, { paths: [pathEntry], bestScore: decayedConfidence });
+              if (!visited.has(neighborId)) {
+                visited.add(neighborId);
+                queue.push({ id: neighborId, depth: current.depth + 1 });
+              }
+            }
           }
         }
 
-        console.log(`Probabilistic impact for "${symbolName}" (decay: ${opts.decay ?? 'linear'}):`);
-        const sorted = [...nodeScores].filter(([k]) => k !== symbolName).sort((a, b) => b[1].score - a[1].score);
-        for (const [name, { score }] of sorted) {
+        console.log(`Probabilistic impact for "${symbolName}" (decay: ${schedule}, maxDepth: ${maxDepth}):`);
+        const sorted = [...nodeScores]
+          .filter(([id]) => id !== targetId)
+          .map(([id, entry]) => {
+            const node = graph.getNode(id);
+            return { name: node?.properties.name ?? id, score: Math.round(entry.bestScore * 1000) / 1000, paths: entry.paths.length };
+          })
+          .sort((a, b) => b.score - a.score);
+
+        for (const { name, score, paths } of sorted) {
           const cat = score >= 0.8 ? 'DIRECT' : score >= 0.4 ? 'TRANSITIVE' : 'LOW-RISK';
-          console.log(`  [${cat}] ${name} (confidence: ${score.toFixed(3)})`);
+          const pathInfo = paths > 1 ? ` (${paths} paths)` : '';
+          console.log(`  [${cat}] ${name} (confidence: ${score.toFixed(3)})${pathInfo}`);
         }
-        if (sorted.length === 0) console.log('  (no directly connected nodes)');
+        if (sorted.length === 0) console.log('  (no connected nodes)');
       } else {
         let found = 0;
         for (const node of graph.iterNodes()) {

--- a/packages/core/src/analysis/impact-decay.ts
+++ b/packages/core/src/analysis/impact-decay.ts
@@ -1,0 +1,46 @@
+// #806: Shared constants and functions for probabilistic impact analysis
+// Used by both MCP server (server.ts) and CLI (cli/src/index.ts)
+// Extracted to shared module per reviewer feedback on PR #817
+
+/** Confidence decay factors per edge type for probabilistic impact propagation */
+export const EDGE_DECAY_FACTORS: Record<string, number> = {
+  CALLS: 0.9,
+  IMPORTS: 0.7,
+  EXTENDS: 0.8,
+  IMPLEMENTS: 0.85,
+  USES: 0.6,
+  ACCESSES: 0.65,
+  CONTAINS: 0.95,
+  DEFINES: 0.95,
+  QUERIES: 0.75,
+  ROUTES: 0.7,
+  MEMBER_OF: 0.3,
+  ENTRY_POINT_OF: 0.4,
+  HAS_PROPERTY: 0.5,
+  CHAINABLE_TO: 0.7,
+  CO_CHANGES: 0.8,
+  SEMANTICALLY_SIMILAR: 0.6,
+};
+
+export type DecaySchedule = 'linear' | 'exponential' | 'logarithmic';
+
+/** Apply distance-based decay to a confidence score */
+export function applyDecay(
+  baseConfidence: number,
+  depth: number,
+  schedule: DecaySchedule,
+): number {
+  if (schedule === 'exponential') {
+    return baseConfidence * Math.exp(-0.3 * (depth - 1));
+  }
+  if (schedule === 'logarithmic') {
+    return baseConfidence / Math.log2(depth + 1);
+  }
+  // linear (default): no distance penalty
+  return baseConfidence;
+}
+
+/** Noisy-OR fusion — combine multiple independent path probabilities */
+export function noisyOr(probs: number[]): number {
+  return 1 - probs.reduce((acc, p) => acc * (1 - p), 1);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -79,3 +79,5 @@ export { chat, callLLM, type ChatMessage, type ChatResponse, type LLMConfig } fr
 export { countGraphlets, buildAdjacencyMap, type GraphletProfile } from './analysis/graphlet/index.js';
 export { detectPatterns, type ArchitecturePattern } from './analysis/graphlet/index.js';
 export { scoreArchitectureHealth, type ArchitectureHealth, type CommunityInfo } from './analysis/graphlet/index.js';
+// #806: Probabilistic impact analysis
+export { EDGE_DECAY_FACTORS, applyDecay, noisyOr, type DecaySchedule } from './analysis/impact-decay.js';

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -167,6 +167,43 @@ function boostResults<T extends { name: string; filePath: string; score: number 
   results.sort((a, b) => b.score - a.score);
 }
 
+// #806: Confidence decay factors per edge type for probabilistic impact analysis
+const EDGE_DECAY_FACTORS: Record<string, number> = {
+  CALLS: 0.9,
+  IMPORTS: 0.7,
+  EXTENDS: 0.8,
+  IMPLEMENTS: 0.85,
+  USES: 0.6,
+  ACCESSES: 0.65,
+  CONTAINS: 0.95,
+  DEFINES: 0.95,
+  QUERIES: 0.75,
+  ROUTES: 0.7,
+  MEMBER_OF: 0.3,
+  ENTRY_POINT_OF: 0.4,
+  HAS_PROPERTY: 0.5,
+  CHAINABLE_TO: 0.7,
+  CO_CHANGES: 0.8,
+  SEMANTICALLY_SIMILAR: 0.6,
+};
+
+// #806: Decay the confidence score based on depth and schedule
+function applyDecay(baseConfidence: number, depth: number, schedule: 'linear' | 'exponential' | 'logarithmic'): number {
+  if (schedule === 'exponential') {
+    return baseConfidence * Math.exp(-0.3 * (depth - 1));
+  }
+  if (schedule === 'logarithmic') {
+    return baseConfidence / Math.log2(depth + 1);
+  }
+  // linear (default): same penalty each hop
+  return baseConfidence;
+}
+
+// #806: Noisy-OR fusion — combine multiple path probabilities
+function noisyOr(probs: number[]): number {
+  return 1 - probs.reduce((acc, p) => acc * (1 - p), 1);
+}
+
 // ── Backend ────────────────────────────────────────────────────────────────
 
 class LocalBackend {
@@ -499,7 +536,7 @@ class LocalBackend {
     return { match_count: results.length, matches: results, siblingWarning };
   }
 
-  impact(target: string, direction: 'upstream' | 'downstream' = 'upstream', repo?: string, maxDepth = 5, minConfidence = 0.3, timeoutMs = 30_000, targetUid?: string, kind?: string, filePath?: string) {
+  impact(target: string, direction: 'upstream' | 'downstream' = 'upstream', repo?: string, maxDepth = 5, minConfidence = 0.3, timeoutMs = 30_000, targetUid?: string, kind?: string, filePath?: string, mode: 'binary' | 'probabilistic' = 'binary', decaySchedule: 'linear' | 'exponential' | 'logarithmic' = 'linear') {
     const ctx = this.getRepo(repo);
     const graph = ctx.loadGraph();
 
@@ -589,27 +626,131 @@ class LocalBackend {
     let truncated = false;
     const deadline = Date.now() + Math.min(timeoutMs, 3_600_000);
 
+    // #806: Probabilistic mode — track accumulated confidence per node across multiple paths
+    const probabilisticResults: Array<{ id: string; name: string; type: string; filePath: string; score: number; paths: Array<{ via: string; depth: number; confidence: number }>; category: string }> = [];
+    const nodeScores = new Map<string, { paths: Array<{ via: string; depth: number; confidence: number }>; bestScore: number; bestDepth: number }>();
+
+    // If probabilistic mode, build adj index without confidence filtering
+    let probAdj: Map<string, Array<{ neighborId: string; type: string; confidence: number }>> | null = null;
+    if (mode === 'probabilistic') {
+      probAdj = new Map<string, Array<{ neighborId: string; type: string; confidence: number }>>();
+      for (const rel of graph.iterRelationships()) {
+        if (rel.type === 'STEP_IN_PROCESS') continue;
+        if (direction === 'upstream') {
+          let bucket = probAdj.get(rel.targetId);
+          if (!bucket) { bucket = []; probAdj.set(rel.targetId, bucket); }
+          bucket.push({ neighborId: rel.sourceId, type: rel.type, confidence: rel.confidence });
+        } else {
+          let bucket = probAdj.get(rel.sourceId);
+          if (!bucket) { bucket = []; probAdj.set(rel.sourceId, bucket); }
+          bucket.push({ neighborId: rel.targetId, type: rel.type, confidence: rel.confidence });
+        }
+      }
+    }
+
     while (queue.length > 0 && affected.length < MAX_IMPACT_RESULTS) {
       if (Date.now() >= deadline) { truncated = true; break; }
       const current = queue.shift()!;
       if (current.depth >= maxDepth) continue;
 
-      const neighbors = adj.get(current.id) ?? [];
-      for (const { neighborId, type, confidence } of neighbors) {
-        if (visited.has(neighborId)) continue;
-        if (affected.length >= MAX_IMPACT_RESULTS) { truncated = true; break; }
-        visited.add(neighborId);
-        const node = graph.getNode(neighborId);
-        queue.push({ id: neighborId, depth: current.depth + 1 });
-        affected.push({
-          depth: current.depth + 1,
-          name: node?.properties.name ?? neighborId,
-          type: node?.label ?? 'unknown',
-          filePath: (node?.properties.filePath as string) ?? '',
-          relationType: type,
-          confidence,
+      const neighbors = mode === 'probabilistic'
+        ? (probAdj!.get(current.id) ?? [])
+        : (adj.get(current.id) ?? []);
+
+      if (mode === 'probabilistic') {
+        // #806: Probabilistic BFS with confidence decay and Noisy-OR fusion
+        for (const { neighborId, type, confidence } of neighbors) {
+          if (neighborId === targetNode.id) continue;
+          if (probabilisticResults.length >= MAX_IMPACT_RESULTS) { truncated = true; break; }
+
+          const edgeDecay = EDGE_DECAY_FACTORS[type] ?? 0.7;
+          const parentEntry = nodeScores.get(current.id);
+          const parentConfidence = parentEntry?.bestScore ?? 1.0;
+          let decayedConfidence = parentConfidence * edgeDecay * Math.max(confidence, 0.1);
+          decayedConfidence = applyDecay(decayedConfidence, current.depth + 1, decaySchedule);
+
+          const existing = nodeScores.get(neighborId);
+          const pathEntry = { via: current.id, depth: current.depth + 1, confidence: decayedConfidence };
+
+          if (existing) {
+            // Noisy-OR: accumulate multi-path evidence
+            existing.paths.push(pathEntry);
+            const allProbs = existing.paths.map((p) => p.confidence);
+            existing.bestScore = noisyOr(allProbs);
+            existing.bestDepth = Math.min(existing.bestDepth, current.depth + 1);
+          } else {
+            nodeScores.set(neighborId, {
+              paths: [pathEntry],
+              bestScore: decayedConfidence,
+              bestDepth: current.depth + 1,
+            });
+            // Enqueue for further traversal
+            if (current.depth + 1 < maxDepth) {
+              queue.push({ id: neighborId, depth: current.depth + 1 });
+            }
+          }
+        }
+      } else {
+        // Binary mode (original)
+        for (const { neighborId, type, confidence } of neighbors) {
+          if (visited.has(neighborId)) continue;
+          if (affected.length >= MAX_IMPACT_RESULTS) { truncated = true; break; }
+          visited.add(neighborId);
+          const node = graph.getNode(neighborId);
+          queue.push({ id: neighborId, depth: current.depth + 1 });
+          affected.push({
+            depth: current.depth + 1,
+            name: node?.properties.name ?? neighborId,
+            type: node?.label ?? 'unknown',
+            filePath: (node?.properties.filePath as string) ?? '',
+            relationType: type,
+            confidence,
+          });
+        }
+      }
+    }
+
+    // #806: Build ranked output for probabilistic mode
+    if (mode === 'probabilistic') {
+      for (const [id, entry] of nodeScores) {
+        const node = graph.getNode(id);
+        if (!node) continue;
+        probabilisticResults.push({
+          id,
+          name: (node.properties.name as string) ?? id,
+          type: node.label ?? 'unknown',
+          filePath: (node.properties.filePath as string) ?? '',
+          score: Math.round(entry.bestScore * 1000) / 1000,
+          paths: entry.paths.map((p) => ({
+            via: p.via,
+            depth: p.depth,
+            confidence: Math.round(p.confidence * 1000) / 1000,
+          })),
+          category: '',
         });
       }
+      // Sort by score descending
+      probabilisticResults.sort((a, b) => b.score - a.score);
+      // Categorize by score
+      for (const r of probabilisticResults) {
+        if (r.score >= 0.8) r.category = 'direct';
+        else if (r.score >= 0.4) r.category = 'transitive';
+        else r.category = 'low-risk';
+      }
+      return {
+        target: { name: targetNode.properties.name ?? targetNode.id, type: targetNode.label, filePath: targetNode.properties.filePath ?? '' },
+        direction,
+        mode: 'probabilistic' as const,
+        decaySchedule,
+        affected_count: probabilisticResults.length,
+        truncated,
+        results: probabilisticResults.slice(0, 100),
+        summary: {
+          direct: probabilisticResults.filter((r) => r.category === 'direct').length,
+          transitive: probabilisticResults.filter((r) => r.category === 'transitive').length,
+          lowRisk: probabilisticResults.filter((r) => r.category === 'low-risk').length,
+        },
+      };
     }
 
     // Group by depth with risk levels
@@ -1041,6 +1182,8 @@ service: monorepo path prefix filter (only active in group mode).`,
         targetUid: { type: 'string', description: 'Exact node ID for zero-ambiguity lookup (skips name resolution)' },
         kind: { type: 'string', description: 'Node label filter for disambiguation when target name is ambiguous' },
         file_path: { type: 'string', description: 'File path filter for disambiguation' },
+        mode: { type: 'string', description: 'Impact scoring mode: binary (current) or probabilistic (confidence decay with Noisy-OR fusion)', enum: ['binary', 'probabilistic'] },
+        decaySchedule: { type: 'string', description: 'Decay schedule for probabilistic mode (default: linear)', enum: ['linear', 'exponential', 'logarithmic'] },
       },
       required: ['target', 'direction'],
     },
@@ -1054,6 +1197,8 @@ service: monorepo path prefix filter (only active in group mode).`,
       const targetUid = params.targetUid as string | undefined;
       const kind = params.kind as string | undefined;
       const filePath = params.file_path as string | undefined;
+      const mode = (params.mode as string) ?? 'binary';
+      const decaySchedule = (params.decaySchedule as string) ?? 'linear';
       let result: unknown;
 
       if (repo?.startsWith('@') && crossDepth > 0) {
@@ -1073,6 +1218,8 @@ service: monorepo path prefix filter (only active in group mode).`,
           targetUid,
           kind,
           filePath,
+          mode as 'binary' | 'probabilistic',
+          decaySchedule as 'linear' | 'exponential' | 'logarithmic',
         );
 
         // Cross-repo fan-out via contract links
@@ -1109,6 +1256,11 @@ service: monorepo path prefix filter (only active in group mode).`,
                     requireNumber(params, 'maxDepth', 3),
                     requireNumber(params, 'minConfidence', 0.3),
                     timeoutMs,
+                    undefined,
+                    undefined,
+                    undefined,
+                    mode as 'binary' | 'probabilistic',
+                    decaySchedule as 'linear' | 'exponential' | 'logarithmic',
                   );
                   crossResults.push({ repo: targetRepo, contract: link.contractType, link, result: crossResult });
                 } catch { /* skip unreachable repos */ }
@@ -1138,6 +1290,8 @@ service: monorepo path prefix filter (only active in group mode).`,
           targetUid,
           kind,
           filePath,
+          mode as 'binary' | 'probabilistic',
+          decaySchedule as 'linear' | 'exponential' | 'logarithmic',
         );
       } else {
         result = backend.impact(
@@ -1150,6 +1304,8 @@ service: monorepo path prefix filter (only active in group mode).`,
           targetUid,
           kind,
           filePath,
+          mode as 'binary' | 'probabilistic',
+          decaySchedule as 'linear' | 'exponential' | 'logarithmic',
         );
       }
 

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -30,6 +30,7 @@ import { generateDiagram, generateMarkdownDoc, type DiagramType, type DiagramOpt
 // #461: Graphlet-based structural analysis
 import { countGraphlets, buildAdjacencyMap, detectPatterns, scoreArchitectureHealth } from '../analysis/graphlet/index.js';
 import type { CommunityInfo } from '../analysis/graphlet/index.js';
+import { EDGE_DECAY_FACTORS, applyDecay, noisyOr } from '../analysis/impact-decay.js';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -165,43 +166,6 @@ function boostResults<T extends { name: string; filePath: string; score: number 
     result.score *= (1 + Math.min(boost, 0.5)); // cap at 50% boost
   }
   results.sort((a, b) => b.score - a.score);
-}
-
-// #806: Confidence decay factors per edge type for probabilistic impact analysis
-const EDGE_DECAY_FACTORS: Record<string, number> = {
-  CALLS: 0.9,
-  IMPORTS: 0.7,
-  EXTENDS: 0.8,
-  IMPLEMENTS: 0.85,
-  USES: 0.6,
-  ACCESSES: 0.65,
-  CONTAINS: 0.95,
-  DEFINES: 0.95,
-  QUERIES: 0.75,
-  ROUTES: 0.7,
-  MEMBER_OF: 0.3,
-  ENTRY_POINT_OF: 0.4,
-  HAS_PROPERTY: 0.5,
-  CHAINABLE_TO: 0.7,
-  CO_CHANGES: 0.8,
-  SEMANTICALLY_SIMILAR: 0.6,
-};
-
-// #806: Decay the confidence score based on depth and schedule
-function applyDecay(baseConfidence: number, depth: number, schedule: 'linear' | 'exponential' | 'logarithmic'): number {
-  if (schedule === 'exponential') {
-    return baseConfidence * Math.exp(-0.3 * (depth - 1));
-  }
-  if (schedule === 'logarithmic') {
-    return baseConfidence / Math.log2(depth + 1);
-  }
-  // linear (default): same penalty each hop
-  return baseConfidence;
-}
-
-// #806: Noisy-OR fusion — combine multiple path probabilities
-function noisyOr(probs: number[]): number {
-  return 1 - probs.reduce((acc, p) => acc * (1 - p), 1);
 }
 
 // ── Backend ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
﻿Probabilistic impact analysis with confidence decay.

Replaces binary reachability in impact analysis with probabilistic scoring using confidence decay per hop and Noisy-OR fusion for multiple paths. Answers 'how much does A affect B?' not just 'can A reach B?'.

Implements: impact() mode parameter ('binary'|'probabilistic'), confidence decay factors per edge type, Noisy-OR fusion, ranked impact report with categories.

Closes #806
