### PR TITLE
feat: spectral graph analysis (#812)

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -32,6 +32,7 @@ import {
   generateWiki,
   startEvalServer,
   countGraphlets, buildAdjacencyMap, detectPatterns, scoreArchitectureHealth,
+  computeSpectralMetrics,
   migrateFromGitNexus,
 } from '@astrolabe-dev/core';
 // #463: Coverage report parser
@@ -1313,6 +1314,62 @@ program
           console.log(JSON.stringify(vulnReport, null, 2));
         }
       }
+    } finally {
+      store.close();
+    }
+  });
+
+// ── spectral (#812) ──────────────────────────────────────────────────────────
+program
+  .command('spectral [repoPath]')
+  .description('Spectral graph analysis — density, entropy, flow hierarchy, topology classification (#812)')
+  .option('-d, --db <path>', 'Database path', '.astrolabe/astrolabe.db')
+  .option('--json', 'Output raw JSON')
+  .action((repoPath: string | undefined, opts: { db: string; json?: boolean }) => {
+    const dbPath = repoPath ? join(repoPath, '.astrolabe', 'astrolabe.db') : opts.db;
+    if (!existsSync(dbPath)) {
+      console.log('No knowledge graph found. Run `astrolabe analyze` first.');
+      return;
+    }
+
+    const store = createSqliteStore(dbPath);
+    try {
+      const graph = store.loadGraph();
+
+      // Build adjacency list from CALLS and IMPORTS edges
+      const adjList = new Map<string, string[]>();
+      for (const node of graph.iterNodes()) {
+        if (!adjList.has(node.id)) adjList.set(node.id, []);
+      }
+      for (const rel of graph.iterRelationships()) {
+        if (rel.type === 'STEP_IN_PROCESS' || rel.type === 'MEMBER_OF' || rel.type === 'ENTRY_POINT_OF') continue;
+        if (rel.type !== 'CALLS' && rel.type !== 'IMPORTS') continue;
+        let targets = adjList.get(rel.sourceId);
+        if (!targets) { targets = []; adjList.set(rel.sourceId, targets); }
+        targets.push(rel.targetId);
+        if (!adjList.has(rel.targetId)) adjList.set(rel.targetId, []);
+      }
+
+      const metrics = computeSpectralMetrics(adjList);
+
+      if (opts.json) {
+        console.log(JSON.stringify(metrics, null, 2));
+        return;
+      }
+
+      console.log(`\n=== Spectral Graph Analysis ===`);
+      console.log(`Nodes: ${metrics.nodeCount} | Edges: ${metrics.edgeCount}`);
+      console.log();
+      console.log(`Density:         ${(metrics.density * 100).toFixed(2)}% (${metrics.density < 0.1 ? 'sparse/loosely coupled' : metrics.density > 0.3 ? 'dense/tightly coupled' : 'moderate'})`);
+      console.log(`Degree Entropy:  ${metrics.degreeEntropy.toFixed(3)} (${metrics.degreeEntropy < 1 ? 'uniform' : metrics.degreeEntropy > 3 ? 'hub-centric/skewed' : 'moderate diversity'})`);
+      console.log(`Avg Degree:      ${metrics.avgDegree.toFixed(1)}`);
+      console.log(`Max Degree:      ${metrics.maxDegree}`);
+      console.log(`Flow Hierarchy:  ${(metrics.flowHierarchy * 100).toFixed(1)}% acyclic (${metrics.flowHierarchy > 0.7 ? 'highly hierarchical' : metrics.flowHierarchy < 0.3 ? 'highly cyclic' : 'mixed'})`);
+      if (metrics.modularityQ > 0) {
+        console.log(`Modularity Q:    ${metrics.modularityQ.toFixed(4)} (${metrics.modularityQ > 0.5 ? 'well-modularized' : 'low modularity'})`);
+      }
+      console.log(`Topology:        ${metrics.topologyType} (confidence: ${metrics.topologyConfidence.toFixed(2)})`);
+      console.log();
     } finally {
       store.close();
     }

--- a/packages/core/src/core/graph-algorithms.ts
+++ b/packages/core/src/core/graph-algorithms.ts
@@ -262,3 +262,194 @@ function hasTarget(adjList: Map<string, string[]>, nodeId: string): boolean {
   }
   return false;
 }
+
+// ── Spectral / Entropy Metrics (#812) ────────────────────────────────────────
+
+export interface SpectralMetrics {
+  nodeCount: number;
+  edgeCount: number;
+  density: number;
+  degreeEntropy: number;
+  avgDegree: number;
+  maxDegree: number;
+  flowHierarchy: number;
+  modularityQ: number;
+  topologyType: 'tree-like' | 'star-like' | 'mesh-like' | 'hybrid';
+  topologyConfidence: number;
+}
+
+/**
+ * Compute spectral graph metrics from a directed adjacency list.
+ *
+ * Metrics include density, degree entropy, flow hierarchy (via Kahn's
+ * algorithm), optional Newman-Girvan modularity Q, and topology classification.
+ *
+ * @param adjList  Directed adjacency list (every node is a key)
+ * @param communities  Optional community→members map for modularity Q
+ */
+export function computeSpectralMetrics(
+  adjList: Map<string, string[]>,
+  communities?: Map<string, string[]>,
+): SpectralMetrics {
+  const nodes = Array.from(adjList.keys());
+  const nodeCount = nodes.length;
+
+  // ── edgeCount ──────────────────────────────────────────────────────────
+  let edgeCount = 0;
+  for (const targets of adjList.values()) {
+    edgeCount += targets.length;
+  }
+
+  // ── density ────────────────────────────────────────────────────────────
+  const density =
+    nodeCount > 1
+      ? Math.min(1, edgeCount / (nodeCount * (nodeCount - 1)))
+      : 0;
+
+  // ── degree distribution & entropy ──────────────────────────────────────
+  const degreeCounts = new Map<number, number>();
+  let maxDegree = 0;
+  for (const node of nodes) {
+    const deg = adjList.get(node)?.length ?? 0;
+    degreeCounts.set(deg, (degreeCounts.get(deg) ?? 0) + 1);
+    if (deg > maxDegree) maxDegree = deg;
+  }
+
+  let degreeEntropy = 0;
+  if (nodeCount > 0) {
+    for (const count of degreeCounts.values()) {
+      const p = count / nodeCount;
+      if (p > 0) degreeEntropy -= p * Math.log2(p);
+    }
+  }
+
+  const avgDegree = nodeCount > 0 ? edgeCount / nodeCount : 0;
+
+  // ── flow hierarchy (Kahn's algorithm) ──────────────────────────────────
+  // Compute in-degree for all nodes
+  const inDegree = new Map<string, number>();
+  for (const node of nodes) inDegree.set(node, 0);
+  for (const targets of adjList.values()) {
+    for (const tgt of targets) {
+      inDegree.set(tgt, (inDegree.get(tgt) ?? 0) + 1);
+    }
+  }
+
+  // Queue nodes with 0 in-degree
+  const queue: string[] = [];
+  const inAcyclic = new Set<string>();
+  for (const node of nodes) {
+    if (inDegree.get(node) === 0) {
+      queue.push(node);
+      inAcyclic.add(node);
+    }
+  }
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    for (const neighbor of adjList.get(current) ?? []) {
+      const newIndeg = (inDegree.get(neighbor) ?? 1) - 1;
+      inDegree.set(neighbor, newIndeg);
+      if (newIndeg === 0 && !inAcyclic.has(neighbor)) {
+        inAcyclic.add(neighbor);
+        queue.push(neighbor);
+      }
+    }
+  }
+
+  // Count hierarchical edges (edge source is in the acyclic subgraph)
+  let hierarchicalEdges = 0;
+  for (const [src, targets] of adjList) {
+    if (inAcyclic.has(src)) {
+      hierarchicalEdges += targets.length;
+    }
+  }
+
+  const flowHierarchy = edgeCount > 0 ? hierarchicalEdges / edgeCount : 0;
+
+  // ── modularity Q (Newman-Girvan) ───────────────────────────────────────
+  let modularityQ = 0;
+  if (communities && communities.size > 0 && edgeCount > 0) {
+    // Build degree map
+    const degree = new Map<string, number>();
+    for (const node of nodes) {
+      degree.set(node, adjList.get(node)?.length ?? 0);
+    }
+    // Also account for incoming edges (undirected modularity view)
+    for (const targets of adjList.values()) {
+      for (const tgt of targets) {
+        degree.set(tgt, (degree.get(tgt) ?? 0) + 1);
+      }
+    }
+
+    const twoM = 2 * edgeCount;
+
+    // Build community lookup: nodeId → communityId
+    const nodeToCommunity = new Map<string, string>();
+    for (const [commId, members] of communities) {
+      for (const member of members) {
+        nodeToCommunity.set(member, commId);
+      }
+    }
+
+    // Only consider nodes present in the graph
+    for (const node of nodes) {
+      if (!nodeToCommunity.has(node)) {
+        // unassigned node gets its own community
+        nodeToCommunity.set(node, '_unassigned_' + node);
+      }
+    }
+
+    // Q = (1/2m) * Σ_ij [A_ij - (k_i * k_j)/(2m)] * δ(c_i, c_j)
+    let qAcc = 0;
+    for (const [src, targets] of adjList) {
+      const ki = degree.get(src) ?? 0;
+      const ci = nodeToCommunity.get(src) ?? '';
+      for (const tgt of targets) {
+        const kj = degree.get(tgt) ?? 0;
+        const cj = nodeToCommunity.get(tgt) ?? '';
+        if (ci === cj) {
+          qAcc += 1 - (ki * kj) / twoM;
+        }
+      }
+    }
+
+    modularityQ = qAcc / twoM;
+  }
+
+  // ── topology classification ────────────────────────────────────────────
+  let topologyType: SpectralMetrics['topologyType'] = 'hybrid';
+  let topologyConfidence = 0.5;
+
+  // Star-like: single hub connects to >50% of nodes, low avg degree
+  if (nodeCount > 1 && maxDegree >= nodeCount * 0.5 && avgDegree < 3) {
+    topologyType = 'star-like';
+    topologyConfidence = maxDegree >= nodeCount * 0.8 ? 0.9 : 0.7;
+  }
+  // Tree-like: at most V-1 edges (sparse) OR density < 0.1
+  if (nodeCount > 1) {
+    const isSparse = edgeCount <= nodeCount - 1 || density < 0.1;
+    if (isSparse && topologyType !== 'star-like') {
+      topologyType = 'tree-like';
+      topologyConfidence = edgeCount <= nodeCount - 1 ? 0.9 : 0.7;
+    }
+  }
+  // Mesh-like: density > 0.3 AND avg degree > 5
+  if (density > 0.3 && avgDegree > 5) {
+    topologyType = 'mesh-like';
+    topologyConfidence = density > 0.5 ? 0.9 : 0.7;
+  }
+
+  return {
+    nodeCount,
+    edgeCount,
+    density,
+    degreeEntropy,
+    avgDegree,
+    maxDegree,
+    flowHierarchy,
+    modularityQ,
+    topologyType,
+    topologyConfidence,
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -79,3 +79,5 @@ export { chat, callLLM, type ChatMessage, type ChatResponse, type LLMConfig } fr
 export { countGraphlets, buildAdjacencyMap, type GraphletProfile } from './analysis/graphlet/index.js';
 export { detectPatterns, type ArchitecturePattern } from './analysis/graphlet/index.js';
 export { scoreArchitectureHealth, type ArchitectureHealth, type CommunityInfo } from './analysis/graphlet/index.js';
+// #812: Spectral graph analysis
+export { computeSpectralMetrics, type SpectralMetrics } from './core/graph-algorithms.js';

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -24,7 +24,7 @@ import { StreamableHttpTransport } from './http-transport.js';
 import { routeMap, toolMap, apiImpact, shapeCheck } from './api-tools.js';
 import { executeTraversal, type TraversalQuery } from './traverse.js';
 import { PhaseTimer } from '../core/phase-timer.js';
-import { pageRank, betweennessCentrality, shortestPath } from '../core/graph-algorithms.js';
+import { pageRank, betweennessCentrality, shortestPath, computeSpectralMetrics } from '../core/graph-algorithms.js';
 import { chat as ragChat, type ChatMessage } from '../agent/rag-chat.js';
 import { generateDiagram, generateMarkdownDoc, type DiagramType, type DiagramOptions } from './diagram-generator.js';
 // #461: Graphlet-based structural analysis
@@ -1711,7 +1711,7 @@ The graph is built from CALLS and IMPORTS relationships (excluding STEP_IN_PROCE
     inputSchema: {
       type: 'object',
       properties: {
-        algorithm: { type: 'string', enum: ['pagerank', 'betweenness', 'shortest_path'], description: 'Algorithm to run' },
+        algorithm: { type: 'string', enum: ['pagerank', 'betweenness', 'shortest_path', 'spectral_analysis'], description: 'Algorithm to run' },
         source: { type: 'string', description: 'Source node ID or name (required for shortest_path)' },
         target: { type: 'string', description: 'Target node ID or name (required for shortest_path)' },
         repo: { type: 'string', description: 'Repository name' },
@@ -1796,6 +1796,59 @@ The graph is built from CALLS and IMPORTS relationships (excluding STEP_IN_PROCE
         });
 
         return { content: [{ type: 'text', text: JSON.stringify({ algorithm: 'shortest_path', source: sourceParam, target: targetParam, path: namedPath, length: path.length - 1 }, null, 2) }] };
+      }
+
+      if (algorithm === 'spectral_analysis') {
+        // Build optional community map from Community nodes + MEMBER_OF edges
+        const communityMap = new Map<string, string[]>();
+        for (const node of graph.iterNodes()) {
+          if (node.label === 'Community') {
+            communityMap.set(
+              (node.properties.name as string) ?? node.id,
+              [],
+            );
+          }
+        }
+        for (const rel of graph.iterRelationships()) {
+          if (rel.type === 'MEMBER_OF') {
+            const commNode = graph.getNode(rel.targetId);
+            if (commNode && commNode.label === 'Community') {
+              const name = (commNode.properties.name as string) ?? commNode.id;
+              let members = communityMap.get(name);
+              if (!members) { members = []; communityMap.set(name, members); }
+              members.push(rel.sourceId);
+            }
+          }
+        }
+
+        const metrics = computeSpectralMetrics(adjList, communityMap.size > 0 ? communityMap : undefined);
+
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              algorithm: 'spectral_analysis',
+              metrics: {
+                nodeCount: metrics.nodeCount,
+                edgeCount: metrics.edgeCount,
+                density: Math.round(metrics.density * 10000) / 10000,
+                degreeEntropy: Math.round(metrics.degreeEntropy * 1000) / 1000,
+                avgDegree: Math.round(metrics.avgDegree * 100) / 100,
+                maxDegree: metrics.maxDegree,
+                flowHierarchy: Math.round(metrics.flowHierarchy * 10000) / 10000,
+                modularityQ: Math.round(metrics.modularityQ * 10000) / 10000,
+                topology: metrics.topologyType,
+                topologyConfidence: Math.round(metrics.topologyConfidence * 100) / 100,
+              },
+              interpretation: {
+                density: metrics.density < 0.1 ? 'Sparse graph — loosely coupled architecture' : metrics.density > 0.3 ? 'Dense graph — tightly coupled architecture' : 'Moderately connected',
+                degreeEntropy: metrics.degreeEntropy < 1 ? 'Uniform degree distribution' : metrics.degreeEntropy > 3 ? 'Highly skewed degree distribution (hub-centric)' : 'Moderately diverse degrees',
+                flowHierarchy: metrics.flowHierarchy > 0.7 ? 'Highly hierarchical — clear dependency direction' : metrics.flowHierarchy < 0.3 ? 'Cyclic — strong bidirectional coupling' : 'Mixed hierarchy',
+                modularityQ: metrics.modularityQ > 0.5 ? 'Well-modularized' : metrics.modularityQ > 0.3 ? 'Moderately modular' : 'Low modularity',
+              },
+            }, null, 2),
+          }],
+        };
       }
 
       return { content: [{ type: 'text', text: JSON.stringify({ error: `Unknown algorithm: ${algorithm}` }) }] };

