### PR TITLE
fix: detect-clones skips isolated functions with empty neighbor sets (#853)

### DIFF
--- a/packages/core/src/core/graph-algorithms.ts
+++ b/packages/core/src/core/graph-algorithms.ts
@@ -505,6 +505,10 @@ export function detectClones(
         const setA = neighborHashSets.get(a)!;
         const setB = neighborHashSets.get(b)!;
 
+        // Skip pairs where both nodes have empty neighbor sets —
+        // they're trivially similar (isolated leaf functions), not actual clones
+        if (setA.size === 0 && setB.size === 0) continue;
+
         // Jaccard similarity on neighbor WL hashes (structural equivalence)
         let intersection = 0;
         for (const item of setA) {


### PR DESCRIPTION
## Problem
\detect-clones\ reported 50,059 exact clones with 100% similarity — all false positives. The root cause: functions with zero CALLS/IMPORTS edges have empty neighbor hash sets, producing trivial Jaccard similarity = 1.0.

## Fix
Added a guard in \detectClones()\ (graph-algorithms.ts) to skip pairs where both nodes have empty neighbor sets. Isolated leaf functions are not clones — they just lack structural context.

## Before
\\\
Functions analyzed: 940
Clone pairs found: 50059
  Exact clones (>=95%):  50059
\\\

## After
\\\
Functions analyzed: 940
Clone pairs found: 0
  Exact clones (>=95%):  0
\\\

## Testing
- \
pm run build\ — clean
- \
pm test\ — 676 pass, 19 skip
- Verified detect-clones output: 0 false positives