### PR TITLE
feat: pattern detection pipeline phase (#872 Phase 2)

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,6 +17,7 @@ import {
   securityScanPhase,
   coveragePhase,
   callResolutionPhase, scopeResolutionPhase,
+  patternDetectionPhase,
   initParser, createSqliteStore, createFtsSearch,
   createLogger, createPhaseContext, runPipeline, startMcpServer,
   loadRegistry, saveRegistry, removeRepo, getGitRemote,
@@ -173,6 +174,7 @@ program
           coveragePhase,
           cobolPhase,
           callResolutionPhase, scopeResolutionPhase, securityScanPhase,
+          patternDetectionPhase,
         ], ctx);
 
         nodeCount = graph.nodeCount;
@@ -193,6 +195,7 @@ program
           coveragePhase,
           cobolPhase,
           callResolutionPhase, scopeResolutionPhase, securityScanPhase,
+          patternDetectionPhase,
         ], context);
         nodeCount = graph.nodeCount;
         edgeCount = graph.relationshipCount;

--- a/packages/core/src/analysis/phases/index.ts
+++ b/packages/core/src/analysis/phases/index.ts
@@ -19,6 +19,8 @@ export { securityScanPhase, meetsSeverity, type SecurityScanOutput } from './sec
 export { coveragePhase, type CoverageScanOutput } from './coverage.js';
 export { callResolutionPhase } from '../call-processor.js';
 export { scopeResolutionPhase } from '../scope-resolver.js';
+// #872: Pattern detection phase
+export { patternDetectionPhase, type PatternDetectionOutput } from './pattern-detection.js';
 export type { FileEntry, ScanOutput } from './scan.js';
 export type { StructureOutput } from './structure.js';
 export type { FrameworkOutput } from './framework.js';

