### PR TITLE
fix: detect-clones OOM on large repos (#837)

### DIFF
--- a/packages/core/src/core/graph-algorithms.ts
+++ b/packages/core/src/core/graph-algorithms.ts
@@ -476,15 +476,31 @@ export function detectClones(
   }
 
   // Compare pairs within each group using neighbor WL hash Jaccard
+  // Memory-safe: cap group size and total pairs to avoid OOM on large repos
+  const MAX_GROUP_SIZE = 500;
+  const MAX_TOTAL_PAIRS = 50000;
   const allPairs: ClonePair[] = [];
 
   for (const [, group] of hashGroups) {
     if (group.length < 2) continue;
+    if (allPairs.length >= MAX_TOTAL_PAIRS) break;
 
-    for (let i = 0; i < group.length; i++) {
-      for (let j = i + 1; j < group.length; j++) {
-        const a = group[i];
-        const b = group[j];
+    // For large groups, sample a subset instead of O(G²) full comparison
+    let compareGroup = group;
+    if (group.length > MAX_GROUP_SIZE) {
+      // Deterministic sample: spread across the group evenly
+      const step = Math.floor(group.length / MAX_GROUP_SIZE);
+      compareGroup = [];
+      for (let k = 0; k < group.length && compareGroup.length < MAX_GROUP_SIZE; k += step) {
+        compareGroup.push(group[k]);
+      }
+    }
+
+    for (let i = 0; i < compareGroup.length; i++) {
+      if (allPairs.length >= MAX_TOTAL_PAIRS) break;
+      for (let j = i + 1; j < compareGroup.length; j++) {
+        const a = compareGroup[i];
+        const b = compareGroup[j];
 
         const setA = neighborHashSets.get(a)!;
         const setB = neighborHashSets.get(b)!;
@@ -509,7 +525,7 @@ export function detectClones(
     }
   }
 
-  // Sort by similarity descending
+  // Sort by similarity descending, cap to maxPairs for output
   allPairs.sort((a, b) => b.similarity - a.similarity);
 
   // ── Stage 3: Union-Find Clustering ────────────────────────────────────


### PR DESCRIPTION
## Summary

Fix OOM crash in `detect-clones` on repos with 9K+ nodes.

### Root Cause

The WL hash pre-filter groups nodes by structural signature. When many nodes share the same signature (e.g., thousands of structurally similar JSON checkpoint files), the nested O(G²) pairwise comparison within a single group causes memory explosion. On the Astrolabe repo, this produced millions of `ClonePair` objects that exhausted the ~4GB heap.

### Fix

Two safety caps in `detectClones()` (`graph-algorithms.ts`):

1. **`MAX_GROUP_SIZE = 500`** — When a hash group exceeds 500 nodes, deterministically sample a subset (even stride) instead of comparing all G×(G-1)/2 pairs.
2. **`MAX_TOTAL_PAIRS = 50000`** — Hard cap on accumulated pairs to bound memory regardless of input.

### Before/After

| Metric | Before | After |
|--------|--------|-------|
| 9K nodes | OOM crash (4GB) | Completes in seconds |
| Memory | Unbounded O(N²) | Bounded to 50K pairs |
| Large groups | Full cross-product | Sampled to 500 nodes |

### Note

The results on this repo show many false clones from `.omo/` checkpoint files — that's issue #839 (now fixed in #841). When the scanner exclusion fix is included, those noise nodes won't enter the graph.

Closes #837

### Test plan

- [x] 38 existing graph-algorithm tests pass
- [x] Build passes (tsc clean)
- [x] `detect-clones .` completes without OOM on 9K-node repo
