### PR TITLE
feat: graph resilience analysis — SPoF detection and bridge edges (#805)

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -33,6 +33,7 @@ import {
   startEvalServer,
   countGraphlets, buildAdjacencyMap, detectPatterns, scoreArchitectureHealth,
   migrateFromGitNexus,
+  detectCutVertices, detectBridges,
 } from '@astrolabe-dev/core';
 // #463: Coverage report parser
 import { parseCoverageReport, detectFormat, annotateGraphWithCoverage } from '@astrolabe-dev/core';
@@ -1311,6 +1312,105 @@ program
         if (vulnReport) {
           console.log('Dependency Vulnerabilities:');
           console.log(JSON.stringify(vulnReport, null, 2));
+        }
+      }
+    } finally {
+      store.close();
+    }
+  });
+
+// ── resilience (#805) ─────────────────────────────────────────────────────────
+program
+  .command('resilience [repoPath]')
+  .description('Analyze graph resilience — detect single points of failure (SPoF) and critical edges')
+  .option('-d, --db <path>', 'Database path', '.astrolabe/astrolabe.db')
+  .option('--json', 'Output raw JSON')
+  .action((repoPath: string | undefined, opts: { db: string; json?: boolean }) => {
+    const dbPath = repoPath ? join(repoPath, '.astrolabe', 'astrolabe.db') : opts.db;
+    if (!existsSync(dbPath)) {
+      console.log('No knowledge graph found. Run `astrolabe analyze` first.');
+      return;
+    }
+
+    const store = createSqliteStore(dbPath);
+    try {
+      const graph = store.loadGraph();
+
+      // Build adjacency list from CALLS and IMPORTS edges (same as MCP handler)
+      const adjList = new Map<string, string[]>();
+      for (const node of graph.iterNodes()) {
+        if (!adjList.has(node.id)) adjList.set(node.id, []);
+      }
+      for (const rel of graph.iterRelationships()) {
+        if (rel.type === 'STEP_IN_PROCESS' || rel.type === 'MEMBER_OF' || rel.type === 'ENTRY_POINT_OF') continue;
+        if (rel.type !== 'CALLS' && rel.type !== 'IMPORTS') continue;
+        let targets = adjList.get(rel.sourceId);
+        if (!targets) { targets = []; adjList.set(rel.sourceId, targets); }
+        targets.push(rel.targetId);
+        if (!adjList.has(rel.targetId)) adjList.set(rel.targetId, []);
+      }
+
+      const cutVertices = detectCutVertices(adjList);
+      const bridges = detectBridges(adjList);
+
+      // Resolve names
+      const namedCutVertices = cutVertices.map((id: string) => {
+        const node = graph.getNode(id);
+        return { id, name: node?.properties.name ?? id };
+      });
+
+      const namedBridges = bridges.map((b: { source: string; target: string }) => {
+        const srcNode = graph.getNode(b.source);
+        const tgtNode = graph.getNode(b.target);
+        return {
+          source: { id: b.source, name: srcNode?.properties.name ?? b.source },
+          target: { id: b.target, name: tgtNode?.properties.name ?? b.target },
+        };
+      });
+
+      const nodeCount = adjList.size;
+      const edgeCount = Array.from(adjList.values()).reduce((s, t) => s + t.length, 0);
+
+      if (opts.json) {
+        console.log(JSON.stringify({
+          nodeCount,
+          edgeCount,
+          cutVertices: { count: cutVertices.length, nodes: namedCutVertices },
+          bridgeEdges: { count: bridges.length, edges: namedBridges },
+          isBiconnected: cutVertices.length === 0 && bridges.length === 0,
+        }, null, 2));
+        return;
+      }
+
+      console.log(`\n=== Graph Resilience Analysis ===`);
+      console.log(`Nodes: ${nodeCount} | Edges: ${edgeCount}`);
+      console.log();
+
+      if (cutVertices.length === 0 && bridges.length === 0) {
+        console.log('\u2713 The graph is biconnected \u2014 no single points of failure detected.');
+      } else {
+        if (cutVertices.length > 0) {
+          console.log(`--- Single Points of Failure (${cutVertices.length} cut vertices) ---`);
+          console.log('These nodes, if removed, would disconnect the dependency graph:');
+          for (const n of namedCutVertices.slice(0, 20)) {
+            console.log(`  \u26A0  ${n.name}`);
+          }
+          if (namedCutVertices.length > 20) {
+            console.log(`  ... and ${namedCutVertices.length - 20} more`);
+          }
+          console.log();
+        }
+
+        if (bridges.length > 0) {
+          console.log(`--- Critical Dependency Bridges (${bridges.length} bridge edges) ---`);
+          console.log('These edges are the ONLY connection between subsystems:');
+          for (const b of namedBridges.slice(0, 20)) {
+            console.log(`  \u26A1 ${b.source.name} \u2192 ${b.target.name}`);
+          }
+          if (namedBridges.length > 20) {
+            console.log(`  ... and ${namedBridges.length - 20} more`);
+          }
+          console.log();
         }
       }
     } finally {

--- a/packages/core/src/core/graph-algorithms.ts
+++ b/packages/core/src/core/graph-algorithms.ts
@@ -262,3 +262,152 @@ function hasTarget(adjList: Map<string, string[]>, nodeId: string): boolean {
   }
   return false;
 }
+
+// ── Cut Vertices (Articulation Points) ──────────────────────────────────────
+
+/**
+ * Tarjan DFS low-link algorithm for articulation points (cut vertices).
+ * Operates on an undirected view of the directed adjacency list.
+ *
+ * A cut vertex is a node whose removal disconnects the graph — a single point
+ * of failure in a dependency graph.
+ */
+export function detectCutVertices(adjList: Map<string, string[]>): string[] {
+  if (adjList.size === 0) return [];
+
+  // Build undirected adjacency list
+  const undirected = new Map<string, Set<string>>();
+  for (const [node, neighbors] of adjList) {
+    let set = undirected.get(node);
+    if (!set) { set = new Set(); undirected.set(node, set); }
+    for (const neighbor of neighbors) {
+      set.add(neighbor);
+      let neighborSet = undirected.get(neighbor);
+      if (!neighborSet) { neighborSet = new Set(); undirected.set(neighbor, neighborSet); }
+      neighborSet.add(node);
+    }
+  }
+
+  const visited = new Set<string>();
+  const disc = new Map<string, number>();
+  const low = new Map<string, number>();
+  const parent = new Map<string, string | null>();
+  const cutVertices = new Set<string>();
+  let time = 0;
+
+  function dfs(u: string): void {
+    visited.add(u);
+    time++;
+    disc.set(u, time);
+    low.set(u, time);
+
+    let children = 0;
+    const neighbors = undirected.get(u) ?? new Set<string>();
+
+    for (const v of neighbors) {
+      if (!visited.has(v)) {
+        children++;
+        parent.set(v, u);
+        dfs(v);
+
+        // Update low-link value of u
+        low.set(u, Math.min(low.get(u)!, low.get(v)!));
+
+        // Non-root cut vertex check: no back edge from v's subtree to an ancestor of u
+        if (parent.get(u) !== null && low.get(v)! >= disc.get(u)!) {
+          cutVertices.add(u);
+        }
+      } else if (v !== parent.get(u)) {
+        // Back edge — update low value with discovery time of v
+        low.set(u, Math.min(low.get(u)!, disc.get(v)!));
+      }
+    }
+
+    // Root cut vertex check: more than one child in DFS tree
+    if (parent.get(u) === null && children > 1) {
+      cutVertices.add(u);
+    }
+  }
+
+  // Visit all nodes (handles disconnected components)
+  for (const node of undirected.keys()) {
+    if (!visited.has(node)) {
+      parent.set(node, null);
+      dfs(node);
+    }
+  }
+
+  return Array.from(cutVertices);
+}
+
+// ── Bridge Edges ────────────────────────────────────────────────────────────
+
+/**
+ * Modified Tarjan DFS for bridge edges.  Operates on an undirected view of
+ * the directed adjacency list.
+ *
+ * A bridge edge is an edge whose removal disconnects the graph — a critical
+ * dependency link between subsystems.
+ */
+export function detectBridges(
+  adjList: Map<string, string[]>,
+): Array<{ source: string; target: string }> {
+  if (adjList.size === 0) return [];
+
+  // Build undirected adjacency list
+  const undirected = new Map<string, Set<string>>();
+  for (const [node, neighbors] of adjList) {
+    let set = undirected.get(node);
+    if (!set) { set = new Set(); undirected.set(node, set); }
+    for (const neighbor of neighbors) {
+      set.add(neighbor);
+      let neighborSet = undirected.get(neighbor);
+      if (!neighborSet) { neighborSet = new Set(); undirected.set(neighbor, neighborSet); }
+      neighborSet.add(node);
+    }
+  }
+
+  const visited = new Set<string>();
+  const disc = new Map<string, number>();
+  const low = new Map<string, number>();
+  const parent = new Map<string, string | null>();
+  const bridges: Array<{ source: string; target: string }> = [];
+  let time = 0;
+
+  function dfs(u: string): void {
+    visited.add(u);
+    time++;
+    disc.set(u, time);
+    low.set(u, time);
+
+    const neighbors = undirected.get(u) ?? new Set<string>();
+
+    for (const v of neighbors) {
+      if (!visited.has(v)) {
+        parent.set(v, u);
+        dfs(v);
+
+        // Update low-link value of u
+        low.set(u, Math.min(low.get(u)!, low.get(v)!));
+
+        // Bridge condition: no back edge from v's subtree to u or its ancestors
+        if (low.get(v)! > disc.get(u)!) {
+          bridges.push({ source: u, target: v });
+        }
+      } else if (v !== parent.get(u)) {
+        // Back edge — update low value with discovery time of v
+        low.set(u, Math.min(low.get(u)!, disc.get(v)!));
+      }
+    }
+  }
+
+  // Visit all nodes (handles disconnected components)
+  for (const node of undirected.keys()) {
+    if (!visited.has(node)) {
+      parent.set(node, null);
+      dfs(node);
+    }
+  }
+
+  return bridges;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -79,3 +79,5 @@ export { chat, callLLM, type ChatMessage, type ChatResponse, type LLMConfig } fr
 export { countGraphlets, buildAdjacencyMap, type GraphletProfile } from './analysis/graphlet/index.js';
 export { detectPatterns, type ArchitecturePattern } from './analysis/graphlet/index.js';
 export { scoreArchitectureHealth, type ArchitectureHealth, type CommunityInfo } from './analysis/graphlet/index.js';
+// #805: Graph resilience analysis
+export { detectCutVertices, detectBridges } from './core/graph-algorithms.js';

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -24,7 +24,7 @@ import { StreamableHttpTransport } from './http-transport.js';
 import { routeMap, toolMap, apiImpact, shapeCheck } from './api-tools.js';
 import { executeTraversal, type TraversalQuery } from './traverse.js';
 import { PhaseTimer } from '../core/phase-timer.js';
-import { pageRank, betweennessCentrality, shortestPath } from '../core/graph-algorithms.js';
+import { pageRank, betweennessCentrality, shortestPath, detectCutVertices, detectBridges } from '../core/graph-algorithms.js';
 import { chat as ragChat, type ChatMessage } from '../agent/rag-chat.js';
 import { generateDiagram, generateMarkdownDoc, type DiagramType, type DiagramOptions } from './diagram-generator.js';
 // #461: Graphlet-based structural analysis
@@ -1706,12 +1706,13 @@ Algorithms:
 - pagerank: Identify the most important modules by link structure. Returns nodes sorted by PageRank score.
 - betweenness: Find bridge nodes that connect different communities. High betweenness = critical dependency bottleneck.
 - shortest_path: Find the dependency chain between two modules. Returns the shortest path or null.
+- resilience: Detect single points of failure (cut vertices) and critical dependency bridges. Returns articulation points and bridge edges.
 
 The graph is built from CALLS and IMPORTS relationships (excluding STEP_IN_PROCESS synthetic edges).`,
     inputSchema: {
       type: 'object',
       properties: {
-        algorithm: { type: 'string', enum: ['pagerank', 'betweenness', 'shortest_path'], description: 'Algorithm to run' },
+        algorithm: { type: 'string', enum: ['pagerank', 'betweenness', 'shortest_path', 'resilience'], description: 'Algorithm to run' },
         source: { type: 'string', description: 'Source node ID or name (required for shortest_path)' },
         target: { type: 'string', description: 'Target node ID or name (required for shortest_path)' },
         repo: { type: 'string', description: 'Repository name' },
@@ -1796,6 +1797,50 @@ The graph is built from CALLS and IMPORTS relationships (excluding STEP_IN_PROCE
         });
 
         return { content: [{ type: 'text', text: JSON.stringify({ algorithm: 'shortest_path', source: sourceParam, target: targetParam, path: namedPath, length: path.length - 1 }, null, 2) }] };
+      }
+
+      if (algorithm === 'resilience') {
+        const cutVertices = detectCutVertices(adjList);
+        const bridges = detectBridges(adjList);
+
+        // Resolve node names for readability
+        const namedCutVertices = cutVertices.map((id) => {
+          const node = graph.getNode(id);
+          return { id, name: node?.properties.name ?? id };
+        });
+
+        const namedBridges = bridges.map((b) => {
+          const srcNode = graph.getNode(b.source);
+          const tgtNode = graph.getNode(b.target);
+          return {
+            source: { id: b.source, name: srcNode?.properties.name ?? b.source },
+            target: { id: b.target, name: tgtNode?.properties.name ?? b.target },
+          };
+        });
+
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              algorithm: 'resilience',
+              analysis: {
+                cutVertices: {
+                  count: cutVertices.length,
+                  nodes: namedCutVertices,
+                  description: 'Nodes whose removal disconnects the graph (single points of failure)',
+                },
+                bridgeEdges: {
+                  count: bridges.length,
+                  edges: namedBridges,
+                  description: 'Edges whose removal disconnects the graph (critical dependency links)',
+                },
+                robustnessSummary: cutVertices.length === 0 && bridges.length === 0
+                  ? 'The graph is biconnected — no single point of failure detected.'
+                  : `Found ${cutVertices.length} cut vertices (SPoF) and ${bridges.length} bridge edges.`,
+              },
+            }, null, 2),
+          }],
+        };
       }
 
       return { content: [{ type: 'text', text: JSON.stringify({ error: `Unknown algorithm: ${algorithm}` }) }] };

--- a/packages/core/tests/core/graph-algorithms.test.ts
+++ b/packages/core/tests/core/graph-algorithms.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { pageRank, betweennessCentrality, shortestPath } from '../../src/core/graph-algorithms.js';
+import { pageRank, betweennessCentrality, shortestPath, detectCutVertices, detectBridges } from '../../src/core/graph-algorithms.js';
 
 // ── PageRank Tests ──────────────────────────────────────────────────────────
 
@@ -192,5 +192,124 @@ describe('shortestPath', () => {
     const path = shortestPath(adj, 'A', 'Z');
 
     expect(path).toBeNull();
+  });
+});
+
+// ── Cut Vertices (Articulation Points) Tests ────────────────────────────────
+
+describe('detectCutVertices', () => {
+  it('detects the middle node as cut vertex in a linear chain A-B-C', () => {
+    const adj = new Map<string, string[]>([
+      ['A', ['B']],
+      ['B', ['C']],
+      ['C', []],
+    ]);
+    const result = detectCutVertices(adj);
+    // B is the only cut vertex — removing it disconnects A from C
+    expect(result).toContain('B');
+    expect(result).not.toContain('A');
+    expect(result).not.toContain('C');
+  });
+
+  it('returns empty array for a triangle (fully connected 3-cycle)', () => {
+    const adj = new Map<string, string[]>([
+      ['A', ['B', 'C']],
+      ['B', ['A', 'C']],
+      ['C', ['A', 'B']],
+    ]);
+    const result = detectCutVertices(adj);
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array for empty graph', () => {
+    expect(detectCutVertices(new Map())).toEqual([]);
+  });
+
+  it('identifies hub as cut vertex in a star graph', () => {
+    // Hub connects all leaves; leaves only connect to hub
+    const adj = new Map<string, string[]>([
+      ['Hub', ['A', 'B', 'C']],
+      ['A', ['Hub']],
+      ['B', ['Hub']],
+      ['C', ['Hub']],
+    ]);
+    const result = detectCutVertices(adj);
+    expect(result).toContain('Hub');
+    expect(result).not.toContain('A');
+  });
+
+  it('detects cut vertices in a dumbbell graph', () => {
+    // A-B-C-D-E where C connects two triangles: (A,B,C) and (C,D,E)
+    const adj = new Map<string, string[]>([
+      ['A', ['B', 'C']],
+      ['B', ['A', 'C']],
+      ['C', ['A', 'B', 'D', 'E']],
+      ['D', ['C', 'E']],
+      ['E', ['C', 'D']],
+    ]);
+    const result = detectCutVertices(adj);
+    // C is the only cut vertex connecting the two triangles
+    expect(result).toContain('C');
+    expect(result).toHaveLength(1);
+  });
+
+  it('returns empty for a single isolated node', () => {
+    const adj = new Map<string, string[]>([['A', []]]);
+    expect(detectCutVertices(adj)).toEqual([]);
+  });
+});
+
+// ── Bridge Edges Tests ──────────────────────────────────────────────────────
+
+describe('detectBridges', () => {
+  it('detects bridges in a linear chain A-B-C', () => {
+    const adj = new Map<string, string[]>([
+      ['A', ['B']],
+      ['B', ['C']],
+      ['C', []],
+    ]);
+    const result = detectBridges(adj);
+    // Both edges A-B and B-C are bridges in a chain
+    expect(result).toHaveLength(2);
+  });
+
+  it('returns empty array for a triangle (no bridges)', () => {
+    const adj = new Map<string, string[]>([
+      ['A', ['B', 'C']],
+      ['B', ['A', 'C']],
+      ['C', ['A', 'B']],
+    ]);
+    const result = detectBridges(adj);
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array for empty graph', () => {
+    expect(detectBridges(new Map())).toEqual([]);
+  });
+
+  it('detects bridge in a simple two-node graph', () => {
+    const adj = new Map<string, string[]>([
+      ['A', ['B']],
+      ['B', ['A']],
+    ]);
+    const result = detectBridges(adj);
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe('A');
+    expect(result[0].target).toBe('B');
+  });
+
+  it('detects the bridge edge in a dumbbell graph', () => {
+    // Two triangles connected by single edge C-D
+    const adj = new Map<string, string[]>([
+      ['A', ['B', 'C']],
+      ['B', ['A', 'C']],
+      ['C', ['A', 'B', 'D']],
+      ['D', ['C', 'E', 'F']],
+      ['E', ['D', 'F']],
+      ['F', ['D', 'E']],
+    ]);
+    const result = detectBridges(adj);
+    expect(result).toHaveLength(1);
+    // Edge C-D is the only bridge
   });
 });


### PR DESCRIPTION
Closes #805

## Summary
- Add Tarjan DFS low-link algorithm for cut vertex (articulation point) detection
- Add bridge edge detection via modified Tarjan
- Wire into \graph_algorithms\ MCP tool as \esilience\ algorithm
- Add \esilience\ CLI command with JSON output
- 10 new tests for both algorithms

See issue #805 for full spec.