### PR TITLE
feat: clone detection via WL graph kernels (#810)

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -32,6 +32,7 @@ import {
   generateWiki,
   startEvalServer,
   countGraphlets, buildAdjacencyMap, detectPatterns, scoreArchitectureHealth,
+  detectClones,
   migrateFromGitNexus,
 } from '@astrolabe-dev/core';
 // #463: Coverage report parser
@@ -1313,6 +1314,83 @@ program
           console.log(JSON.stringify(vulnReport, null, 2));
         }
       }
+    } finally {
+      store.close();
+    }
+  });
+
+// ── detect-clones (#810) ─────────────────────────────────────────────────────
+program
+  .command('detect-clones [repoPath]')
+  .description('Detect structurally similar functions using Weisfeiler-Lehman graph kernels (#810)')
+  .option('-d, --db <path>', 'Database path', '.astrolabe/astrolabe.db')
+  .option('--threshold <n>', 'Similarity threshold (0-1)', '0.6')
+  .option('--json', 'Output raw JSON')
+  .action((repoPath: string | undefined, opts: { db: string; threshold: string; json?: boolean }) => {
+    const dbPath = repoPath ? join(repoPath, '.astrolabe', 'astrolabe.db') : opts.db;
+    if (!existsSync(dbPath)) {
+      console.log('No knowledge graph found. Run `astrolabe analyze` first.');
+      return;
+    }
+
+    const threshold = parseFloat(opts.threshold);
+    if (isNaN(threshold) || threshold < 0 || threshold > 1) {
+      console.log('Threshold must be a number between 0 and 1.');
+      return;
+    }
+
+    const store = createSqliteStore(dbPath);
+    try {
+      const graph = store.loadGraph();
+
+      // Build adjacency + node names (same as MCP handler)
+      const adjList = new Map<string, string[]>();
+      const nodeNames = new Map<string, string>();
+      for (const node of graph.iterNodes()) {
+        if (!adjList.has(node.id)) adjList.set(node.id, []);
+        nodeNames.set(node.id, (node.properties.name as string) ?? node.id);
+      }
+      for (const rel of graph.iterRelationships()) {
+        if (rel.type === 'STEP_IN_PROCESS' || rel.type === 'MEMBER_OF' || rel.type === 'ENTRY_POINT_OF') continue;
+        if (rel.type !== 'CALLS' && rel.type !== 'IMPORTS') continue;
+        let targets = adjList.get(rel.sourceId);
+        if (!targets) { targets = []; adjList.set(rel.sourceId, targets); }
+        targets.push(rel.targetId);
+        if (!adjList.has(rel.targetId)) adjList.set(rel.targetId, []);
+      }
+
+      const result = detectClones(adjList, nodeNames, { threshold });
+
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+
+      console.log(`\n=== Clone Detection (WL Graph Kernel) ===`);
+      console.log(`Functions analyzed: ${result.totalFunctions}`);
+      console.log(`Clone pairs found: ${result.totalPairs} (threshold: ${threshold})`);
+      console.log(`  Exact clones (>=95%):  ${result.summary.exactClones}`);
+      console.log(`  Near-misses (80-95%):  ${result.summary.nearMisses}`);
+      console.log(`  Potential clones (60-80%): ${result.summary.potentialClones}`);
+
+      if (result.clusters.length > 0) {
+        console.log(`\n--- Clone Clusters (${result.clusters.length}) ---`);
+        for (const c of result.clusters.slice(0, 10)) {
+          console.log(`  Cluster ${c.clusterId}: ${c.memberCount} functions, representative: ${c.representativeFunction}`);
+          const memberNames = c.members.map((m) => m.name).join(', ');
+          console.log(`    Members: ${memberNames}`);
+        }
+        if (result.clusters.length > 10) console.log(`  ... and ${result.clusters.length - 10} more clusters`);
+      }
+
+      if (result.topPairs.length > 0) {
+        console.log(`\n--- Top Similar Pairs ---`);
+        for (const pair of result.topPairs.slice(0, 15)) {
+          console.log(`  ${(pair.similarity * 100).toFixed(0)}%: ${pair.functionA.name} ↔ ${pair.functionB.name}`);
+        }
+      }
+
+      console.log();
     } finally {
       store.close();
     }

--- a/packages/core/src/core/graph-algorithms.ts
+++ b/packages/core/src/core/graph-algorithms.ts
@@ -262,3 +262,315 @@ function hasTarget(adjList: Map<string, string[]>, nodeId: string): boolean {
   }
   return false;
 }
+
+// ── Clone Detection (Weisfeiler-Lehman Graph Kernel) ────────────────────────
+
+/**
+ * Build a reverse adjacency map: for each node, which nodes point TO it.
+ * Not exported — used internally by detectClones().
+ */
+function buildReverseAdj(adjList: Map<string, string[]>): Map<string, string[]> {
+  const reverse = new Map<string, string[]>();
+  for (const node of adjList.keys()) reverse.set(node, []);
+  for (const [src, targets] of adjList) {
+    for (const tgt of targets) {
+      const bucket = reverse.get(tgt);
+      if (bucket) bucket.push(src);
+      else reverse.set(tgt, [src]);
+    }
+  }
+  return reverse;
+}
+
+/**
+ * Simple polynomial hash function for WL label generation.
+ * Not cryptographic — used for structural equivalence grouping.
+ */
+function wlHash(input: string): string {
+  let hash = 5381;
+  for (let i = 0; i < input.length; i++) {
+    hash = ((hash * 33) + input.charCodeAt(i)) & 0x7FFFFFFF;
+  }
+  return hash.toString(16);
+}
+
+export interface ClonePair {
+  functionA: { id: string; name: string };
+  functionB: { id: string; name: string };
+  similarity: number;  // 0-1, Jaccard on feature vector
+  sharedNeighbors: number;
+}
+
+export interface CloneDetectionResult {
+  totalFunctions: number;
+  totalPairs: number;
+  clusters: CloneCluster[];
+  topPairs: ClonePair[];  // top 20 by similarity
+  summary: {
+    exactClones: number;    // similarity >= 0.95
+    nearMisses: number;     // 0.8-0.95
+    potentialClones: number; // 0.6-0.8
+  };
+}
+
+export interface CloneCluster {
+  clusterId: number;
+  memberCount: number;
+  members: Array<{ id: string; name: string }>;
+  avgSimilarity: number;
+  representativeFunction: string;
+}
+
+/**
+ * Detect structurally similar functions using the Weisfeiler-Lehman
+ * graph kernel (2-iteration refinement).
+ *
+ * Stage 1: WL hash pre-filter — group nodes with identical structural signatures.
+ * Stage 2: Within each group, compute Jaccard similarity on neighbor sets.
+ *
+ * Only compares pairs that share the same WL hash, avoiding O(N²).
+ *
+ * @param adjList    Adjacency map (node → outgoing neighbors)
+ * @param nodeNames  Node ID → human-readable name map
+ * @param options    threshold (0-1), minClusterSize, maxPairs
+ */
+export function detectClones(
+  adjList: Map<string, string[]>,
+  nodeNames: Map<string, string>,
+  options?: { threshold?: number; minClusterSize?: number; maxPairs?: number },
+): CloneDetectionResult {
+  const threshold = options?.threshold ?? 0.6;
+  const minClusterSize = options?.minClusterSize ?? 2;
+  const maxPairs = options?.maxPairs ?? 20;
+
+  const nodes = Array.from(adjList.keys());
+  const n = nodes.length;
+
+  if (n === 0) {
+    return {
+      totalFunctions: 0,
+      totalPairs: 0,
+      clusters: [],
+      topPairs: [],
+      summary: { exactClones: 0, nearMisses: 0, potentialClones: 0 },
+    };
+  }
+
+  // ── Stage 0: Pre-compute degrees and reverse adjacency ────────────────
+  const reverseAdj = buildReverseAdj(adjList);
+
+  const outDegree = new Map<string, number>();
+  const inDegree = new Map<string, number>();
+  for (const node of nodes) {
+    outDegree.set(node, adjList.get(node)?.length ?? 0);
+    inDegree.set(node, reverseAdj.get(node)?.length ?? 0);
+  }
+
+  // ── Stage 1: WL Hash (2 iterations) ───────────────────────────────────
+
+  // Initial label: degree signature
+  const labels = new Map<string, string>();
+  for (const node of nodes) {
+    const out = outDegree.get(node) ?? 0;
+    const inv = inDegree.get(node) ?? 0;
+    labels.set(node, `d:${out},${inv}`);
+  }
+
+  // 2 iterations of WL refinement
+  for (let iter = 0; iter < 2; iter++) {
+    const nextLabels = new Map<string, string>();
+    for (const node of nodes) {
+      const neighborLabels: string[] = [];
+      for (const neighbor of adjList.get(node) ?? []) {
+        neighborLabels.push(labels.get(neighbor) ?? '');
+      }
+      neighborLabels.sort();
+      const combined = (labels.get(node) ?? '') + '|' + neighborLabels.join(',');
+      nextLabels.set(node, wlHash(combined));
+    }
+    for (const [node, label] of nextLabels) {
+      labels.set(node, label);
+    }
+  }
+
+  // ── Stage 2: Group by WL hash, compare within groups ──────────────────
+
+  // Build neighbor WL hash sets for each node (for structural Jaccard)
+  const neighborHashSets = new Map<string, Set<string>>();
+  for (const node of nodes) {
+    const hashSet = new Set<string>();
+    for (const neighbor of adjList.get(node) ?? []) {
+      hashSet.add(labels.get(neighbor) ?? '');
+    }
+    neighborHashSets.set(node, hashSet);
+  }
+
+  // Group nodes by final WL hash
+  const hashGroups = new Map<string, string[]>();
+  for (const node of nodes) {
+    const hash = labels.get(node) ?? '';
+    const group = hashGroups.get(hash);
+    if (group) group.push(node);
+    else hashGroups.set(hash, [node]);
+  }
+
+  // Compare pairs within each group using neighbor WL hash Jaccard
+  const allPairs: ClonePair[] = [];
+
+  for (const [, group] of hashGroups) {
+    if (group.length < 2) continue;
+
+    for (let i = 0; i < group.length; i++) {
+      for (let j = i + 1; j < group.length; j++) {
+        const a = group[i];
+        const b = group[j];
+
+        const setA = neighborHashSets.get(a)!;
+        const setB = neighborHashSets.get(b)!;
+
+        // Jaccard similarity on neighbor WL hashes (structural equivalence)
+        let intersection = 0;
+        for (const item of setA) {
+          if (setB.has(item)) intersection++;
+        }
+        const union = setA.size + setB.size - intersection;
+        const similarity = union === 0 ? 1 : intersection / union;
+
+        if (similarity >= threshold) {
+          allPairs.push({
+            functionA: { id: a, name: nodeNames.get(a) ?? a },
+            functionB: { id: b, name: nodeNames.get(b) ?? b },
+            similarity,
+            sharedNeighbors: intersection,
+          });
+        }
+      }
+    }
+  }
+
+  // Sort by similarity descending
+  allPairs.sort((a, b) => b.similarity - a.similarity);
+
+  // ── Stage 3: Union-Find Clustering ────────────────────────────────────
+
+  const parent = new Map<string, string>();
+  const size = new Map<string, number>();
+
+  function find(x: string): string {
+    let p = parent.get(x);
+    if (p === undefined) {
+      parent.set(x, x);
+      size.set(x, 1);
+      return x;
+    }
+    if (p !== x) {
+      const root = find(p);
+      parent.set(x, root);
+      return root;
+    }
+    return x;
+  }
+
+  function union(x: string, y: string): void {
+    const rx = find(x);
+    const ry = find(y);
+    if (rx === ry) return;
+    const sx = size.get(rx) ?? 1;
+    const sy = size.get(ry) ?? 1;
+    if (sx < sy) {
+      parent.set(rx, ry);
+      size.set(ry, sx + sy);
+    } else {
+      parent.set(ry, rx);
+      size.set(rx, sx + sy);
+    }
+  }
+
+  // Initialize all nodes
+  for (const node of nodes) find(node);
+
+  // Union pairs above threshold
+  for (const pair of allPairs) {
+    union(pair.functionA.id, pair.functionB.id);
+  }
+
+  // Collect clusters
+  const clusterMap = new Map<string, Array<{ id: string; name: string }>>();
+  for (const node of nodes) {
+    const root = find(node);
+    const cluster = clusterMap.get(root);
+    const member = { id: node, name: nodeNames.get(node) ?? node };
+    if (cluster) cluster.push(member);
+    else clusterMap.set(root, [member]);
+  }
+
+  // Build cluster results (only multi-member clusters)
+  const clusters: CloneCluster[] = [];
+  const clusterPairMap = new Map<string, ClonePair[]>();
+
+  for (const pair of allPairs) {
+    const root = find(pair.functionA.id); // both nodes share same root after union
+
+    const group = clusterPairMap.get(root);
+    if (group) group.push(pair);
+    else clusterPairMap.set(root, [pair]);
+  }
+
+  let clusterIdCounter = 0;
+  for (const [root, members] of clusterMap) {
+    if (members.length < minClusterSize) continue;
+
+    const pairs = clusterPairMap.get(root) ?? [];
+    const avgSimilarity = pairs.length > 0
+      ? pairs.reduce((sum, p) => sum + p.similarity, 0) / pairs.length
+      : 1;
+
+    // Representative: highest total similarity to other members (or first member)
+    let rep = members[0];
+    let bestScore = -1;
+    for (const m of members) {
+      let score = 0;
+      for (const p of pairs) {
+        if (p.functionA.id === m.id || p.functionB.id === m.id) {
+          score += p.similarity;
+        }
+      }
+      if (score > bestScore) {
+        bestScore = score;
+        rep = m;
+      }
+    }
+
+    clusters.push({
+      clusterId: clusterIdCounter++,
+      memberCount: members.length,
+      members,
+      avgSimilarity: Math.round(avgSimilarity * 10000) / 10000,
+      representativeFunction: rep.name,
+    });
+  }
+
+  // Sort clusters by size descending
+  clusters.sort((a, b) => b.memberCount - a.memberCount);
+
+  // ── Summary counts ────────────────────────────────────────────────────
+
+  const topPairs = allPairs.slice(0, maxPairs);
+  let exactClones = 0;
+  let nearMisses = 0;
+  let potentialClones = 0;
+
+  for (const p of allPairs) {
+    if (p.similarity >= 0.95) exactClones++;
+    else if (p.similarity >= 0.8) nearMisses++;
+    else if (p.similarity >= 0.6) potentialClones++;
+  }
+
+  return {
+    totalFunctions: n,
+    totalPairs: allPairs.length,
+    clusters,
+    topPairs,
+    summary: { exactClones, nearMisses, potentialClones },
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -79,3 +79,5 @@ export { chat, callLLM, type ChatMessage, type ChatResponse, type LLMConfig } fr
 export { countGraphlets, buildAdjacencyMap, type GraphletProfile } from './analysis/graphlet/index.js';
 export { detectPatterns, type ArchitecturePattern } from './analysis/graphlet/index.js';
 export { scoreArchitectureHealth, type ArchitectureHealth, type CommunityInfo } from './analysis/graphlet/index.js';
+// #810: Clone detection
+export { detectClones, type CloneDetectionResult, type ClonePair, type CloneCluster } from './core/graph-algorithms.js';

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -24,7 +24,7 @@ import { StreamableHttpTransport } from './http-transport.js';
 import { routeMap, toolMap, apiImpact, shapeCheck } from './api-tools.js';
 import { executeTraversal, type TraversalQuery } from './traverse.js';
 import { PhaseTimer } from '../core/phase-timer.js';
-import { pageRank, betweennessCentrality, shortestPath } from '../core/graph-algorithms.js';
+import { pageRank, betweennessCentrality, shortestPath, detectClones } from '../core/graph-algorithms.js';
 import { chat as ragChat, type ChatMessage } from '../agent/rag-chat.js';
 import { generateDiagram, generateMarkdownDoc, type DiagramType, type DiagramOptions } from './diagram-generator.js';
 // #461: Graphlet-based structural analysis
@@ -1706,12 +1706,13 @@ Algorithms:
 - pagerank: Identify the most important modules by link structure. Returns nodes sorted by PageRank score.
 - betweenness: Find bridge nodes that connect different communities. High betweenness = critical dependency bottleneck.
 - shortest_path: Find the dependency chain between two modules. Returns the shortest path or null.
+- clone_detection: Detect structurally similar functions using Weisfeiler-Lehman graph kernels (#810). Returns clone clusters and top pairs.
 
 The graph is built from CALLS and IMPORTS relationships (excluding STEP_IN_PROCESS synthetic edges).`,
     inputSchema: {
       type: 'object',
       properties: {
-        algorithm: { type: 'string', enum: ['pagerank', 'betweenness', 'shortest_path'], description: 'Algorithm to run' },
+        algorithm: { type: 'string', enum: ['pagerank', 'betweenness', 'shortest_path', 'clone_detection'], description: 'Algorithm to run' },
         source: { type: 'string', description: 'Source node ID or name (required for shortest_path)' },
         target: { type: 'string', description: 'Target node ID or name (required for shortest_path)' },
         repo: { type: 'string', description: 'Repository name' },
@@ -1796,6 +1797,37 @@ The graph is built from CALLS and IMPORTS relationships (excluding STEP_IN_PROCE
         });
 
         return { content: [{ type: 'text', text: JSON.stringify({ algorithm: 'shortest_path', source: sourceParam, target: targetParam, path: namedPath, length: path.length - 1 }, null, 2) }] };
+      }
+
+      if (algorithm === 'clone_detection') {
+        // Build node name map
+        const nodeNames = new Map<string, string>();
+        for (const node of graph.iterNodes()) {
+          nodeNames.set(node.id, (node.properties.name as string) ?? node.id);
+        }
+
+        const result = detectClones(adjList, nodeNames);
+
+        // Format output
+        const output = {
+          algorithm: 'clone_detection',
+          totalFunctions: result.totalFunctions,
+          clonePairs: result.topPairs.map((p) => ({
+            functionA: p.functionA.name,
+            functionB: p.functionB.name,
+            similarity: Math.round(p.similarity * 100) / 100,
+          })),
+          clusters: result.clusters.map((c) => ({
+            id: c.clusterId,
+            size: c.memberCount,
+            representative: c.representativeFunction,
+            members: c.members.map((m) => m.name),
+          })),
+          summary: result.summary,
+          method: 'Weisfeiler-Lehman graph kernel (2 iterations)',
+        };
+
+        return { content: [{ type: 'text', text: JSON.stringify(output, null, 2) }] };
       }
 
       return { content: [{ type: 'text', text: JSON.stringify({ error: `Unknown algorithm: ${algorithm}` }) }] };

--- a/packages/core/tests/core/graph-algorithms.test.ts
+++ b/packages/core/tests/core/graph-algorithms.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { pageRank, betweennessCentrality, shortestPath } from '../../src/core/graph-algorithms.js';
+import { pageRank, betweennessCentrality, shortestPath, detectClones } from '../../src/core/graph-algorithms.js';
 
 // ── PageRank Tests ──────────────────────────────────────────────────────────
 
@@ -192,5 +192,111 @@ describe('shortestPath', () => {
     const path = shortestPath(adj, 'A', 'Z');
 
     expect(path).toBeNull();
+  });
+});
+
+// ── Clone Detection Tests ──────────────────────────────────────────────────
+
+describe('detectClones', () => {
+  it('detects structurally identical functions as exact clones', () => {
+    // Two functions with identical call patterns: each calls 2 helpers
+    const adj = new Map<string, string[]>([
+      ['FuncA', ['Helper1', 'Helper2']],
+      ['FuncB', ['Helper3', 'Helper4']],
+      ['Helper1', []],
+      ['Helper2', []],
+      ['Helper3', []],
+      ['Helper4', []],
+    ]);
+    const names = new Map(Object.entries({
+      FuncA: 'processOrder', FuncB: 'processPayment',
+      Helper1: 'validate', Helper2: 'transform',
+      Helper3: 'check', Helper4: 'convert',
+    }));
+
+    const result = detectClones(adj, names, { threshold: 0.6 });
+    expect(result.totalFunctions).toBe(6);
+
+    // FuncA and FuncB should be detected as clones (same out-degree, structurally identical)
+    const abPair = result.topPairs.find(
+      (p) => (p.functionA.name === 'processOrder' && p.functionB.name === 'processPayment') ||
+             (p.functionA.name === 'processPayment' && p.functionB.name === 'processOrder')
+    );
+    expect(abPair).toBeDefined();
+    if (abPair) expect(abPair.similarity).toBeGreaterThan(0.8);
+  });
+
+  it('returns empty result for graph with no similar functions', () => {
+    // All functions have unique structures
+    const adj = new Map<string, string[]>([
+      ['A', ['B', 'C']],
+      ['B', ['C']],
+      ['C', []],
+    ]);
+    const names = new Map(Object.entries({
+      A: 'fnA', B: 'fnB', C: 'fnC',
+    }));
+
+    const result = detectClones(adj, names, { threshold: 0.9 });
+    // No two functions share the same WL hash
+    expect(result.totalPairs).toBe(0);
+    expect(result.clusters).toHaveLength(0);
+  });
+
+  it('handles empty graph', () => {
+    const result = detectClones(new Map(), new Map());
+    expect(result.totalFunctions).toBe(0);
+    expect(result.totalPairs).toBe(0);
+    expect(result.clusters).toEqual([]);
+  });
+
+  it('groups similar functions into clusters', () => {
+    // Three functions with identical call patterns
+    const adj = new Map<string, string[]>([
+      ['A', ['H1', 'H2']],
+      ['B', ['H3', 'H4']],
+      ['C', ['H5', 'H6']],
+      ['H1', []], ['H2', []], ['H3', []], ['H4', []], ['H5', []], ['H6', []],
+    ]);
+    const names = new Map(Object.entries({
+      A: 'fnA', B: 'fnB', C: 'fnC',
+    }));
+
+    const result = detectClones(adj, names, { threshold: 0.5, minClusterSize: 2 });
+    // A, B, C should be in the same cluster
+    expect(result.clusters.length).toBeGreaterThan(0);
+    const cluster = result.clusters[0];
+    expect(cluster.memberCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it('respects similarity threshold', () => {
+    // Two groups of structurally similar functions
+    const adj = new Map<string, string[]>([
+      // Group: both call 1 helper (structurally identical)
+      ['A', ['HA']],
+      ['B', ['HB']],
+      // Different structure: calls 2 helpers
+      ['C', ['HC', 'HD']],
+      // Helpers
+      ['HA', []], ['HB', []], ['HC', []], ['HD', []],
+    ]);
+    const names = new Map(Object.entries({
+      A: 'fnA', B: 'fnB', C: 'fnC',
+    }));
+
+    // A and B are struct-equals → high similarity (within their WL group)
+    const result = detectClones(adj, names, { threshold: 0.5 });
+    // A and B should pair; C is different
+    expect(result.totalPairs).toBeGreaterThanOrEqual(1);
+
+    // With very high threshold, should still find A-B (they're exact structural matches)
+    const resultHigh = detectClones(adj, names, { threshold: 0.95 });
+    expect(resultHigh.totalPairs).toBeGreaterThanOrEqual(1);
+
+    // C should not pair with A or B (different WL hash)
+    const hasCPair = result.topPairs.some(
+      (p) => p.functionA.name === 'fnC' || p.functionB.name === 'fnC'
+    );
+    expect(hasCPair).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #810

## Summary
- Add detectClones() using Weisfeiler-Lehman graph kernel (2-iteration refinement)
- Two-stage: WL hash pre-filter + Jaccard structural comparison on neighbor WL hashes
- Clone clusters with representative function identification
- Wire into graph_algorithms MCP tool as clone_detection
- Add detect-clones CLI command with --threshold option

See issue #810 for full spec.