### PR TITLE
fix: gracefully degrade when Transformers model unavailable (#870)

### DIFF
--- a/packages/core/src/search/embeddings-store.ts
+++ b/packages/core/src/search/embeddings-store.ts
@@ -110,6 +110,7 @@ export class TransformersEmbeddingProvider implements EmbeddingProvider {
   private _pipeline: unknown = null;
   private _modelName: string;
   private _ready = false;
+  private _initLogged = false;
   private _initPromise: Promise<void> | null = null;
 
   constructor(dimensions = DEFAULT_LOCAL_DIMS) {
@@ -145,10 +146,18 @@ export class TransformersEmbeddingProvider implements EmbeddingProvider {
       });
       this._ready = true;
     } catch (err) {
-      throw new Error(
-        `Failed to load transformers model "${this._modelName}": ${(err as Error).message}. ` +
-        `Install with: npm install @huggingface/transformers`,
-      );
+      // Gracefully degrade — bag-of-words fallback in encodeAsync() handles null pipeline.
+      // This avoids CI failures when HuggingFace is rate-limited (429) or the package
+      // is not installed. Log once so operators know the model isn't loaded.
+      if (!this._initLogged) {
+        console.warn(
+          `[astrolabe] Transformers model "${this._modelName}" unavailable: ${(err as Error).message}. ` +
+          `Falling back to bag-of-words embeddings. Install @huggingface/transformers for better results.`,
+        );
+        this._initLogged = true;
+      }
+      this._pipeline = null;
+      this._ready = true;
     }
   }
 


### PR DESCRIPTION
## Problem

\TransformersEmbeddingProvider._init()\ throws when HuggingFace returns 429 (rate limit) or the package is unavailable. This causes CI failures across all matrix jobs because \encodeAsync()\ calls \ensureReady()\ → \_init()\ → throws, even though a bag-of-words fallback exists.

Fixes #864, fixes #870.

## Changes

- \_init()\ now catches errors and sets \_pipeline = null\ + \_ready = true\ instead of re-throwing
- \encodeAsync()\ naturally falls through to bag-of-words when \_pipeline\ is null
- Logs a one-time warning so operators know the model isn't loaded
- 1 file changed, 13 insertions, 4 deletions

## Testing

- 676 pass, 19 skip (unchanged)
- Build clean
- The \encodeAsync fallback\ tests now pass reliably even when HuggingFace is rate-limited