### PR TITLE
fix: Add type shim for @huggingface/transformers (#865)

### DIFF
--- a/packages/core/src/types/transformers.d.ts
+++ b/packages/core/src/types/transformers.d.ts
@@ -1,0 +1,16 @@
+/**
+ * Type declarations for @huggingface/transformers (optional dependency).
+ *
+ * This shim prevents TS2307 when the package is not installed (optional deps
+ * can fail silently in CI). The runtime code uses dynamic import() with
+ * try/catch, so it degrades gracefully when unavailable.
+ *
+ * @see #865
+ */
+declare module '@huggingface/transformers' {
+  export function pipeline(
+    task: string,
+    model: string,
+    options?: Record<string, unknown>,
+  ): Promise<any>;
+}


### PR DESCRIPTION
## Summary

Fixes the intermittent TS2307 build failure in the integration test CI job.

### Problem
\@huggingface/transformers\ is an optional dependency that can fail to install silently in CI. TypeScript still needs type declarations at compile time even for dynamic \import()\ calls. When the package isn't installed, \	sc\ errors with:

\\\
src/search/embeddings-store.ts(141,41): error TS2307: Cannot find module '@huggingface/transformers'
\\\

### Fix
Adds a minimal type shim at \packages/core/src/types/transformers.d.ts\ that declares the module for TypeScript. The runtime code already uses \	ry/catch\ around dynamic \import()\, so it degrades gracefully when the package isn't available.

### Verification
- \
pm run build --workspace packages/core\ — clean
- \
pm test\ — 676 pass, 19 skip
- No runtime behavior change

Closes #865