### PR TITLE
fix: CLI commands hang on exit — JobManager setInterval at module scope (#852)

### DIFF
--- a/packages/core/src/server/http-server.ts
+++ b/packages/core/src/server/http-server.ts
@@ -446,9 +446,10 @@ async function handleGrep(res: ServerResponse, repoName: string, pattern: string
   }
 }
 
-// ── Job Manager (singleton) ────────────────────────────────────────────────
-
-const jobManager = new JobManager();
+// ── Job Manager (lazy singleton) ────────────────────────────────────────────
+// Initialized inside startHttpServer() to avoid keeping the event loop alive
+// when the HTTP server is not running (e.g., CLI commands that import this module).
+let jobManager: JobManager;
 
 // ── Analyze Handlers ──────────────────────────────────────────────────────
 
@@ -680,6 +681,10 @@ async function handleChat(res: ServerResponse, params: Record<string, unknown>) 
 }
 
 export function startHttpServer(opts: ServeOptions = {}): Server {
+  // Lazy-init JobManager only when the HTTP server starts,
+  // not at module import time (avoids keeping event loop alive for CLI commands).
+  jobManager = new JobManager();
+
   const port = opts.port ?? 4747;
   const host = opts.host ?? 'localhost';
 


### PR DESCRIPTION
## Problem
Every CLI command (status, detect-smells, detect-clones, ersion, etc.) hangs after completing — the Node.js process never exits.

## Root Cause
1. Any CLI command imports @astrolabe-dev/core
2. packages/core/src/index.ts re-exports startHttpServer from ./server/http-server.js
3. http-server.ts line 451: const jobManager = new JobManager() — **module-level instantiation**
4. JobManager constructor starts setInterval(() => this.cleanup(), CLEANUP_INTERVAL_MS) 
5. The setInterval keeps the Node.js event loop alive → process never exits

## Fix
Move 
ew JobManager() from module scope into startHttpServer(). The cleanup timer now only runs when the HTTP server is actually started, not on every CLI import.

## Verification
All commands that previously hung now exit cleanly:
- strolabe version ✅ exits
- strolabe status ✅ exits  
- strolabe detect-smells ✅ exits
- strolabe detect-clones ✅ exits
- strolabe detect-changes ✅ exits

## Testing
- \
pm run build\ — clean
- \
pm test\ — 676 pass, 19 skip (no regressions)