--- a/packages/core/tests/core/graph-algorithms.test.ts
+++ b/packages/core/tests/core/graph-algorithms.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { pageRank, betweennessCentrality, shortestPath } from '../../src/core/graph-algorithms.js';
+import { pageRank, betweennessCentrality, shortestPath, computeSpectralMetrics } from '../../src/core/graph-algorithms.js';
 
 // ── PageRank Tests ──────────────────────────────────────────────────────────
 
@@ -192,5 +192,110 @@ describe('shortestPath', () => {
     const path = shortestPath(adj, 'A', 'Z');
 
     expect(path).toBeNull();
+  });
+});
+
+// ── Spectral Metrics Tests (#812) ────────────────────────────────────────────
+
+describe('computeSpectralMetrics', () => {
+  it('computes correct density for a chain graph', () => {
+    const adj = new Map<string, string[]>([
+      ['A', ['B']],
+      ['B', ['C']],
+      ['C', ['D']],
+      ['D', []],
+    ]);
+    const metrics = computeSpectralMetrics(adj);
+    expect(metrics.nodeCount).toBe(4);
+    expect(metrics.edgeCount).toBe(3);
+    // density = 3 / (4*3) = 0.25
+    expect(metrics.density).toBeCloseTo(0.25, 2);
+  });
+
+  it('returns zero density for empty graph', () => {
+    const adj = new Map<string, string[]>();
+    const metrics = computeSpectralMetrics(adj);
+    expect(metrics.nodeCount).toBe(0);
+    expect(metrics.edgeCount).toBe(0);
+    expect(metrics.density).toBe(0);
+  });
+
+  it('classifies tree-like topology for a simple tree', () => {
+    const adj = new Map<string, string[]>([
+      ['Root', ['A', 'B']],
+      ['A', ['A1', 'A2']],
+      ['B', []],
+      ['A1', []],
+      ['A2', []],
+    ]);
+    const metrics = computeSpectralMetrics(adj);
+    expect(metrics.topologyType).toBe('tree-like');
+    expect(metrics.topologyConfidence).toBeGreaterThan(0.5);
+  });
+
+  it('classifies star-like topology', () => {
+    const adj = new Map<string, string[]>([
+      ['Hub', ['A', 'B', 'C', 'D', 'E']],
+      ['A', ['Hub']],
+      ['B', ['Hub']],
+      ['C', ['Hub']],
+      ['D', ['Hub']],
+      ['E', ['Hub']],
+    ]);
+    const metrics = computeSpectralMetrics(adj);
+    expect(metrics.topologyType).toBe('star-like');
+  });
+
+  it('computes degree entropy for mixed degree graph', () => {
+    const adj = new Map<string, string[]>([
+      ['A', ['B', 'C', 'D']],
+      ['B', ['C']],
+      ['C', []],
+      ['D', []],
+    ]);
+    const metrics = computeSpectralMetrics(adj);
+    expect(metrics.degreeEntropy).toBeGreaterThan(0);
+    expect(metrics.maxDegree).toBe(3);
+  });
+
+  it('computes flow hierarchy for acyclic graph as 1.0', () => {
+    // Pure DAG: A→B, A→C, B→D, C→D
+    const adj = new Map<string, string[]>([
+      ['A', ['B', 'C']],
+      ['B', ['D']],
+      ['C', ['D']],
+      ['D', []],
+    ]);
+    const metrics = computeSpectralMetrics(adj);
+    expect(metrics.flowHierarchy).toBeCloseTo(1.0, 1);
+  });
+
+  it('computes flow hierarchy for cyclic graph < 1.0', () => {
+    // Cycle: A→B→C→A
+    const adj = new Map<string, string[]>([
+      ['A', ['B']],
+      ['B', ['C']],
+      ['C', ['A']],
+    ]);
+    const metrics = computeSpectralMetrics(adj);
+    expect(metrics.flowHierarchy).toBeLessThan(1.0);
+  });
+
+  it('computes modularity Q when communities provided', () => {
+    // Two clear clusters: cluster1 {A,B} heavily interconnected, cluster2 {C,D} heavily interconnected
+    // Weak connection between clusters: B→C
+    const adj = new Map<string, string[]>([
+      ['A', ['B']],
+      ['B', ['A', 'C']],
+      ['C', ['D', 'B']],
+      ['D', ['C']],
+    ]);
+    const communities = new Map<string, string[]>([
+      ['cluster1', ['A', 'B']],
+      ['cluster2', ['C', 'D']],
+    ]);
+    const metrics = computeSpectralMetrics(adj, communities);
+    // Should show positive modularity (inter-cluster edges < intra-cluster)
+    expect(metrics.modularityQ).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
Closes #812

## Summary
- Add computeSpectralMetrics() — graph density, degree entropy, flow hierarchy, modularity Q, topology classification
- Wire into graph_algorithms MCP tool as spectral_analysis
- Add spectral CLI command with --json output
- 8 tests for spectral metrics

See issue #812 for full spec.