### PR TITLE
feat: graph-based test coverage metrics (#811)

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -33,6 +33,7 @@ import {
   startEvalServer,
   countGraphlets, buildAdjacencyMap, detectPatterns, scoreArchitectureHealth,
   migrateFromGitNexus,
+  computeGraphCoverageMetrics,
 } from '@astrolabe-dev/core';
 // #463: Coverage report parser
 import { parseCoverageReport, detectFormat, annotateGraphWithCoverage } from '@astrolabe-dev/core';
@@ -1313,6 +1314,64 @@ program
           console.log(JSON.stringify(vulnReport, null, 2));
         }
       }
+    } finally {
+      store.close();
+    }
+  });
+
+// ── test-coverage (#811) ─────────────────────────────────────────────────────
+program
+  .command('test-coverage [repoPath]')
+  .description('Analyze test coverage using graph structure — per-community metrics and gap prioritization (#811)')
+  .option('-d, --db <path>', 'Database path', '.astrolabe/astrolabe.db')
+  .option('--json', 'Output raw JSON')
+  .action((repoPath: string | undefined, opts: { db: string; json?: boolean }) => {
+    const dbPath = repoPath ? join(repoPath, '.astrolabe', 'astrolabe.db') : opts.db;
+    if (!existsSync(dbPath)) {
+      console.log('No knowledge graph found. Run `astrolabe analyze` first.');
+      return;
+    }
+
+    const store = createSqliteStore(dbPath);
+    try {
+      const graph = store.loadGraph();
+      const metrics = computeGraphCoverageMetrics(graph);
+
+      if (opts.json) {
+        console.log(JSON.stringify(metrics, null, 2));
+        return;
+      }
+
+      if (metrics.totalFunctionNodes === 0) {
+        console.log('No function nodes found. Run `astrolabe analyze` first.');
+        return;
+      }
+
+      console.log(`\n=== Test Coverage Analysis (Graph-Aware) ===`);
+      console.log(`\nOverall:`);
+      console.log(`  Node coverage: ${metrics.overallNodeCoveragePercent.toFixed(1)}% (${metrics.coveredFunctionNodes} covered / ${metrics.partialFunctionNodes} partial / ${metrics.uncoveredFunctionNodes} uncovered of ${metrics.totalFunctionNodes} total)`);
+      console.log(`  Edge coverage: ${metrics.overallEdgeCoveragePercent.toFixed(1)}% (${metrics.coveredCallEdges} covered / ${metrics.totalCallEdges} total call edges)`);
+
+      console.log(`\n--- Per-Community Coverage (${metrics.communities.length} communities) ---`);
+      for (const c of metrics.communities) {
+        const bar = '█'.repeat(Math.round(c.nodeCoveragePercent / 10)) + '░'.repeat(10 - Math.round(c.nodeCoveragePercent / 10));
+        console.log(`  ${c.communityName}: ${bar} ${c.nodeCoveragePercent.toFixed(0)}% nodes`);
+        for (const gap of c.topGaps.slice(0, 3)) {
+          console.log(`    ⚠  ${gap.label}:${gap.name} (impact: ${gap.impact})`);
+        }
+      }
+
+      if (metrics.topUntestedHighImpact.length > 0) {
+        console.log(`\n--- Top Untested High-Impact Symbols ---`);
+        for (const gap of metrics.topUntestedHighImpact.slice(0, 15)) {
+          console.log(`  ⚠  [${gap.community}] ${gap.label}:${gap.name} — ${gap.impact} dependents`);
+        }
+        if (metrics.topUntestedHighImpact.length > 15) {
+          console.log(`  ... and ${metrics.topUntestedHighImpact.length - 15} more`);
+        }
+      }
+
+      console.log();
     } finally {
       store.close();
     }

--- a/packages/core/src/analysis/coverage/graph-metrics.ts
+++ b/packages/core/src/analysis/coverage/graph-metrics.ts
@@ -1,0 +1,329 @@
+/**
+ * Graph-Aware Test Coverage Metrics (#811).
+ *
+ * Combines coverage annotations with graph structure (communities, call edges,
+ * impact scores) to produce per-community breakdowns and prioritised gap lists.
+ */
+
+import type { KnowledgeGraph } from '@astrolabe-dev/shared';
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface CommunityCoverage {
+  communityId: string;
+  communityName: string;
+  totalNodes: number;
+  coveredNodes: number;
+  partialNodes: number;
+  uncoveredNodes: number;
+  nodeCoveragePercent: number;
+  totalCallEdges: number;
+  coveredCallEdges: number;
+  edgeCoveragePercent: number;
+  topGaps: Array<{ name: string; label: string; impact: number; filePath: string }>;
+}
+
+export interface GraphCoverageMetrics {
+  totalFunctionNodes: number;
+  coveredFunctionNodes: number;
+  partialFunctionNodes: number;
+  uncoveredFunctionNodes: number;
+  overallNodeCoveragePercent: number;
+  totalCallEdges: number;
+  coveredCallEdges: number;
+  overallEdgeCoveragePercent: number;
+  communities: CommunityCoverage[];
+  topUntestedHighImpact: Array<{ name: string; label: string; impact: number; community: string; filePath: string }>;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const FUNCTION_LABELS = new Set(['Function', 'Method', 'Constructor']);
+
+interface CoverageData {
+  status: 'covered' | 'partial' | 'uncovered';
+  lineCoverage: number;
+  functionCoverage: number;
+}
+
+function getCoverageData(node: {
+  properties: Record<string, unknown>;
+}): CoverageData {
+  const status = node.properties._coverageStatus as string | undefined;
+  const cov = node.properties._coverage as
+    | { lineCoverage?: number; functionCoverage?: number }
+    | undefined;
+
+  // If no _coverageStatus, treat as uncovered
+  if (!status) {
+    return { status: 'uncovered', lineCoverage: 0, functionCoverage: 0 };
+  }
+
+  return {
+    status: status as 'covered' | 'partial' | 'uncovered',
+    lineCoverage: cov?.lineCoverage ?? 0,
+    functionCoverage: cov?.functionCoverage ?? 0,
+  };
+}
+
+// ── Main Algorithm ─────────────────────────────────────────────────────────
+
+export function computeGraphCoverageMetrics(
+  graph: KnowledgeGraph,
+): GraphCoverageMetrics {
+  // 1. Build community index from MEMBER_OF edges
+  const communityOf = new Map<string, string>();
+  const communityNameMap = new Map<string, string>();
+
+  for (const rel of graph.iterRelationships()) {
+    if (rel.type === 'MEMBER_OF') {
+      const communityNode = graph.getNode(rel.targetId);
+      if (communityNode && communityNode.label === 'Community') {
+        communityOf.set(rel.sourceId, rel.targetId);
+        communityNameMap.set(
+          rel.targetId,
+          (communityNode.properties.name as string) ?? rel.targetId,
+        );
+      }
+    }
+  }
+
+  // 2. Count incoming CALLS edges for impact scoring
+  const incomingCallCount = new Map<string, number>();
+  for (const rel of graph.iterRelationships()) {
+    if (rel.type === 'CALLS') {
+      incomingCallCount.set(
+        rel.targetId,
+        (incomingCallCount.get(rel.targetId) ?? 0) + 1,
+      );
+    }
+  }
+
+  // 3. Per-community accumulators
+  interface CommunityAccum {
+    totalNodes: number;
+    coveredNodes: number;
+    partialNodes: number;
+    uncoveredNodes: number;
+    totalCallEdges: number;
+    coveredCallEdges: number;
+    gaps: Array<{ name: string; label: string; impact: number; filePath: string }>;
+  }
+
+  const communityMap = new Map<string, CommunityAccum>();
+  const ensureCommunity = (communityId: string): CommunityAccum => {
+    let acc = communityMap.get(communityId);
+    if (!acc) {
+      acc = {
+        totalNodes: 0,
+        coveredNodes: 0,
+        partialNodes: 0,
+        uncoveredNodes: 0,
+        totalCallEdges: 0,
+        coveredCallEdges: 0,
+        gaps: [],
+      };
+      communityMap.set(communityId, acc);
+    }
+    return acc;
+  };
+
+  // Overall accumulators
+  let totalFunctionNodes = 0;
+  let coveredFunctionNodes = 0;
+  let partialFunctionNodes = 0;
+  let uncoveredFunctionNodes = 0;
+
+  // All function nodes for edge pass
+  const fnNodeIds = new Set<string>();
+
+  // Iterate all function-like nodes
+  for (const node of graph.iterNodes()) {
+    if (!FUNCTION_LABELS.has(node.label)) continue;
+
+    const cov = getCoverageData(node);
+    const commId = communityOf.get(node.id) ?? '__unassigned__';
+    const acc = ensureCommunity(commId);
+
+    fnNodeIds.add(node.id);
+    totalFunctionNodes++;
+    acc.totalNodes++;
+
+    switch (cov.status) {
+      case 'covered':
+        coveredFunctionNodes++;
+        acc.coveredNodes++;
+        break;
+      case 'partial':
+        partialFunctionNodes++;
+        acc.partialNodes++;
+        break;
+      case 'uncovered':
+        uncoveredFunctionNodes++;
+        acc.uncoveredNodes++;
+        break;
+    }
+  }
+
+  // 4. Count CALLS edges for edge coverage (both endpoints must be covered)
+  // Also track which functions are source/target of calls for per-community edge stats
+  let totalCallEdges = 0;
+  let coveredCallEdges = 0;
+
+  // Build per-community call edge maps
+  const commCallEdges = new Map<string, number>(); // communityId -> total call edges
+  const commCoveredCallEdges = new Map<string, number>(); // communityId -> covered call edges
+
+  for (const rel of graph.iterRelationships()) {
+    if (rel.type !== 'CALLS') continue;
+
+    const sourceFn = fnNodeIds.has(rel.sourceId);
+    const targetFn = fnNodeIds.has(rel.targetId);
+
+    // Only count edges where both endpoints are function-like nodes
+    if (!sourceFn || !targetFn) continue;
+
+    totalCallEdges++;
+
+    const sourceNode = graph.getNode(rel.sourceId);
+    const targetNode = graph.getNode(rel.targetId);
+
+    const sourceCov = sourceNode ? getCoverageData(sourceNode) : undefined;
+    const targetCov = targetNode ? getCoverageData(targetNode) : undefined;
+
+    const isCovered =
+      sourceCov?.status === 'covered' && targetCov?.status === 'covered';
+    if (isCovered) coveredCallEdges++;
+
+    // Per-community edge stats: attribute edge to target's community
+    const targetComm = communityOf.get(rel.targetId) ?? '__unassigned__';
+    commCallEdges.set(targetComm, (commCallEdges.get(targetComm) ?? 0) + 1);
+    if (isCovered)
+      commCoveredCallEdges.set(
+        targetComm,
+        (commCoveredCallEdges.get(targetComm) ?? 0) + 1,
+      );
+
+    // Also attribute to source community
+    const sourceComm = communityOf.get(rel.sourceId) ?? '__unassigned__';
+    if (sourceComm !== targetComm) {
+      commCallEdges.set(sourceComm, (commCallEdges.get(sourceComm) ?? 0) + 1);
+      if (isCovered)
+        commCoveredCallEdges.set(
+          sourceComm,
+          (commCoveredCallEdges.get(sourceComm) ?? 0) + 1,
+        );
+    }
+  }
+
+  // 5. Build per-community top gaps (populated below in second pass)
+
+  // Second pass: populate gaps for uncovered nodes
+  for (const node of graph.iterNodes()) {
+    if (!FUNCTION_LABELS.has(node.label)) continue;
+
+    const cov = getCoverageData(node);
+    if (cov.status !== 'uncovered') continue;
+
+    const commId = communityOf.get(node.id) ?? '__unassigned__';
+    const acc = communityMap.get(commId);
+    if (!acc) continue;
+
+    const impact = incomingCallCount.get(node.id) ?? 0;
+
+    acc.gaps.push({
+      name: (node.properties.name as string) ?? node.id,
+      label: node.label,
+      impact,
+      filePath: (node.properties.filePath as string) ?? '',
+    });
+  }
+
+  // 6. Build community summaries
+  const communities: CommunityCoverage[] = [];
+
+  for (const [commId, acc] of communityMap) {
+    const commName =
+      commId === '__unassigned__'
+        ? '(unassigned)'
+        : (communityNameMap.get(commId) ?? commId);
+
+    // Sort gaps by impact (highest first), take top 5
+    acc.gaps.sort((a, b) => b.impact - a.impact);
+    const topGaps = acc.gaps.slice(0, 5);
+
+    const totalCalls = commCallEdges.get(commId) ?? 0;
+    const coveredCalls = commCoveredCallEdges.get(commId) ?? 0;
+
+    communities.push({
+      communityId: commId,
+      communityName: commName,
+      totalNodes: acc.totalNodes,
+      coveredNodes: acc.coveredNodes,
+      partialNodes: acc.partialNodes,
+      uncoveredNodes: acc.uncoveredNodes,
+      nodeCoveragePercent:
+        acc.totalNodes > 0
+          ? (acc.coveredNodes / acc.totalNodes) * 100
+          : 0,
+      totalCallEdges: totalCalls,
+      coveredCallEdges: coveredCalls,
+      edgeCoveragePercent:
+        totalCalls > 0 ? (coveredCalls / totalCalls) * 100 : 0,
+      topGaps,
+    });
+  }
+
+  // Sort communities by node coverage (worst first)
+  communities.sort((a, b) => a.nodeCoveragePercent - b.nodeCoveragePercent);
+
+  // 7. Build overall top untested high-impact
+  const allGaps: Array<{
+    name: string;
+    label: string;
+    impact: number;
+    community: string;
+    filePath: string;
+  }> = [];
+
+  for (const node of graph.iterNodes()) {
+    if (!FUNCTION_LABELS.has(node.label)) continue;
+
+    const cov = getCoverageData(node);
+    if (cov.status !== 'uncovered') continue;
+
+    const impact = incomingCallCount.get(node.id) ?? 0;
+    const commId = communityOf.get(node.id) ?? '__unassigned__';
+    const commName =
+      commId === '__unassigned__'
+        ? '(unassigned)'
+        : (communityNameMap.get(commId) ?? commId);
+
+    allGaps.push({
+      name: (node.properties.name as string) ?? node.id,
+      label: node.label,
+      impact,
+      community: commName,
+      filePath: (node.properties.filePath as string) ?? '',
+    });
+  }
+
+  allGaps.sort((a, b) => b.impact - a.impact);
+
+  return {
+    totalFunctionNodes,
+    coveredFunctionNodes,
+    partialFunctionNodes,
+    uncoveredFunctionNodes,
+    overallNodeCoveragePercent:
+      totalFunctionNodes > 0
+        ? (coveredFunctionNodes / totalFunctionNodes) * 100
+        : 0,
+    totalCallEdges,
+    coveredCallEdges,
+    overallEdgeCoveragePercent:
+      totalCallEdges > 0 ? (coveredCallEdges / totalCallEdges) * 100 : 0,
+    communities,
+    topUntestedHighImpact: allGaps.slice(0, 20),
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,6 +39,8 @@ export { parseLcov, parseIstanbul, parseCobertura, parseCoverageReport, detectFo
 export type { CoverageReport, FileCoverage } from './analysis/coverage/parser.js';
 export type { CoverageScanOutput } from './analysis/phases/coverage.js';
 export { annotateGraphWithCoverage } from './analysis/phases/coverage.js';
+// #811: Graph-based coverage metrics
+export { computeGraphCoverageMetrics, type GraphCoverageMetrics, type CommunityCoverage } from './analysis/coverage/graph-metrics.js';
 export { createSqliteStore, acquireDbLock } from './persist/index.js';
 export type { SqliteStore } from './persist/sqlite.js';
 export type { DbLock } from './persist/lock.js';

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -30,6 +30,8 @@ import { generateDiagram, generateMarkdownDoc, type DiagramType, type DiagramOpt
 // #461: Graphlet-based structural analysis
 import { countGraphlets, buildAdjacencyMap, detectPatterns, scoreArchitectureHealth } from '../analysis/graphlet/index.js';
 import type { CommunityInfo } from '../analysis/graphlet/index.js';
+// #811: Graph-based coverage metrics
+import { computeGraphCoverageMetrics } from '../analysis/coverage/graph-metrics.js';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -2356,6 +2358,64 @@ DIAGRAM TYPES:
 
       lines.push('');
       lines.push('These symbols have no test coverage but are depended upon by multiple callers. Consider adding tests to reduce risk.');
+
+      return { content: [{ type: 'text', text: lines.join('\n') }] };
+    },
+  },
+
+  // #811: Graph-based test coverage analysis
+  'astrolabe.test_coverage': {
+    name: 'astrolabe.test_coverage',
+    description: `Analyze test coverage using graph structure — per-community metrics, edge coverage, and gap prioritization. Requires coverage data to have been ingested via the ingest-coverage CLI command.
+
+Returns:
+- Overall node/edge coverage percentages
+- Per-community breakdown with top coverage gaps
+- Top untested high-impact symbols for prioritization`,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        repo: { type: 'string', description: 'Repository name' },
+      },
+    },
+    handler: async (params) => {
+      const ctx = backend.getRepo(params.repo as string);
+      const graph = ctx.loadGraph();
+      const metrics = computeGraphCoverageMetrics(graph);
+
+      if (metrics.totalFunctionNodes === 0) {
+        return { content: [{ type: 'text', text: 'No function nodes found in the knowledge graph. Run `astrolabe analyze` first.' }] };
+      }
+
+      // Build text output
+      const lines: string[] = [
+        `=== Test Coverage Analysis (Graph-Aware) ===`,
+        '',
+        `Overall: ${metrics.overallNodeCoveragePercent.toFixed(1)}% node coverage (${metrics.coveredFunctionNodes} covered / ${metrics.partialFunctionNodes} partial / ${metrics.uncoveredFunctionNodes} uncovered of ${metrics.totalFunctionNodes} total)`,
+        `Calls edges: ${metrics.overallEdgeCoveragePercent.toFixed(1)}% edge coverage (${metrics.coveredCallEdges} covered / ${metrics.totalCallEdges} total)`,
+        '',
+      ];
+
+      // Per-community breakdown
+      lines.push(`--- Per-Community Coverage (${metrics.communities.length} communities) ---`);
+      for (const c of metrics.communities) {
+        const bar = '█'.repeat(Math.round(c.nodeCoveragePercent / 10)) + '░'.repeat(10 - Math.round(c.nodeCoveragePercent / 10));
+        lines.push(`  ${c.communityName}: ${bar} ${c.nodeCoveragePercent.toFixed(0)}% nodes, ${c.edgeCoveragePercent.toFixed(0)}% edges`);
+        for (const gap of c.topGaps) {
+          lines.push(`    ⚠ ${gap.label}:${gap.name} (impact: ${gap.impact})`);
+        }
+      }
+
+      // Top gaps
+      if (metrics.topUntestedHighImpact.length > 0) {
+        lines.push('');
+        lines.push('--- Top 20 Untested High-Impact Symbols ---');
+        for (const gap of metrics.topUntestedHighImpact) {
+          lines.push(`  ⚠ [${gap.community}] ${gap.label}:${gap.name} — ${gap.impact} dependents (${gap.filePath})`);
+        }
+        lines.push('');
+        lines.push('These symbols have no test coverage but are heavily depended upon. Prioritize adding tests for them.');
+      }
 
       return { content: [{ type: 'text', text: lines.join('\n') }] };
     },

--- a/packages/core/tests/analysis/coverage/graph-metrics.test.ts
+++ b/packages/core/tests/analysis/coverage/graph-metrics.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { createKnowledgeGraph } from '../../../src/core/graph.js';
+import { computeGraphCoverageMetrics } from '../../../src/analysis/coverage/graph-metrics.js';
+import type { KnowledgeGraph } from '@astrolabe-dev/shared';
+
+function createTestGraph(): KnowledgeGraph {
+  const graph = createKnowledgeGraph();
+
+  // Create community nodes
+  graph.addNode({ id: 'community:1', label: 'Community', properties: { name: 'core', symbolCount: 3 } });
+  graph.addNode({ id: 'community:2', label: 'Community', properties: { name: 'utils', symbolCount: 2 } });
+
+  // Create function nodes with coverage
+  graph.addNode({ id: 'fn1', label: 'Function', properties: { name: 'coveredFn', filePath: 'src/core.ts', _coverageStatus: 'covered', _coverage: { lineCoverage: 95, functionCoverage: 100, uncoveredLines: [] } } });
+  graph.addNode({ id: 'fn2', label: 'Function', properties: { name: 'uncoveredFn', filePath: 'src/core.ts', _coverageStatus: 'uncovered', _coverage: { lineCoverage: 0, functionCoverage: 0, uncoveredLines: [10, 20] } } });
+  graph.addNode({ id: 'fn3', label: 'Method', properties: { name: 'partialMethod', filePath: 'src/core.ts', _coverageStatus: 'partial', _coverage: { lineCoverage: 45, functionCoverage: 50, uncoveredLines: [30] } } });
+  graph.addNode({ id: 'fn4', label: 'Function', properties: { name: 'utilFn', filePath: 'src/utils.ts', _coverageStatus: 'covered', _coverage: { lineCoverage: 88, functionCoverage: 100, uncoveredLines: [] } } });
+  graph.addNode({ id: 'fn5', label: 'Function', properties: { name: 'helperFn', filePath: 'src/utils.ts', _coverageStatus: 'uncovered', _coverage: { lineCoverage: 0, functionCoverage: 0, uncoveredLines: [5] } } });
+
+  // Community membership
+  graph.addRelationship({ id: 'mem1', sourceId: 'fn1', targetId: 'community:1', type: 'MEMBER_OF', confidence: 0.7, reason: 'core member' });
+  graph.addRelationship({ id: 'mem2', sourceId: 'fn2', targetId: 'community:1', type: 'MEMBER_OF', confidence: 0.7, reason: 'core member' });
+  graph.addRelationship({ id: 'mem3', sourceId: 'fn3', targetId: 'community:1', type: 'MEMBER_OF', confidence: 0.7, reason: 'core member' });
+  graph.addRelationship({ id: 'mem4', sourceId: 'fn4', targetId: 'community:2', type: 'MEMBER_OF', confidence: 0.7, reason: 'utils member' });
+  graph.addRelationship({ id: 'mem5', sourceId: 'fn5', targetId: 'community:2', type: 'MEMBER_OF', confidence: 0.7, reason: 'utils member' });
+
+  // CALLS edges (fn1→fn2, fn1→fn3, fn3→fn4, fn4→fn5)
+  graph.addRelationship({ id: 'call1', sourceId: 'fn1', targetId: 'fn2', type: 'CALLS', confidence: 0.8, reason: 'covered→uncovered' });
+  graph.addRelationship({ id: 'call2', sourceId: 'fn1', targetId: 'fn3', type: 'CALLS', confidence: 0.8, reason: 'covered→partial' });
+  graph.addRelationship({ id: 'call3', sourceId: 'fn3', targetId: 'fn4', type: 'CALLS', confidence: 0.8, reason: 'partial→covered' });
+  graph.addRelationship({ id: 'call4', sourceId: 'fn4', targetId: 'fn5', type: 'CALLS', confidence: 0.8, reason: 'covered→uncovered' });
+
+  return graph;
+}
+
+describe('computeGraphCoverageMetrics', () => {
+  it('computes correct overall node coverage percentages', () => {
+    const graph = createTestGraph();
+    const metrics = computeGraphCoverageMetrics(graph);
+
+    expect(metrics.totalFunctionNodes).toBe(5);
+    expect(metrics.coveredFunctionNodes).toBe(2);   // fn1, fn4
+    expect(metrics.partialFunctionNodes).toBe(1);    // fn3
+    expect(metrics.uncoveredFunctionNodes).toBe(2);  // fn2, fn5
+    expect(metrics.overallNodeCoveragePercent).toBeCloseTo(40, 0); // 2/5 fully covered
+  });
+
+  it('computes correct edge coverage', () => {
+    const graph = createTestGraph();
+    const metrics = computeGraphCoverageMetrics(graph);
+
+    expect(metrics.totalCallEdges).toBe(4);
+    // Only edges where BOTH endpoints are 'covered': fn1→fn2 (NO), fn1→fn3 (NO), fn3→fn4 (NO), fn4→fn5 (NO)
+    expect(metrics.coveredCallEdges).toBe(0);
+    expect(metrics.overallEdgeCoveragePercent).toBe(0);
+  });
+
+  it('computes per-community breakdown', () => {
+    const graph = createTestGraph();
+    const metrics = computeGraphCoverageMetrics(graph);
+
+    expect(metrics.communities).toHaveLength(2);
+
+    const core = metrics.communities.find((c) => c.communityName === 'core')!;
+    expect(core).toBeDefined();
+    expect(core.totalNodes).toBe(3);
+    expect(core.coveredNodes).toBe(1);  // fn1
+    expect(core.partialNodes).toBe(1);  // fn3
+    expect(core.uncoveredNodes).toBe(1); // fn2
+
+    const utils = metrics.communities.find((c) => c.communityName === 'utils')!;
+    expect(utils).toBeDefined();
+    expect(utils.totalNodes).toBe(2);
+    expect(utils.coveredNodes).toBe(1);   // fn4
+    expect(utils.uncoveredNodes).toBe(1); // fn5
+  });
+
+  it('returns zeros for empty graph', () => {
+    const graph = createKnowledgeGraph();
+    const metrics = computeGraphCoverageMetrics(graph);
+
+    expect(metrics.totalFunctionNodes).toBe(0);
+    expect(metrics.communities).toEqual([]);
+    expect(metrics.topUntestedHighImpact).toEqual([]);
+  });
+
+  it('identifies top untested high-impact nodes', () => {
+    const graph = createTestGraph();
+    const metrics = computeGraphCoverageMetrics(graph);
+
+    // fn2 has 1 incoming call (from fn1), fn5 has 1 incoming call (from fn4)
+    // Both are uncovered
+    expect(metrics.topUntestedHighImpact.length).toBeGreaterThanOrEqual(1);
+
+    const fn2Gap = metrics.topUntestedHighImpact.find((g) => g.name === 'uncoveredFn');
+    expect(fn2Gap).toBeDefined();
+    expect(fn2Gap!.impact).toBe(1);
+  });
+
+  it('handles nodes with no coverage data by treating as uncovered', () => {
+    const graph = createKnowledgeGraph();
+    // Node with no _coverageStatus at all
+    graph.addNode({ id: 'fn1', label: 'Function', properties: { name: 'noCov', filePath: 'src/x.ts' } });
+    graph.addNode({ id: 'fn2', label: 'Function', properties: { name: 'hasCov', filePath: 'src/x.ts', _coverageStatus: 'covered', _coverage: { lineCoverage: 90, functionCoverage: 100, uncoveredLines: [] } } });
+
+    const metrics = computeGraphCoverageMetrics(graph);
+    expect(metrics.totalFunctionNodes).toBe(2);
+    expect(metrics.coveredFunctionNodes).toBe(1);
+    expect(metrics.uncoveredFunctionNodes).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #811

## Summary
- Add computeGraphCoverageMetrics() — per-community node/edge coverage metrics using graph structure
- Add astrolabe.test_coverage MCP tool
- Add test-coverage CLI command with --json output
- 6 tests for graph coverage metrics

See issue #811 for full spec.