### PR TITLE
fix: scanner noise exclusion and false cycle detection (#839 #840)

### DIFF
--- a/packages/core/src/analysis/phases/scan.ts
+++ b/packages/core/src/analysis/phases/scan.ts
@@ -62,6 +62,10 @@ const DEFAULT_IGNORE = [
   'target',
   'bin',
   'obj',
+  '.omo',
+  '.claude',
+  '_debug_*.mjs',
+  '_test_*.mjs',
 ];
 
 /** Extensions to skip regardless of language support (binary, media, fonts). */

--- a/packages/core/src/core/graph-algorithms.ts
+++ b/packages/core/src/core/graph-algorithms.ts
@@ -884,6 +884,7 @@ export function tarjanSCC(adjList: Map<string, string[]>): SccResult[] {
   }
 
   return sccs
+    .filter(scc => scc.length >= 2)
     .sort((a, b) => b.length - a.length)
     .map((nodeIds, i) => ({
       id: i,


### PR DESCRIPTION
## Summary

Dogfooding fixes discovered by running Astrolabe's analysis tools against itself.

### Fix 1: Scanner excludes tool-generated files (#839)

Files in `.omo/`, `.claude/`, and root-level `_debug_*.mjs`/`_test_*.mjs` were being indexed as source code, polluting the knowledge graph with hundreds of isolated noise nodes. These inflated node counts, distorted health scores, and appeared as false SPoFs in resilience analysis.

Added 4 patterns to `DEFAULT_IGNORE` in `scan.ts`.

### Fix 2: False 1-node "cycles" in detect-smells (#840)

`tarjanSCC()` was returning all strongly connected components including 1-node SCCs (isolated nodes with no edges). On the Astrolabe repo this produced 9181 false "Cyclic Dependencies" reports, making the tool completely unusable.

Added `.filter(scc => scc.length >= 2)` — a cycle requires at least 2 nodes.

### Issues

Closes #839
Closes #840

### Test plan

- [x] 50 existing tests pass (detect.test.ts, graph-algorithms.test.ts, scan.test.ts)
- [x] Build passes (tsc clean)
- [x] No new type errors