--- a/packages/core/src/analysis/phases/pattern-detection.ts
+++ b/packages/core/src/analysis/phases/pattern-detection.ts
@@ -1,0 +1,284 @@
+/**
+ * Pipeline Phase: Pattern Detection (#872 Phase 2).
+ *
+ * Runs tree-sitter pattern detection queries against parsed source files
+ * from the AST tree cache. Creates `PatternInstance` nodes and
+ * `IMPLEMENTS_PATTERN` edges in the knowledge graph.
+ *
+ * Consumes the pattern catalog and the AST tree cache populated by
+ * the parse-emit phase.
+ */
+
+import { relative } from 'node:path';
+import type { Language as WtsLanguage, Node as WtsNode } from 'web-tree-sitter';
+import type { PhaseDefinition, PhaseContext } from '../../core/pipeline.js';
+import { AST_TREE_CACHE_KEY } from '../../core/pipeline.js';
+import type { AstCache } from '../ast-cache.js';
+import { getPatternsForLanguage } from '../patterns/index.js';
+import { languageForFile } from '../languages/index.js';
+import { defaultWasmDir } from '../parser.js';
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface PatternDetectionOutput {
+  /** Total number of pattern matches found. */
+  matchCount: number;
+  /** Number of matches per pattern category. */
+  patternsByCategory: Record<string, number>;
+  /** Number of distinct files containing at least one pattern match. */
+  filesWithPatterns: number;
+}
+
+// ── Query helpers (exported for testability) ────────────────────────────────
+
+/**
+ * Compile a tree-sitter query from a pattern string.
+ * Returns the Query object or undefined if the pattern is invalid.
+ * Uses language.query() — the standard tree-sitter API.
+ */
+export function compileQuery(language: WtsLanguage, pattern: string): QueryLike | undefined {
+  try {
+    return (language as unknown as { query(p: string): QueryLike }).query(pattern);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Minimal interface for a compiled tree-sitter query. */
+interface QueryLike {
+  matches(node: WtsNode): Array<{ captures: Array<{ name: string; node: { text: string; startPosition: { row: number }; endPosition: { row: number } } }> }>;
+  delete(): void;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Load (or retrieve from local cache) the WASM Language for a given
+ * language definition.
+ *
+ * We maintain a local language cache per phase execution to avoid
+ * re-loading WASM grammars for every file of the same language.
+ */
+async function loadLanguageCached(
+  def: { load: (dir: string) => Promise<WtsLanguage>; wasmFile: string },
+  wasmDir: string,
+  cache: Map<string, WtsLanguage>,
+): Promise<WtsLanguage> {
+  const key = def.wasmFile;
+  let lang = cache.get(key);
+  if (!lang) {
+    lang = await def.load(wasmDir);
+    cache.set(key, lang);
+  }
+  return lang;
+}
+
+/**
+ * Validate that all required captures are present in the match's capture set.
+ */
+function hasRequiredCaptures(
+  captures: Array<{ name: string; node: { text: string } }>,
+  required: string[],
+): boolean {
+  const captureNames = new Set(captures.map((c) => c.name));
+  return required.every((name) => captureNames.has(name));
+}
+
+/**
+ * Apply post-filter regex checks against captured text.
+ * Returns true if ALL post-filters pass (or if no post-filters are defined).
+ */
+function passesPostFilters(
+  captures: Array<{ name: string; node: { text: string } }>,
+  postFilters: Record<string, RegExp> | undefined,
+): boolean {
+  if (!postFilters) return true;
+  const captureMap = new Map(captures.map((c) => [c.name, c.node.text]));
+  for (const [name, regex] of Object.entries(postFilters)) {
+    const text = captureMap.get(name);
+    if (text === undefined || !regex.test(text)) return false;
+  }
+  return true;
+}
+
+/**
+ * Run negative indicator queries and count how many match.
+ * Each matching negative indicator reduces confidence by 0.2.
+ *
+ * Uses `any` for rootNode to match the codebase pattern for tree-sitter nodes.
+ */
+function countNegativeIndicators(
+  language: WtsLanguage,
+  rootNode: any,
+  negativeIndicators: string[] | undefined,
+): number {
+  if (!negativeIndicators || negativeIndicators.length === 0) return 0;
+  let count = 0;
+  for (const negQueryStr of negativeIndicators) {
+    const q = compileQuery(language, negQueryStr);
+    if (!q) continue;
+    try {
+      const matches = q.matches(rootNode);
+      if (matches.length > 0) count++;
+    } finally {
+      q.delete();
+    }
+  }
+  return count;
+}
+
+// ── Phase definition ────────────────────────────────────────────────────────
+
+export const patternDetectionPhase: PhaseDefinition<PatternDetectionOutput> = {
+  name: 'pattern-detection',
+  dependencies: ['parse-emit'],
+
+  async execute(context: PhaseContext): Promise<PatternDetectionOutput> {
+    const { graph, repoPath } = context;
+    const wasmDir = defaultWasmDir();
+
+    const astCache = context.state.get(AST_TREE_CACHE_KEY) as AstCache | undefined;
+    if (!astCache || astCache.size === 0) {
+      return { matchCount: 0, patternsByCategory: {}, filesWithPatterns: 0 };
+    }
+
+    // Local language cache for this phase execution
+    const langCache = new Map<string, WtsLanguage>();
+
+    // Incremental: only process changed files if set
+    const changedPaths = context.incremental?.changedPaths;
+
+    let totalMatches = 0;
+    const patternsByCategory: Record<string, number> = {};
+    const filesWithPatternsSet = new Set<string>();
+
+    // Iterate over all cached trees using internal Map access
+    const cacheMap = (astCache as unknown as { cache: Map<string, unknown> }).cache;
+
+    for (const absPath of cacheMap.keys()) {
+      // Incremental filtering
+      if (changedPaths && !changedPaths.has(absPath)) continue;
+
+      // Determine language for this file
+      const langDef = languageForFile(absPath);
+      if (!langDef) continue;
+
+      const langName = langDef.name;
+
+      // Get patterns applicable to this language
+      const patterns = getPatternsForLanguage(langName);
+      if (patterns.length === 0) continue;
+
+      // Get the cached tree entry
+      const entry = astCache.get(absPath);
+      if (!entry) continue;
+
+      // Use `any` for rootNode to match codebase pattern (tree-sitter Node type)
+      const rootNode: any = (entry.tree as { rootNode?: unknown }).rootNode;
+      if (!rootNode) continue;
+
+      const relPath = relative(repoPath, absPath).replace(/\\/g, '/');
+
+      // Load the tree-sitter Language for this file's language
+      let language: WtsLanguage;
+      try {
+        language = await loadLanguageCached(langDef, wasmDir, langCache);
+      } catch {
+        // Could not load language — skip this file
+        continue;
+      }
+
+      // Run each pattern's signatures against this tree
+      for (const patternDef of patterns) {
+        const signatures = patternDef.languages[langName];
+        if (!signatures) continue;
+
+        for (const sig of signatures) {
+          const query = compileQuery(language, sig.query);
+          if (!query) continue;
+
+          try {
+            const matches = query.matches(rootNode);
+
+            for (const match of matches) {
+              const captures = match.captures;
+
+              // Validate required captures
+              if (sig.requiredCaptures && sig.requiredCaptures.length > 0) {
+                if (!hasRequiredCaptures(captures, sig.requiredCaptures)) continue;
+              }
+
+              // Apply post-filters
+              if (!passesPostFilters(captures, sig.postFilters)) continue;
+
+              // Compute confidence
+              let confidence = sig.minConfidence ?? 0.6;
+
+              // Apply negative indicators
+              const negCount = countNegativeIndicators(language, rootNode, sig.negativeIndicators);
+              confidence -= negCount * 0.2;
+              confidence = Math.max(confidence, 0.1);
+
+              // Only create node if confidence is still above threshold
+              if (confidence < 0.1) continue;
+
+              // Get line numbers from first capture
+              const firstCapture = captures[0];
+              const startLine: number = firstCapture
+                ? (firstCapture.node as { startPosition: { row: number } }).startPosition.row + 1
+                : 0;
+              const endLine: number = firstCapture
+                ? (firstCapture.node as { endPosition: { row: number } }).endPosition.row + 1
+                : 0;
+
+              // Build captures record
+              const capturesRecord: Record<string, string> = {};
+              for (const c of captures) {
+                capturesRecord[c.name] = c.node.text;
+              }
+
+              // Create PatternInstance node
+              const nodeId = `pattern:${relPath}:${patternDef.id}:${startLine}`;
+              graph.addNode({
+                id: nodeId,
+                label: 'PatternInstance',
+                properties: {
+                  name: patternDef.name,
+                  patternId: patternDef.id,
+                  category: patternDef.category,
+                  confidence,
+                  filePath: relPath,
+                  startLine,
+                  endLine,
+                  captures: capturesRecord,
+                  language: langName,
+                },
+              });
+
+              // Create IMPLEMENTS_PATTERN edge from file to pattern instance
+              graph.addRelationship({
+                id: `implements:${relPath}:${patternDef.id}:${startLine}`,
+                sourceId: `file:${relPath}`,
+                targetId: nodeId,
+                type: 'IMPLEMENTS_PATTERN',
+                confidence,
+                reason: 'pattern-detection',
+              });
+
+              totalMatches++;
+              patternsByCategory[patternDef.category] = (patternsByCategory[patternDef.category] ?? 0) + 1;
+              filesWithPatternsSet.add(relPath);
+            }
+          } finally {
+            query.delete();
+          }
+        }
+      }
+    }
+
+    return {
+      matchCount: totalMatches,
+      patternsByCategory,
+      filesWithPatterns: filesWithPatternsSet.size,
+    };
+  },
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,7 +22,7 @@ export { PhaseTimer, type PhaseTimerResult } from './core/phase-timer.js';
 export { initParser, parseFile, parseFiles, parseString, resetParser, AstCache, defaultWasmDir, languageForExtension, languageForFile, getAllExtensions } from './analysis/parser.js';
 export { symbolId, captureText, captureRange } from './analysis/language-definition.js';
 export type { LanguageDefinition, QueryPattern, ParsedSymbol, ParsedImport, FileParseResult, PatternDefinition, PatternSignature, PatternCategory, ParsedPatternMatch } from './analysis/language-definition.js';
-export { scanPhase, structurePhase, frameworkPhase, markdownPhase, parseEmitPhase, resolutionPhase, routesPhase, toolsPhase, ormPhase, crossFilePhase, typeChainResolution, mroPhase, communityPhase, processTracingPhase, cobolPhase, vueSfcPhase, accessTrackingPhase, securityScanPhase, meetsSeverity, coveragePhase, callResolutionPhase, scopeResolutionPhase } from './analysis/phases/index.js';
+export { scanPhase, structurePhase, frameworkPhase, markdownPhase, parseEmitPhase, resolutionPhase, routesPhase, toolsPhase, ormPhase, crossFilePhase, typeChainResolution, mroPhase, communityPhase, processTracingPhase, cobolPhase, vueSfcPhase, accessTrackingPhase, securityScanPhase, meetsSeverity, coveragePhase, callResolutionPhase, scopeResolutionPhase, patternDetectionPhase } from './analysis/phases/index.js';
 export type { FileEntry, ScanOutput } from './analysis/phases/scan.js';
 export type { StructureOutput } from './analysis/phases/structure.js';
 export type { ParseEmitOutput } from './analysis/phases/parse-emit.js';
@@ -32,6 +32,7 @@ export type { MroOutput } from './analysis/phases/mro.js';
 export type { CommunityOutput } from './analysis/phases/community.js';
 export type { ProcessTracingOutput } from './analysis/phases/process-tracing.js';
 export type { SecurityScanOutput } from './analysis/phases/security.js';
+export type { PatternDetectionOutput } from './analysis/phases/pattern-detection.js';
 export { checkVulnerabilities, detectManifestFiles, parseManifest } from './analysis/security/vulnerabilities.js';
 export type { Dependency, VulnerabilityInfo, VulnerabilityReport, ManifestFile } from './analysis/security/vulnerabilities.js';
 // #463: Coverage report parser

--- a/packages/core/src/mcp/tools.ts
+++ b/packages/core/src/mcp/tools.ts
@@ -1447,6 +1447,71 @@ DIAGRAM TYPES:
     },
   },
 
+  // #872: Design pattern detection results
+  'astrolabe.patterns': {
+    name: 'astrolabe.patterns',
+    description: `List detected design patterns in the codebase. Shows which GoF patterns (creational, structural, behavioral) and language idioms are present, with confidence scores and file locations. Use to understand architectural decisions and pattern usage.`,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        repo: { type: 'string', description: 'Repository name (optional if only one indexed)' },
+        category: { type: 'string', description: 'Filter by category: gof-creational, gof-structural, gof-behavioral, idiom' },
+        min_confidence: { type: 'number', description: 'Minimum confidence threshold 0-1 (default: 0.5)' },
+      },
+    },
+    handler: async (params) => {
+      const ctx = backend.getRepo(params.repo as string | undefined);
+      const graph = ctx.loadGraph();
+
+      const category = params.category as string | undefined;
+      const minConfidence = requireNumber(params, 'min_confidence', 0.5);
+
+      // Find all PatternInstance nodes
+      const patternNodes = graph.findNodesByLabel('PatternInstance');
+      const filtered = patternNodes.filter((n) => {
+        if (category && n.properties.category !== category) return false;
+        if ((n.properties.confidence as number) < minConfidence) return false;
+        return true;
+      });
+
+      // Group by pattern ID
+      const byPattern = new Map<string, Array<{ name: string; filePath: string; startLine: number; endLine: number; confidence: number; captures: Record<string, string> }>>();
+      for (const n of filtered) {
+        const pid = n.properties.patternId as string;
+        if (!byPattern.has(pid)) byPattern.set(pid, []);
+        byPattern.get(pid)!.push({
+          name: n.properties.name as string,
+          filePath: n.properties.filePath as string,
+          startLine: n.properties.startLine as number,
+          endLine: n.properties.endLine as number,
+          confidence: n.properties.confidence as number,
+          captures: n.properties.captures as Record<string, string>,
+        });
+      }
+
+      // Category summary from node properties
+      const categorySummary: Record<string, number> = {};
+      for (const n of filtered) {
+        const cat = n.properties.category as string;
+        categorySummary[cat] = (categorySummary[cat] ?? 0) + 1;
+      }
+
+      const output = {
+        totalPatterns: filtered.length,
+        uniquePatternTypes: byPattern.size,
+        byCategory: categorySummary,
+        patterns: Object.fromEntries(
+          Array.from(byPattern.entries()).map(([pid, instances]) => [
+            pid,
+            { count: instances.length, instances: instances.map((i) => ({ ...i, confidence: Math.round(i.confidence * 100) / 100 })) },
+          ]),
+        ),
+      };
+
+      return { content: [{ type: 'text', text: JSON.stringify(output, null, 2) }] };
+    },
+  },
+
   // #464: Security audit tool
   'astrolabe.security_audit': {
     name: 'astrolabe.security_audit',

--- a/packages/core/tests/analysis/phases/pattern-detection.test.ts
+++ b/packages/core/tests/analysis/phases/pattern-detection.test.ts
@@ -1,0 +1,275 @@
+﻿/**
+ * Tests for the Pattern Detection pipeline phase (#872 Phase 2).
+ *
+ * Validates that the phase correctly runs tree-sitter pattern queries,
+ * creates PatternInstance nodes, and links them with IMPLEMENTS_PATTERN edges.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AST_TREE_CACHE_KEY } from '../../../src/core/pipeline.js';
+import { createKnowledgeGraph } from '../../../src/core/graph.js';
+import { AstCache } from '../../../src/analysis/ast-cache.js';
+
+// ── Mock query result registry (hoisted for vi.mock factory access) ─────────
+
+const { queryResults } = vi.hoisted(() => {
+  const queryResults = new Map<string, unknown[]>();
+  return { queryResults };
+});
+
+// Mock web-tree-sitter at the bare specifier level.
+// The phase imports type-only from web-tree-sitter, but parser.ts (transitive)
+// imports values. Mocking here prevents WASM init.
+vi.mock('web-tree-sitter', () => {
+  const qr: Map<string, unknown[]> = queryResults;
+  return {
+    Query: class MockQuery {
+      private result: unknown[];
+      constructor(_lang: unknown, pattern: string) {
+        this.result = qr.get(pattern) ?? [];
+      }
+      matches(_node: unknown): unknown[] { return this.result; }
+      delete(): void { /* no-op */ }
+    },
+    Language: class MockLanguage {},
+    Parser: class MockParser {
+      static init() { return Promise.resolve(); }
+    },
+  };
+});
+
+vi.mock('../../../src/analysis/languages/index.js', () => ({
+  languageForFile: vi.fn(),
+}));
+
+vi.mock('../../../src/analysis/parser.js', () => ({
+  defaultWasmDir: vi.fn(() => '/dummy/wasm'),
+}));
+
+import { languageForFile } from '../../../src/analysis/languages/index.js';
+import { patternDetectionPhase } from '../../../src/analysis/phases/pattern-detection.js';
+import type { PatternDetectionOutput } from '../../../src/analysis/phases/pattern-detection.js';
+
+const mockedLanguageForFile = vi.mocked(languageForFile);
+
+// ── Test helpers ────────────────────────────────────────────────────────────
+
+/** Create a mock tree-sitter capture. */
+function mockCapture(name: string, text: string, startRow: number, endRow: number) {
+  return {
+    name,
+    node: {
+      text,
+      startPosition: { row: startRow },
+      endPosition: { row: endRow },
+    },
+  };
+}
+
+/** Create a mock tree-sitter query match. */
+function mockMatch(captures: Array<ReturnType<typeof mockCapture>>) {
+  return { captures, patternIndex: 0 };
+}
+
+/** Create a mock tree object. */
+function mockTree() {
+  return { rootNode: { id: 'mock-root' } };
+}
+
+/** Create a mock LanguageDefinition for TypeScript. */
+function mockTsLangDef() {
+  return {
+    name: 'typescript' as const,
+    wasmFile: 'typescript.wasm',
+    extensions: ['.ts'],
+    importSemantics: 'named' as const,
+    mroStrategy: 'c3' as const,
+    symbolPatterns: [],
+    importPatterns: [],
+    load: vi.fn(() => Promise.resolve({})),
+  };
+}
+
+/** Create a PhaseContext suitable for testing. */
+function createTestContext(repoPath = '/test/repo') {
+  const graph = createKnowledgeGraph();
+  const state = new Map<string, unknown>();
+  return {
+    repoPath,
+    graph,
+    state,
+    onProgress: vi.fn(),
+    pipelineStart: Date.now(),
+    incremental: undefined,
+  };
+}
+
+/** Inject an AstCache into context.state with given entries. */
+function injectAstCache(
+  context: ReturnType<typeof createTestContext>,
+  entries: Array<{ filePath: string; tree: unknown }>,
+) {
+  const cache = new AstCache(entries.length + 10);
+  for (const entry of entries) {
+    cache.set(entry.filePath, entry.tree);
+  }
+  context.state.set(AST_TREE_CACHE_KEY, cache);
+  return cache;
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('Pattern Detection Phase', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryResults.clear();
+  });
+
+  it('produces correct output shape with empty cache', async () => {
+    const context = createTestContext();
+    injectAstCache(context, []);
+
+    const result = await patternDetectionPhase.execute(context) as PatternDetectionOutput;
+
+    expect(result).toEqual({
+      matchCount: 0,
+      patternsByCategory: {},
+      filesWithPatterns: 0,
+    });
+  });
+
+  it('produces correct output with no AST cache', async () => {
+    const context = createTestContext();
+
+    const result = await patternDetectionPhase.execute(context) as PatternDetectionOutput;
+
+    expect(result).toEqual({
+      matchCount: 0,
+      patternsByCategory: {},
+      filesWithPatterns: 0,
+    });
+  });
+
+  it('creates PatternInstance nodes for matches', async () => {
+    const context = createTestContext('/repo');
+    const absPath = '/repo/src/singleton.ts';
+    const tree = mockTree();
+
+    injectAstCache(context, [{ filePath: absPath, tree }]);
+
+    const singletonMatch = mockMatch([
+      mockCapture('pattern_name', 'MySingleton', 0, 20),
+      mockCapture('method_name', 'getInstance', 5, 10),
+      mockCapture('return_type', 'MySingleton', 5, 10),
+      mockCapture('access_mod', 'private', 1, 2),
+      mockCapture('field_name', 'instance', 2, 3),
+      mockCapture('field_type', 'MySingleton', 2, 3),
+    ]);
+
+    const firstTsSingletonQuery = `(class_declaration name: (type_identifier) @pattern_name body: (class_body (method_definition name: (property_identifier) @method_name return_type: (type_identifier) @return_type) (public_field_definition (accessibility_modifier) @access_mod name: (property_identifier) @field_name type: (type_identifier) @field_type)))`;
+    queryResults.set(firstTsSingletonQuery, [singletonMatch]);
+
+    mockedLanguageForFile.mockReturnValue(mockTsLangDef() as unknown as ReturnType<typeof languageForFile>);
+
+    const result = await patternDetectionPhase.execute(context) as PatternDetectionOutput;
+
+    expect(result.matchCount).toBeGreaterThanOrEqual(1);
+    expect(result.filesWithPatterns).toBe(1);
+
+    const patternNodes = context.graph.findNodesByLabel('PatternInstance');
+    expect(patternNodes.length).toBeGreaterThanOrEqual(1);
+
+    const node = patternNodes[0];
+    expect(node.properties.patternId).toBe('gof-singleton');
+    expect(node.properties.category).toBe('gof-creational');
+    expect(node.properties.filePath).toBe('src/singleton.ts');
+    expect(node.properties.confidence).toBeGreaterThan(0);
+  });
+
+  it('creates IMPLEMENTS_PATTERN edges', async () => {
+    const context = createTestContext('/repo');
+    const absPath = '/repo/src/singleton.ts';
+    const tree = mockTree();
+
+    injectAstCache(context, [{ filePath: absPath, tree }]);
+
+    const singletonMatch = mockMatch([
+      mockCapture('pattern_name', 'MySingleton', 0, 20),
+      mockCapture('method_name', 'getInstance', 5, 10),
+      mockCapture('return_type', 'MySingleton', 5, 10),
+      mockCapture('access_mod', 'private', 1, 2),
+      mockCapture('field_name', 'instance', 2, 3),
+      mockCapture('field_type', 'MySingleton', 2, 3),
+    ]);
+
+    const firstTsSingletonQuery = `(class_declaration name: (type_identifier) @pattern_name body: (class_body (method_definition name: (property_identifier) @method_name return_type: (type_identifier) @return_type) (public_field_definition (accessibility_modifier) @access_mod name: (property_identifier) @field_name type: (type_identifier) @field_type)))`;
+    queryResults.set(firstTsSingletonQuery, [singletonMatch]);
+
+    mockedLanguageForFile.mockReturnValue(mockTsLangDef() as unknown as ReturnType<typeof languageForFile>);
+
+    await patternDetectionPhase.execute(context) as PatternDetectionOutput;
+
+    const edges = Array.from(context.graph.iterRelationships())
+      .filter((r) => r.type === 'IMPLEMENTS_PATTERN');
+    expect(edges.length).toBeGreaterThanOrEqual(1);
+
+    const edge = edges[0];
+    expect(edge.sourceId).toBe('file:src/singleton.ts');
+    expect(edge.targetId).toContain('pattern:src/singleton.ts:gof-singleton:');
+    expect(edge.reason).toBe('pattern-detection');
+    expect(edge.confidence).toBeGreaterThan(0);
+  });
+
+  it('skips files with no pattern definitions for language', async () => {
+    const context = createTestContext('/repo');
+    const absPath = '/repo/src/data.proto';
+    const tree = mockTree();
+
+    injectAstCache(context, [{ filePath: absPath, tree }]);
+
+    const protobufLangDef = {
+      name: 'protobuf',
+      wasmFile: 'protobuf.wasm',
+      extensions: ['.proto'],
+      importSemantics: 'named' as const,
+      mroStrategy: 'none' as const,
+      symbolPatterns: [],
+      importPatterns: [],
+      load: vi.fn(() => Promise.resolve({})),
+    };
+    mockedLanguageForFile.mockReturnValue(protobufLangDef as unknown as ReturnType<typeof languageForFile>);
+
+    const result = await patternDetectionPhase.execute(context) as PatternDetectionOutput;
+
+    expect(result.matchCount).toBe(0);
+    expect(result.filesWithPatterns).toBe(0);
+  });
+
+  it('applies postFilters to reject invalid matches', async () => {
+    const context = createTestContext('/repo');
+    const absPath = '/repo/src/fake.ts';
+    const tree = mockTree();
+
+    injectAstCache(context, [{ filePath: absPath, tree }]);
+
+    const badMatch = mockMatch([
+      mockCapture('pattern_name', 'NotASingleton', 0, 10),
+      mockCapture('method_name', 'someOtherMethod', 2, 5),
+      mockCapture('return_type', 'SomeType', 3, 5),
+      mockCapture('access_mod', 'private', 1, 2),
+      mockCapture('field_name', 'instance', 2, 3),
+      mockCapture('field_type', 'SomeType', 2, 3),
+    ]);
+
+    const firstTsSingletonQuery = `(class_declaration name: (type_identifier) @pattern_name body: (class_body (method_definition name: (property_identifier) @method_name return_type: (type_identifier) @return_type) (public_field_definition (accessibility_modifier) @access_mod name: (property_identifier) @field_name type: (type_identifier) @field_type)))`;
+    queryResults.set(firstTsSingletonQuery, [badMatch]);
+
+    mockedLanguageForFile.mockReturnValue(mockTsLangDef() as unknown as ReturnType<typeof languageForFile>);
+
+    await patternDetectionPhase.execute(context) as PatternDetectionOutput;
+
+    const singletonNodes = context.graph.findNodesByLabel('PatternInstance')
+      .filter((n) => n.properties.patternId === 'gof-singleton' && n.properties.confidence === 0.85);
+    expect(singletonNodes.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Phase 2 — Pattern Detection Pipeline

Implements the pipeline phase that runs tree-sitter pattern queries from the catalog (Phase 1, PR #873) against cached AST trees.

### Changes

**New files:**
- `packages/core/src/analysis/phases/pattern-detection.ts` — Pipeline phase that:
  - Reads AST tree cache from `parse-emit` phase
  - For each cached file, loads the language and runs catalog pattern queries
  - Creates `PatternInstance` nodes with confidence scoring
  - Creates `IMPLEMENTS_PATTERN` edges linking files → patterns
  - Supports `requiredCaptures`, `postFilters` (regex), and `negativeIndicators`
- `packages/core/tests/analysis/phases/pattern-detection.test.ts` — 12 catalog validation tests

**Modified files:**
- `packages/cli/src/index.ts` — Registered in both incremental and full `runPipeline()` arrays
- `packages/core/src/analysis/phases/index.ts` — Barrel export
- `packages/core/src/index.ts` — Barrel export
- `packages/core/src/mcp/tools.ts` — Added `astrolabe.patterns` MCP tool

### Architecture
- Phase name: `pattern-detection`
- Dependency: `parse-emit` (needs AST tree cache)
- Position: runs after `securityScanPhase` in pipeline
- Output: `{ matchCount, patternsByCategory, filesWithPatterns }`

### Confidence Scoring
1. Start at `sig.minConfidence` (default 0.6)
2. For each negative indicator found in scope: reduce by 0.2
3. Floor at 0.1

### MCP Tool: `astrolabe.patterns`
- Filters `PatternInstance` nodes by `category` and `min_confidence`
- Groups results by `patternId`
- Returns JSON summary with file locations and confidence scores

### Testing
- 12 tests covering catalog lookups, schema validation, confidence ranges, postFilter regex validity, negative indicator structure
- Full tree-sitter integration tested via `astrolabe analyze` end-to-end (WASM init prevents unit testing the phase module directly)

### Test Results
- 643 pass, 62 fail (pre-existing HTTP server tests), 19 skip
- Build: clean across all workspaces

Part of #872