### PR TITLE
feat: semantic (typed) graphlets (#872 Phase 3)

### DIFF
--- a/packages/core/src/analysis/graphlet/index.ts
+++ b/packages/core/src/analysis/graphlet/index.ts
@@ -1,7 +1,8 @@
 /**
- * Graphlet Analysis — Barrel export (#461).
+ * Graphlet Analysis — Barrel export (#461, #872).
  *
  * Re-exports graphlet counting, pattern detection, and health scoring.
+ * Also re-exports typed (semantic) variants from #872.
  */
 
 // #461: Graphlet motif counting
@@ -12,3 +13,29 @@ export { detectPatterns, type ArchitecturePattern } from './patterns.js';
 
 // #461: Architecture health scoring
 export { scoreArchitectureHealth, type ArchitectureHealth, type CommunityInfo } from './health.js';
+
+// #872: Typed (semantic) graphlet counting
+export {
+  buildTypedAdjacencyMap,
+  countTypedGraphlets,
+  emptyTypedProfile,
+  type TypedAdjacencyMap,
+  type TypedMotifKey as TypedCounterMotifKey,
+  type TypedGraphletProfile,
+} from './typed-counter.js';
+
+// #872: Typed architectural pattern detection
+export {
+  detectTypedPatterns,
+  type TypedMotifKey,
+  type TypedMotifSummary,
+  type TypedArchitecturePattern,
+} from './typed-patterns.js';
+
+// #872: Typed architecture health scoring
+export {
+  scoreTypedArchitectureHealth,
+  type TypedAntiPattern,
+  type TypedArchitectureHealth,
+  type LabelHealthBreakdown,
+} from './typed-health.js';

--- a/packages/core/src/analysis/graphlet/typed-counter.ts
+++ b/packages/core/src/analysis/graphlet/typed-counter.ts
@@ -1,0 +1,498 @@
+/**
+ * Graphlet Analysis — Typed motif counting with node labels and edge types (#872).
+ *
+ * Extends the untyped graphlet counter (#461) by considering node labels
+ * (Class, Function, Method, …) and relationship types (CALLS, IMPORTS, …)
+ * when counting 3-node and 4-node motifs. This enables semantic pattern
+ * detection such as "Class-CALLS-Function-CALLS-Class triangles" vs
+ * "Class-EXTENDS-Class-IMPLEMENTS-Interface diamonds".
+ */
+
+import type { GraphNode, GraphRelationship } from '@astrolabe-dev/shared';
+
+// #872: Relationship types considered by the typed counter.
+// Broader than the untyped counter (CALLS, IMPORTS, EXTENDS) to capture
+// richer semantic patterns.
+const TYPED_ALLOWED_REL_TYPES: ReadonlySet<string> = new Set([
+  'CALLS',
+  'IMPORTS',
+  'EXTENDS',
+  'IMPLEMENTS',
+  'USES',
+  'MEMBER_OF',
+  'HAS_METHOD',
+  'HAS_PROPERTY',
+]);
+
+// #872: Sampling thresholds — same strategy as untyped counter (#461)
+const FULL_ENUMERATION_THRESHOLD = 1000;
+const DEFAULT_SAMPLE_SIZE = 500;
+
+// ── Exported types ────────────────────────────────────────────────────────────
+
+/**
+ * Typed adjacency map: nodeId → (neighborId → relationshipType).
+ *
+ * Stores the relationship type for every undirected edge. If multiple
+ * relationship types exist between the same pair, only one is kept
+ * (first encountered wins during construction).
+ */
+export type TypedAdjacencyMap = Map<string, Map<string, string>>;
+
+/**
+ * Branded string key encoding a typed motif signature.
+ *
+ * For a single edge:   `"SourceLabel-REL_TYPE-TargetLabel"`
+ * For a 3-node motif:  `"LabelA:LabelB:LabelC"` with edge types encoded
+ *                       as `"RelAB-RelAC-RelBC"`
+ * For a 4-node motif:  `"LabelA:LabelB:LabelC:LabelD"` with edge types encoded
+ *                       as `"RelAB-RelAC-RelAD-RelBC-RelBD-RelCD"`
+ */
+export type TypedMotifKey = string & { readonly __brand: unique symbol };
+
+/**
+ * Typed graphlet profile — same shape as GraphletProfile but each motif
+ * class is further broken down by node-label and edge-type combinations.
+ */
+export interface TypedGraphletProfile {
+  /** 3-node motif counts keyed by TypedMotifKey (label triplet + edge types) */
+  motif3: Map<TypedMotifKey, number>;
+  /** 4-node motif counts keyed by TypedMotifKey (label quartet + edge types) */
+  motif4: Map<TypedMotifKey, number>;
+  /** Total nodes and edges analyzed */
+  nodeCount: number;
+  edgeCount: number;
+  /** Sampling metadata */
+  sampled: boolean;
+  sampleSize?: number;
+}
+
+// ── Build typed adjacency ────────────────────────────────────────────────────
+
+/**
+ * Build a typed adjacency map and node label lookup from raw graph data.
+ *
+ * Returns:
+ * - `nodeLabels`: nodeId → label string
+ * - `typedAdj`: nodeId → (neighborId → relationshipType)
+ *
+ * Only edges with allowed relationship types are included. Edges are stored
+ * undirected — both directions are populated with the same type.
+ */
+// #872: Build typed adjacency from GraphNode[] and GraphRelationship[]
+export function buildTypedAdjacencyMap(
+  nodes: readonly GraphNode[],
+  relationships: readonly GraphRelationship[],
+): {
+  nodeLabels: Map<string, string>;
+  typedAdj: TypedAdjacencyMap;
+} {
+  const nodeLabels = new Map<string, string>();
+  const typedAdj: TypedAdjacencyMap = new Map();
+
+  // Register all nodes
+  for (const node of nodes) {
+    nodeLabels.set(node.id, node.label);
+    typedAdj.set(node.id, new Map());
+  }
+
+  // Add undirected typed edges
+  for (const rel of relationships) {
+    if (!TYPED_ALLOWED_REL_TYPES.has(rel.type)) continue;
+    if (!nodeLabels.has(rel.sourceId) || !nodeLabels.has(rel.targetId)) continue;
+
+    const srcMap = typedAdj.get(rel.sourceId);
+    const tgtMap = typedAdj.get(rel.targetId);
+    if (!srcMap || !tgtMap) continue;
+
+    // Only store first encountered type per edge pair
+    if (!srcMap.has(rel.targetId)) {
+      srcMap.set(rel.targetId, rel.type);
+    }
+    if (!tgtMap.has(rel.sourceId)) {
+      tgtMap.set(rel.sourceId, rel.type);
+    }
+  }
+
+  return { nodeLabels, typedAdj };
+}
+
+// ── Typed graphlet counting ──────────────────────────────────────────────────
+
+/**
+ * Count typed graphlet motifs in a dependency graph.
+ *
+ * For graphs ≤ 1000 nodes: enumerates all 3-node and 4-node subgraphs.
+ * For graphs > 1000 nodes: samples up to 500 random nodes.
+ *
+ * Each motif is classified by:
+ * 1. The sorted label triplet/quartet (e.g. "Class:Function:Method")
+ * 2. The edge type combination (e.g. "CALLS-IMPORTS-EXTENDS")
+ *
+ * Both parts are combined into a single TypedMotifKey.
+ *
+ * @param nodes      Graph nodes (must have `id` and `label`)
+ * @param typedAdj   Typed adjacency map from `buildTypedAdjacencyMap`
+ * @param nodeLabels Node label lookup from `buildTypedAdjacencyMap`
+ * @param maxNodes   Optional override for the sampling threshold
+ */
+// #872: Main typed graphlet counting entry point
+export function countTypedGraphlets(
+  nodes: Iterable<GraphNode>,
+  typedAdj: TypedAdjacencyMap,
+  nodeLabels: Map<string, string>,
+  maxNodes?: number,
+): TypedGraphletProfile {
+  const threshold = maxNodes ?? FULL_ENUMERATION_THRESHOLD;
+
+  // Collect node IDs
+  const allNodeIds: string[] = [];
+  for (const node of nodes) {
+    allNodeIds.push(node.id);
+  }
+
+  const totalNodes = allNodeIds.length;
+
+  if (totalNodes === 0) {
+    return emptyTypedProfile(0, 0, false);
+  }
+
+  // Count total edges (each undirected edge stored twice)
+  let totalEdges = 0;
+  for (const [, neighbors] of typedAdj) {
+    totalEdges += neighbors.size;
+  }
+  totalEdges = Math.floor(totalEdges / 2);
+
+  if (totalNodes < 3) {
+    return emptyTypedProfile(totalNodes, totalEdges, false);
+  }
+
+  // Decide sampling strategy
+  let sampledNodeIds: string[];
+  let sampled = false;
+  let sampleSize: number | undefined;
+
+  if (totalNodes > threshold) {
+    sampledNodeIds = randomSample(allNodeIds, DEFAULT_SAMPLE_SIZE);
+    sampled = true;
+    sampleSize = sampledNodeIds.length;
+  } else {
+    sampledNodeIds = allNodeIds;
+  }
+
+  // Motif counters
+  const motif3 = new Map<TypedMotifKey, number>();
+  const motif4 = new Map<TypedMotifKey, number>();
+
+  // #872: 3-node typed motif counting
+  const counted3 = new Set<string>();
+
+  for (const nodeId of sampledNodeIds) {
+    const neighbors = typedAdj.get(nodeId);
+    if (!neighbors || neighbors.size < 2) continue;
+
+    const neighborArr = Array.from(neighbors.keys());
+    for (let i = 0; i < neighborArr.length; i++) {
+      for (let j = i + 1; j < neighborArr.length; j++) {
+        const b = neighborArr[i];
+        const c = neighborArr[j];
+        const key = sort3(nodeId, b, c);
+        if (counted3.has(key)) continue;
+        counted3.add(key);
+
+        // Check edges among the 3 nodes
+        const nA = typedAdj.get(nodeId);
+        const nB = typedAdj.get(b);
+        const nC = typedAdj.get(c);
+        if (!nA || !nB || !nC) continue;
+
+        const hasAB = nA.has(b);
+        const hasAC = nA.has(c);
+        const hasBC = nB.has(c);
+
+        if (!hasAB && !hasAC) continue; // nodeId not connected to either → skip (handled below)
+
+        const motifKey = buildTypedMotifKey3(
+          nodeId, b, c,
+          hasAB ? nA.get(b)! : '',
+          hasAC ? nA.get(c)! : '',
+          hasBC ? nB.get(c)! : '',
+          nodeLabels,
+        );
+
+        incrementMap(motif3, motifKey);
+      }
+    }
+  }
+
+  // Count disconnected and single-edge triples via random sampling
+  if (totalNodes >= 3) {
+    const tripleSamples = Math.min(5000, totalNodes * 3);
+    for (let s = 0; s < tripleSamples; s++) {
+      const a = allNodeIds[Math.floor(pseudoRandom(s) * totalNodes)];
+      const b = allNodeIds[Math.floor(pseudoRandom(s + 1000) * totalNodes)];
+      const c = allNodeIds[Math.floor(pseudoRandom(s + 2000) * totalNodes)];
+      if (a === b || b === c || a === c) continue;
+
+      const key = sort3(a, b, c);
+      if (counted3.has(key)) continue;
+      counted3.add(key);
+
+      const nA = typedAdj.get(a);
+      const nB = typedAdj.get(b);
+      const nC = typedAdj.get(c);
+      if (!nA || !nB || !nC) continue;
+
+      const hasAB = nA.has(b);
+      const hasAC = nA.has(c);
+      const hasBC = nB.has(c);
+      const edgeCount = (hasAB ? 1 : 0) + (hasAC ? 1 : 0) + (hasBC ? 1 : 0);
+
+      // Only count lower-edge motifs here (higher ones already counted)
+      if (edgeCount < 2) {
+        const motifKey = buildTypedMotifKey3(
+          a, b, c,
+          hasAB ? nA.get(b)! : '',
+          hasAC ? nA.get(c)! : '',
+          hasBC ? nB.get(c)! : '',
+          nodeLabels,
+        );
+        incrementMap(motif3, motifKey);
+      }
+    }
+  }
+
+  // #872: 4-node typed motif counting
+  const counted4 = new Set<string>();
+
+  for (const nodeId of sampledNodeIds) {
+    const neighbors = typedAdj.get(nodeId);
+    if (!neighbors || neighbors.size < 3) continue;
+
+    const neighborArr = Array.from(neighbors.keys());
+    const maxIdx = Math.min(neighborArr.length, 30);
+
+    for (let i = 0; i < maxIdx; i++) {
+      for (let j = i + 1; j < maxIdx; j++) {
+        for (let k = j + 1; k < maxIdx; k++) {
+          const b = neighborArr[i];
+          const c = neighborArr[j];
+          const d = neighborArr[k];
+          const key = sort4(nodeId, b, c, d);
+          if (counted4.has(key)) continue;
+          counted4.add(key);
+
+          const nA = typedAdj.get(nodeId);
+          const nB = typedAdj.get(b);
+          const nC = typedAdj.get(c);
+          const nD = typedAdj.get(d);
+          if (!nA || !nB || !nC || !nD) continue;
+
+          // Count all 6 possible edges
+          let edges = 0;
+          const hasAB = nA.has(b); if (hasAB) edges++;
+          const hasAC = nA.has(c); if (hasAC) edges++;
+          const hasAD = nA.has(d); if (hasAD) edges++;
+          const hasBC = nB.has(c); if (hasBC) edges++;
+          const hasBD = nB.has(d); if (hasBD) edges++;
+          const hasCD = nC.has(d); if (hasCD) edges++;
+
+          if (edges <= 1) continue; // not meaningful for architectural patterns
+
+          // Determine 4-node motif shape
+          const shape = classify4NodeMotif(
+            hasAB, hasAC, hasAD, hasBC, hasBD, hasCD,
+            nA, nB, nC, nD,
+            nodeId, b, c, d,
+          );
+
+          if (shape === null) continue;
+
+          const motifKey = buildTypedMotifKey4(
+            nodeId, b, c, d,
+            hasAB ? nA.get(b)! : '',
+            hasAC ? nA.get(c)! : '',
+            hasAD ? nA.get(d)! : '',
+            hasBC ? nB.get(c)! : '',
+            hasBD ? nB.get(d)! : '',
+            hasCD ? nC.get(d)! : '',
+            nodeLabels,
+            shape,
+          );
+
+          incrementMap(motif4, motifKey);
+        }
+      }
+    }
+  }
+
+  return {
+    motif3,
+    motif4,
+    nodeCount: totalNodes,
+    edgeCount: totalEdges,
+    sampled,
+    sampleSize,
+  };
+}
+
+/**
+ * Create an empty typed graphlet profile for edge cases.
+ */
+// #872: Empty typed profile helper
+export function emptyTypedProfile(
+  nodeCount: number,
+  edgeCount: number,
+  sampled: boolean,
+): TypedGraphletProfile {
+  return {
+    motif3: new Map(),
+    motif4: new Map(),
+    nodeCount,
+    edgeCount,
+    sampled,
+  };
+}
+
+// ── Private helpers ───────────────────────────────────────────────────────────
+
+// #872: Build a typed motif key for a 3-node subgraph
+function buildTypedMotifKey3(
+  a: string,
+  b: string,
+  c: string,
+  relAB: string,
+  relAC: string,
+  relBC: string,
+  nodeLabels: Map<string, string>,
+): TypedMotifKey {
+  const labelA = nodeLabels.get(a) ?? 'Unknown';
+  const labelB = nodeLabels.get(b) ?? 'Unknown';
+  const labelC = nodeLabels.get(c) ?? 'Unknown';
+
+  // Sort labels alphabetically for canonical form
+  const labels = [labelA, labelB, labelC].sort();
+  const labelKey = labels.join(':');
+
+  // Sort non-empty edge types for canonical form
+  const edgeTypes = [relAB, relAC, relBC].filter(t => t !== '').sort();
+  const edgeKey = edgeTypes.join('-');
+
+  return `${labelKey}|${edgeKey}` as TypedMotifKey;
+}
+
+// #872: Build a typed motif key for a 4-node subgraph
+function buildTypedMotifKey4(
+  a: string,
+  b: string,
+  c: string,
+  d: string,
+  relAB: string,
+  relAC: string,
+  relAD: string,
+  relBC: string,
+  relBD: string,
+  relCD: string,
+  nodeLabels: Map<string, string>,
+  shape: string,
+): TypedMotifKey {
+  const labelA = nodeLabels.get(a) ?? 'Unknown';
+  const labelB = nodeLabels.get(b) ?? 'Unknown';
+  const labelC = nodeLabels.get(c) ?? 'Unknown';
+  const labelD = nodeLabels.get(d) ?? 'Unknown';
+
+  const labels = [labelA, labelB, labelC, labelD].sort();
+  const labelKey = labels.join(':');
+
+  const edgeTypes = [relAB, relAC, relAD, relBC, relBD, relCD]
+    .filter(t => t !== '')
+    .sort();
+  const edgeKey = edgeTypes.join('-');
+
+  return `${shape}|${labelKey}|${edgeKey}` as TypedMotifKey;
+}
+
+// #872: Classify a 4-node motif shape by edge count and degree pattern
+type NeighborMap = Map<string, string>;
+
+function classify4NodeMotif(
+  hasAB: boolean, hasAC: boolean, hasAD: boolean,
+  hasBC: boolean, hasBD: boolean, hasCD: boolean,
+  _nA: NeighborMap, _nB: NeighborMap, _nC: NeighborMap, _nD: NeighborMap,
+  _idA: string, _idB: string, _idC: string, _idD: string,
+): string | null {
+  const edges = (hasAB ? 1 : 0) + (hasAC ? 1 : 0) + (hasAD ? 1 : 0)
+    + (hasBC ? 1 : 0) + (hasBD ? 1 : 0) + (hasCD ? 1 : 0);
+
+  if (edges === 6) return 'clique';
+  if (edges === 5) return 'diamond'; // near-clique variant
+
+  if (edges === 4) {
+    // Check if it's a 4-cycle: each node has degree 2 in the subgraph
+    const degA = (hasAB ? 1 : 0) + (hasAC ? 1 : 0) + (hasAD ? 1 : 0);
+    const degB = (hasAB ? 1 : 0) + (hasBC ? 1 : 0) + (hasBD ? 1 : 0);
+    const degC = (hasAC ? 1 : 0) + (hasBC ? 1 : 0) + (hasCD ? 1 : 0);
+    const degD = (hasAD ? 1 : 0) + (hasBD ? 1 : 0) + (hasCD ? 1 : 0);
+
+    if (degA === 2 && degB === 2 && degC === 2 && degD === 2) {
+      return 'cycle';
+    }
+    return 'diamond';
+  }
+
+  if (edges === 3) {
+    const degA = (hasAB ? 1 : 0) + (hasAC ? 1 : 0) + (hasAD ? 1 : 0);
+    const degB = (hasAB ? 1 : 0) + (hasBC ? 1 : 0) + (hasBD ? 1 : 0);
+    const degC = (hasAC ? 1 : 0) + (hasBC ? 1 : 0) + (hasCD ? 1 : 0);
+    const degD = (hasAD ? 1 : 0) + (hasBD ? 1 : 0) + (hasCD ? 1 : 0);
+
+    if (degA === 3 || degB === 3 || degC === 3 || degD === 3) {
+      return 'star';
+    }
+    return 'chain';
+  }
+
+  if (edges === 2) {
+    return 'chain';
+  }
+
+  return null; // 0 or 1 edges — not meaningful
+}
+
+// #872: Increment a counter in a Map<TypedMotifKey, number>
+function incrementMap(
+  map: Map<TypedMotifKey, number>,
+  key: TypedMotifKey,
+): void {
+  const current = map.get(key);
+  map.set(key, (current ?? 0) + 1);
+}
+
+// #872: Create a canonical key for a 3-node subgraph
+function sort3(a: string, b: string, c: string): string {
+  const arr = [a, b, c].sort();
+  return `${arr[0]}:${arr[1]}:${arr[2]}`;
+}
+
+// #872: Create a canonical key for a 4-node subgraph
+function sort4(a: string, b: string, c: string, d: string): string {
+  const arr = [a, b, c, d].sort();
+  return `${arr[0]}:${arr[1]}:${arr[2]}:${arr[3]}`;
+}
+
+// #872: Deterministic pseudo-random for reproducible sampling
+function pseudoRandom(seed: number): number {
+  let x = Math.sin(seed * 9301 + 49297) * 49297;
+  return x - Math.floor(x);
+}
+
+// #872: Random sample of array elements (Fisher-Yates partial shuffle)
+function randomSample<T>(arr: T[], size: number): T[] {
+  const shuffled = arr.slice();
+  for (let i = 0; i < Math.min(size, shuffled.length); i++) {
+    const j = i + Math.floor(pseudoRandom(i) * (shuffled.length - i));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return shuffled.slice(0, size);
+}

--- a/packages/core/src/analysis/graphlet/typed-health.ts
+++ b/packages/core/src/analysis/graphlet/typed-health.ts
@@ -1,0 +1,351 @@
+/**
+ * Graphlet Analysis — Typed architecture health scoring (#872).
+ *
+ * Extends the base architecture health scoring with typed graphlet profiles
+ * for more precise anti-pattern detection using node labels and relationship
+ * types (Class, Function, CALLS, EXTENDS, etc.).
+ */
+
+import type { GraphletProfile } from './counter.js';
+import {
+  scoreArchitectureHealth,
+  type ArchitectureHealth,
+  type CommunityInfo,
+} from './health.js';
+
+// #872: Summary of typed motif counts keyed by composite label strings
+export type TypedMotifSummary = Record<string, number>;
+
+// #872: Anti-pattern enriched with typed motif indicators
+export interface TypedAntiPattern {
+  name: string;
+  severity: 'critical' | 'warning' | 'info';
+  description: string;
+  affectedNodes: string[];
+  /** Typed motif keys that triggered this anti-pattern */
+  typedIndicators: string[];
+}
+
+// #872: Per-label health breakdown entry
+export interface LabelHealthBreakdown {
+  nodeCount: number;
+  avgDegree: number;
+  /** Proportion of overall health score attributable to this label type (0–1) */
+  healthContribution: number;
+}
+
+// #872: Typed architecture health result — extends base health with typed anti-patterns
+export interface TypedArchitectureHealth extends ArchitectureHealth {
+  /** Anti-patterns enriched with typed motif information */
+  typedAntiPatterns: TypedAntiPattern[];
+  /** Per-label-type health breakdown (e.g., Class cohesion, Module modularity) */
+  labelBreakdown: Record<string, LabelHealthBreakdown>;
+}
+
+// #872: Edge entry in the typed adjacency map
+interface TypedEdge {
+  target: string;
+  type: string;
+}
+
+// #872: Typed adjacency map — node ID → list of outgoing typed edges
+export type TypedAdjMap = Map<string, TypedEdge[]>;
+
+// #872: Node label map — node ID → label string
+export type NodeLabelMap = Map<string, string>;
+
+/**
+ * Score architecture health using typed graphlet data.
+ *
+ * Computes base health metrics via {@link scoreArchitectureHealth}, then
+ * enriches the result with typed anti-patterns that leverage node labels
+ * (Class, Function, Method, Interface, Module) and relationship types
+ * (CALLS, EXTENDS, IMPORTS, HAS_METHOD, HAS_PROPERTY) for precise detection.
+ *
+ * @param profile       Untyped graphlet profile from countGraphlets()
+ * @param typedProfile  Typed motif summary (composite key → count)
+ * @param communities   Community membership data
+ * @param adjMap        Optional untyped adjacency map (for base health)
+ * @param nodeLabels    Optional node ID → label mapping
+ * @param typedAdjMap   Optional typed adjacency map for label-aware detection
+ * @returns             Typed architecture health with enriched anti-patterns
+ */
+// #872: Main typed health scoring entry point
+export function scoreTypedArchitectureHealth(
+  profile: GraphletProfile,
+  typedProfile: TypedMotifSummary,
+  communities: CommunityInfo[],
+  adjMap?: Map<string, Set<string>>,
+  nodeLabels?: NodeLabelMap,
+  typedAdjMap?: TypedAdjMap,
+): TypedArchitectureHealth {
+  // ── Base health (reuse existing logic) ──────────────────────────────────
+  const baseHealth = scoreArchitectureHealth(profile, communities, adjMap);
+
+  // Edge case: no typed data available
+  if (!nodeLabels || nodeLabels.size === 0 || !typedAdjMap || typedAdjMap.size === 0) {
+    return {
+      ...baseHealth,
+      typedAntiPatterns: baseHealth.antiPatterns.map((ap) => ({
+        ...ap,
+        typedIndicators: [],
+      })),
+      labelBreakdown: {},
+    };
+  }
+
+  // ── Typed anti-pattern detection ────────────────────────────────────────
+
+  const typedAntiPatterns: TypedAntiPattern[] = [];
+
+  // #872: Build per-node degree maps keyed by edge type for efficient lookup
+  const callsDegree = new Map<string, number>();
+  const hasPropertyDegree = new Map<string, number>();
+  const hasMethodDegree = new Map<string, number>();
+  const extendsDegree = new Map<string, number>();
+  const importsDegree = new Map<string, number>();
+
+  for (const [nodeId, edges] of typedAdjMap) {
+    let calls = 0;
+    let hasProp = 0;
+    let hasMeth = 0;
+    let ext = 0;
+    let imp = 0;
+    for (const edge of edges) {
+      switch (edge.type) {
+        case 'CALLS': calls++; break;
+        case 'HAS_PROPERTY': hasProp++; break;
+        case 'HAS_METHOD': hasMeth++; break;
+        case 'EXTENDS': ext++; break;
+        case 'IMPORTS': imp++; break;
+      }
+    }
+    if (calls > 0) callsDegree.set(nodeId, calls);
+    if (hasProp > 0) hasPropertyDegree.set(nodeId, hasProp);
+    if (hasMeth > 0) hasMethodDegree.set(nodeId, hasMeth);
+    if (ext > 0) extendsDegree.set(nodeId, ext);
+    if (imp > 0) importsDegree.set(nodeId, imp);
+  }
+
+  // ── God Controller ─────────────────────────────────────────────────────
+  // Class nodes with CALLS degree > 15 to Functions/Methods
+
+  const GOD_CONTROLLER_THRESHOLD = 15;
+  for (const [nodeId, deg] of callsDegree) {
+    const label = nodeLabels.get(nodeId);
+    if (label === 'Class' && deg > GOD_CONTROLLER_THRESHOLD) {
+      // Verify targets are Functions/Methods
+      const edges = typedAdjMap.get(nodeId) ?? [];
+      const targetLabels = new Set<string>();
+      for (const edge of edges) {
+        if (edge.type === 'CALLS') {
+          const targetLabel = nodeLabels.get(edge.target);
+          if (targetLabel === 'Function' || targetLabel === 'Method') {
+            targetLabels.add(targetLabel);
+          }
+        }
+      }
+      if (targetLabels.size > 0) {
+        typedAntiPatterns.push({
+          name: 'God Controller',
+          severity: deg > 30 ? 'critical' : 'warning',
+          description: `Class "${nodeId}" calls ${deg} functions/methods (threshold: ${GOD_CONTROLLER_THRESHOLD}). Consider splitting responsibilities into smaller, focused classes.`,
+          affectedNodes: [nodeId],
+          typedIndicators: [`Class→CALLS→${deg}`, ...Array.from(targetLabels, (l) => `calls:${l}`)],
+        });
+      }
+    }
+  }
+
+  // ── Data Class ─────────────────────────────────────────────────────────
+  // Class nodes with high HAS_PROPERTY but near-zero CALLS (anemic data holders)
+
+  const DATA_CLASS_PROPERTY_THRESHOLD = 5;
+  for (const [nodeId, propDeg] of hasPropertyDegree) {
+    const label = nodeLabels.get(nodeId);
+    if (label === 'Class' && propDeg >= DATA_CLASS_PROPERTY_THRESHOLD) {
+      const callDeg = callsDegree.get(nodeId) ?? 0;
+      if (callDeg <= 1) {
+        typedAntiPatterns.push({
+          name: 'Data Class',
+          severity: propDeg > 10 ? 'warning' : 'info',
+          description: `Class "${nodeId}" has ${propDeg} properties but only ${callDeg} outgoing calls. This anemic data holder may indicate missing behavior encapsulation.`,
+          affectedNodes: [nodeId],
+          typedIndicators: [`Class→HAS_PROPERTY→${propDeg}`, `Class→CALLS→${callDeg}`],
+        });
+      }
+    }
+  }
+
+  // ── Interface Bloat ────────────────────────────────────────────────────
+  // Interface nodes with HAS_METHOD count > 10
+
+  const INTERFACE_BLOAT_THRESHOLD = 10;
+  for (const [nodeId, methDeg] of hasMethodDegree) {
+    const label = nodeLabels.get(nodeId);
+    if (label === 'Interface' && methDeg > INTERFACE_BLOAT_THRESHOLD) {
+      typedAntiPatterns.push({
+        name: 'Interface Bloat',
+        severity: methDeg > 20 ? 'critical' : 'warning',
+        description: `Interface "${nodeId}" declares ${methDeg} methods (threshold: ${INTERFACE_BLOAT_THRESHOLD}). Consider splitting into smaller, cohesive interfaces.`,
+        affectedNodes: [nodeId],
+        typedIndicators: [`Interface→HAS_METHOD→${methDeg}`],
+      });
+    }
+  }
+
+  // ── Import Cycle ───────────────────────────────────────────────────────
+  // Cycle motifs where edges are IMPORTS type between Module nodes
+
+  const importCycleKeys = Object.entries(typedProfile)
+    .filter(([key, count]) => key.includes('IMPORTS') && key.includes('cycle') && count > 0);
+  if (importCycleKeys.length > 0) {
+    const totalCycles = importCycleKeys.reduce((sum, [, count]) => sum + count, 0);
+    typedAntiPatterns.push({
+      name: 'Import Cycle',
+      severity: totalCycles > 5 ? 'critical' : 'warning',
+      description: `Detected ${totalCycles} import cycle motif(s) between modules. Circular imports can cause initialization order issues and increase build times.`,
+      affectedNodes: [],
+      typedIndicators: importCycleKeys.map(([key]) => key),
+    });
+  }
+
+  // ── Deep Inheritance ───────────────────────────────────────────────────
+  // Chain motifs > 4 levels of EXTENDS between Class nodes
+
+  const DEEP_INHERITANCE_DEPTH = 4;
+  const extendsChainKeys = Object.entries(typedProfile)
+    .filter(([key, count]) => key.includes('EXTENDS') && key.includes('chain') && count > 0);
+  if (extendsChainKeys.length > 0) {
+    // Walk EXTENDS chains to find nodes with depth > threshold
+    const visited = new Set<string>();
+    const classNodes = new Set<string>();
+    for (const [nodeId, label] of nodeLabels) {
+      if (label === 'Class') classNodes.add(nodeId);
+    }
+
+    for (const startNode of classNodes) {
+      if (visited.has(startNode)) continue;
+      const chain: string[] = [];
+      let current: string | undefined = startNode;
+      while (current && classNodes.has(current) && !visited.has(current)) {
+        visited.add(current);
+        chain.push(current);
+        const edges = typedAdjMap.get(current);
+        current = undefined;
+        if (edges) {
+          for (const edge of edges) {
+            if (edge.type === 'EXTENDS' && classNodes.has(edge.target)) {
+              current = edge.target;
+              break;
+            }
+          }
+        }
+      }
+      if (chain.length > DEEP_INHERITANCE_DEPTH) {
+        typedAntiPatterns.push({
+          name: 'Deep Inheritance',
+          severity: chain.length > 6 ? 'critical' : 'warning',
+          description: `Inheritance chain of depth ${chain.length} detected (threshold: ${DEEP_INHERITANCE_DEPTH}). Deep hierarchies increase cognitive load and fragility. Consider composition over inheritance.`,
+          affectedNodes: chain,
+          typedIndicators: [`Class→EXTENDS→chain:${chain.length}`],
+        });
+      }
+    }
+  }
+
+  // ── Shotgun Surgery ────────────────────────────────────────────────────
+  // High cross-community CALLS edges (functions in many communities calling each other)
+
+  if (communities.length > 1) {
+    // Infer cross-community calls from typed adjacency structure.
+    // Community membership is approximated by first path component in node IDs
+    // since CommunityInfo only provides aggregate node counts, not member IDs.
+    let crossCommunityCalls = 0;
+    let totalCalls = 0;
+    for (const [nodeId, edges] of typedAdjMap) {
+      const srcLabel = nodeLabels.get(nodeId);
+      if (srcLabel === 'Function' || srcLabel === 'Method') {
+        for (const edge of edges) {
+          if (edge.type === 'CALLS') {
+            totalCalls++;
+            const tgtLabel = nodeLabels.get(edge.target);
+            if (tgtLabel === 'Function' || tgtLabel === 'Method') {
+              // Approximate cross-community: different module prefix in ID
+              const srcModule = nodeId.split('/')[0] ?? nodeId;
+              const tgtModule = edge.target.split('/')[0] ?? edge.target;
+              if (srcModule !== tgtModule) {
+                crossCommunityCalls++;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    const crossCommunityRatio = totalCalls > 0 ? crossCommunityCalls / totalCalls : 0;
+    if (crossCommunityRatio > 0.3 && totalCalls > 20) {
+      typedAntiPatterns.push({
+        name: 'Shotgun Surgery',
+        severity: crossCommunityRatio > 0.5 ? 'critical' : 'warning',
+        description: `${(crossCommunityRatio * 100).toFixed(1)}% of function/method calls cross module boundaries (${crossCommunityCalls}/${totalCalls}). Changes to one module are likely to require changes in many others.`,
+        affectedNodes: [],
+        typedIndicators: [
+          `cross-community-calls:${crossCommunityCalls}`,
+          `calls-ratio:${crossCommunityRatio.toFixed(3)}`,
+        ],
+      });
+    }
+  }
+
+  // ── Label breakdown ────────────────────────────────────────────────────
+
+  const labelStats = new Map<string, { count: number; totalDegree: number }>();
+  for (const [nodeId, label] of nodeLabels) {
+    const existing = labelStats.get(label);
+    const degree = adjMap?.get(nodeId)?.size ?? typedAdjMap.get(nodeId)?.length ?? 0;
+    if (existing) {
+      existing.count++;
+      existing.totalDegree += degree;
+    } else {
+      labelStats.set(label, { count: 1, totalDegree: degree });
+    }
+  }
+
+  const labelBreakdown: Record<string, LabelHealthBreakdown> = {};
+  const totalLabeledNodes = Array.from(labelStats.values()).reduce((s, v) => s + v.count, 0);
+
+  for (const [label, stats] of labelStats) {
+    const avgDegree = stats.count > 0 ? stats.totalDegree / stats.count : 0;
+    // Health contribution: fraction of total nodes this label represents,
+    // weighted by inverse avgDegree (lower degree = healthier per-label)
+    const degreePenalty = Math.min(1, avgDegree / 20); // normalize against threshold
+    const healthContribution = totalLabeledNodes > 0
+      ? (stats.count / totalLabeledNodes) * (1 - degreePenalty * 0.5)
+      : 0;
+
+    labelBreakdown[label] = {
+      nodeCount: stats.count,
+      avgDegree: Math.round(avgDegree * 1000) / 1000,
+      healthContribution: Math.round(healthContribution * 1000) / 1000,
+    };
+  }
+
+  // ── Re-score with typed anti-patterns ──────────────────────────────────
+
+  let adjustedScore = baseHealth.overallScore;
+  for (const ap of typedAntiPatterns) {
+    switch (ap.severity) {
+      case 'critical': adjustedScore -= 8; break;
+      case 'warning': adjustedScore -= 4; break;
+      case 'info': adjustedScore -= 1; break;
+    }
+  }
+
+  return {
+    ...baseHealth,
+    overallScore: Math.max(0, Math.min(100, Math.round(adjustedScore))),
+    typedAntiPatterns,
+    labelBreakdown,
+  };
+}

--- a/packages/core/src/analysis/graphlet/typed-patterns.ts
+++ b/packages/core/src/analysis/graphlet/typed-patterns.ts
@@ -1,0 +1,499 @@
+/**
+ * Graphlet Analysis — Typed architectural pattern detection (#872).
+ *
+ * Extends untyped graphlet pattern detection with type-aware motif profiles.
+ * Typed motif keys (e.g. "Class:CALLS:Function") enable richer, more specific
+ * pattern detection such as controller-fat, callback-hell, and circular imports.
+ */
+
+import type { GraphletProfile } from './counter.js';
+import type { ArchitecturePattern } from './patterns.js';
+
+// #872: Typed motif key — e.g. "Class:CALLS:Function", "Module:IMPORTS:Module"
+export type TypedMotifKey = `${string}:${string}:${string}`;
+
+/** Typed motif summary — maps typed motif keys to their occurrence counts */
+export type TypedMotifSummary = Record<TypedMotifKey, number>;
+
+// #872: Typed architectural pattern — extends untyped pattern with typed indicators
+export interface TypedArchitecturePattern extends ArchitecturePattern {
+  /** Typed motif keys that triggered this detection */
+  typedIndicators: TypedMotifKey[];
+}
+
+// ── Thresholds ──────────────────────────────────────────────────────────────
+
+/** Minimum total typed entries before relying on typed analysis */
+const TYPED_THRESHOLD = 5;
+/** Star motif count threshold for "high star" detection */
+const STAR_HIGH = 6;
+/** Diamond motif count threshold for "high diamond" detection */
+const DIAMOND_HIGH = 4;
+/** Chain motif count threshold for "high chain" detection */
+const CHAIN_HIGH = 8;
+/** Cycle motif count threshold for "high cycle" detection */
+const CYCLE_HIGH = 3;
+/** Interface method count threshold for segregation violation */
+const INTERFACE_METHOD_LIMIT = 8;
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Sum all values in a typed motif summary.
+ * Returns 0 for empty or undefined summaries.
+ */
+function typedTotal(summary: TypedMotifSummary): number {
+  let total = 0;
+  for (const val of Object.values(summary)) {
+    total += val;
+  }
+  return total;
+}
+
+/**
+ * Extract motif keys matching a prefix pattern (e.g. "Class:CALLS:").
+ * Returns matching keys sorted by count descending.
+ */
+function keysWithPrefix(summary: TypedMotifSummary, prefix: string): TypedMotifKey[] {
+  const entries = Object.entries(summary)
+    .filter(([key]) => key.startsWith(prefix))
+    .sort(([, a], [, b]) => b - a);
+  return entries.map(([key]) => key as TypedMotifKey);
+}
+
+/**
+ * Sum counts for all keys matching a prefix.
+ */
+function sumPrefix(summary: TypedMotifSummary, prefix: string): number {
+  let sum = 0;
+  for (const [key, val] of Object.entries(summary)) {
+    if (key.startsWith(prefix)) {
+      sum += val;
+    }
+  }
+  return sum;
+}
+
+/**
+ * Sum counts for all keys matching a regex.
+ */
+function sumMatching(summary: TypedMotifSummary, pattern: RegExp): number {
+  let sum = 0;
+  for (const [key, val] of Object.entries(summary)) {
+    if (pattern.test(key)) {
+      sum += val;
+    }
+  }
+  return sum;
+}
+
+// ── Typed pattern detectors ─────────────────────────────────────────────────
+
+/**
+ * Detect Controller-Fat pattern: high star motifs where a Class calls many
+ * Functions or Methods — a "fat controller" anti-pattern.
+ */
+function detectControllerFat(summary: TypedMotifSummary): TypedArchitecturePattern | null {
+  const classCallsFn = sumPrefix(summary, 'Class:CALLS:');
+  const classCallsMethod = sumPrefix(summary, 'Class:CALLS:Method');
+  const total = classCallsFn + classCallsMethod;
+
+  if (total < STAR_HIGH) return null;
+
+  const indicators = keysWithPrefix(summary, 'Class:CALLS:');
+  const confidence = Math.min(1, total / (STAR_HIGH * 3));
+
+  return {
+    name: 'Controller-Fat',
+    confidence,
+    description: `Classes calling many functions/methods (star motif). ` +
+      `${total} outgoing Class→Function/Method edges suggest fat controllers that should be decomposed.`,
+    indicators: [
+      `Class:CALLS star count: ${total} (threshold: ${STAR_HIGH})`,
+      ...indicators.slice(0, 5).map(k => `${k}: ${summary[k]}`),
+    ],
+    typedIndicators: indicators,
+  };
+}
+
+/**
+ * Detect Data-Clump pattern: high diamond motifs where the same label quartet
+ * repeats — e.g. Class:USES:Class edges forming convergent-divergent patterns.
+ */
+function detectDataClump(summary: TypedMotifSummary): TypedArchitecturePattern | null {
+  // Look for repeated same-label diamond patterns (A:USES:B, A:USES:B again)
+  const usesEdges = sumPrefix(summary, 'Class:USES:');
+  const classDiamond = sumMatching(summary, /^Class:USES:Class/);
+
+  if (classDiamond < DIAMOND_HIGH && usesEdges < DIAMOND_HIGH) return null;
+
+  const indicators = keysWithPrefix(summary, 'Class:USES:');
+  const confidence = Math.min(1, (classDiamond + usesEdges) / (DIAMOND_HIGH * 2));
+
+  return {
+    name: 'Data-Clump',
+    confidence,
+    description: `Diamond-shaped data dependency patterns detected. ` +
+      `${classDiamond} Class→Class USES edges forming diamond motifs suggest data clumps — ` +
+      `groups of data always passed together that should be encapsulated.`,
+    indicators: [
+      `Class:USES:Class diamond count: ${classDiamond}`,
+      `Class:USES total: ${usesEdges}`,
+    ],
+    typedIndicators: indicators,
+  };
+}
+
+/**
+ * Detect Inheritance-Deep pattern: high chain motifs in Class:EXTENDS:Class
+ * patterns indicating deep inheritance hierarchies.
+ */
+function detectInheritanceDeep(summary: TypedMotifSummary): TypedArchitecturePattern | null {
+  const extendsChains = sumPrefix(summary, 'Class:EXTENDS:');
+
+  if (extendsChains < CHAIN_HIGH) return null;
+
+  const indicators = keysWithPrefix(summary, 'Class:EXTENDS:');
+  const confidence = Math.min(1, extendsChains / (CHAIN_HIGH * 2));
+
+  return {
+    name: 'Inheritance-Deep',
+    confidence,
+    description: `Deep inheritance chains detected via Class:EXTENDS edges. ` +
+      `${extendsChains} extend chains suggest hierarchies deeper than 3 levels, ` +
+      `which increase coupling and make changes harder to trace.`,
+    indicators: [
+      `Class:EXTENDS chain count: ${extendsChains} (threshold: ${CHAIN_HIGH})`,
+    ],
+    typedIndicators: indicators,
+  };
+}
+
+/**
+ * Detect Callback-Hell pattern: high chain motifs in Function:CALLS:Function
+ * patterns indicating deeply nested or chained function calls.
+ */
+function detectCallbackHell(summary: TypedMotifSummary): TypedArchitecturePattern | null {
+  const fnCallsFn = sumPrefix(summary, 'Function:CALLS:Function');
+  const fnCallsMethod = sumPrefix(summary, 'Function:CALLS:Method');
+  const methodCallsFn = sumPrefix(summary, 'Method:CALLS:Function');
+  const methodCallsMethod = sumPrefix(summary, 'Method:CALLS:Method');
+  const total = fnCallsFn + fnCallsMethod + methodCallsFn + methodCallsMethod;
+
+  if (total < CHAIN_HIGH) return null;
+
+  const indicators: TypedMotifKey[] = [
+    ...keysWithPrefix(summary, 'Function:CALLS:'),
+    ...keysWithPrefix(summary, 'Method:CALLS:'),
+  ];
+  const confidence = Math.min(1, total / (CHAIN_HIGH * 3));
+
+  return {
+    name: 'Callback-Hell',
+    confidence,
+    description: `Long call chains detected among functions and methods. ` +
+      `${total} Function/Method→Function/Method chains suggest deeply nested ` +
+      `or sequential callback patterns that reduce readability.`,
+    indicators: [
+      `Function:CALLS:Function: ${fnCallsFn}`,
+      `Function:CALLS:Method: ${fnCallsMethod}`,
+      `Method:CALLS:Function: ${methodCallsFn}`,
+      `Method:CALLS:Method: ${methodCallsMethod}`,
+    ],
+    typedIndicators: indicators.slice(0, 10),
+  };
+}
+
+/**
+ * Detect Interface-Segregation-Violation: high star motifs with
+ * Interface:HAS_METHOD:Method where the interface center has too many methods.
+ */
+function detectInterfaceSegregation(summary: TypedMotifSummary): TypedArchitecturePattern | null {
+  const hasMethodCount = sumPrefix(summary, 'Interface:HAS_METHOD:');
+
+  if (hasMethodCount < INTERFACE_METHOD_LIMIT) return null;
+
+  const indicators = keysWithPrefix(summary, 'Interface:HAS_METHOD:');
+  const confidence = Math.min(1, hasMethodCount / (INTERFACE_METHOD_LIMIT * 2));
+
+  return {
+    name: 'Interface-Segregation-Violation',
+    confidence,
+    description: `Interfaces with too many methods detected. ` +
+      `${hasMethodCount} Interface:HAS_METHOD edges suggest interfaces with ` +
+      `>${INTERFACE_METHOD_LIMIT} methods, violating the Interface Segregation Principle.`,
+    indicators: [
+      `Interface:HAS_METHOD count: ${hasMethodCount} (threshold: ${INTERFACE_METHOD_LIMIT})`,
+    ],
+    typedIndicators: indicators,
+  };
+}
+
+/**
+ * Detect Circular-Import pattern: high cycle motifs in Module:IMPORTS:Module
+ * patterns indicating circular dependency chains between modules.
+ */
+function detectCircularImport(summary: TypedMotifSummary): TypedArchitecturePattern | null {
+  const importCycles = sumPrefix(summary, 'Module:IMPORTS:');
+
+  if (importCycles < CYCLE_HIGH) return null;
+
+  const indicators = keysWithPrefix(summary, 'Module:IMPORTS:');
+  const confidence = Math.min(1, importCycles / (CYCLE_HIGH * 2));
+
+  return {
+    name: 'Circular-Import',
+    confidence,
+    description: `Circular import patterns detected via Module:IMPORTS edges. ` +
+      `${importCycles} import edges forming cycle motifs indicate circular dependencies ` +
+      `between modules that can cause build and initialization issues.`,
+    indicators: [
+      `Module:IMPORTS cycle count: ${importCycles} (threshold: ${CYCLE_HIGH})`,
+    ],
+    typedIndicators: indicators,
+  };
+}
+
+/**
+ * Detect Cross-Cutting-Concern pattern: high star motifs where edges are
+ * DECORATES or USES types — indicating concerns spread across many modules.
+ */
+function detectCrossCuttingConcern(summary: TypedMotifSummary): TypedArchitecturePattern | null {
+  const decoratesEdges = sumMatching(summary, /:DECORATES:/);
+  const usesEdges = sumMatching(summary, /:USES:/);
+  const total = decoratesEdges + usesEdges;
+
+  if (total < STAR_HIGH) return null;
+
+  const decoratesKeys = Object.keys(summary)
+    .filter(k => k.includes(':DECORATES:'))
+    .sort((a, b) => summary[b as TypedMotifKey] - summary[a as TypedMotifKey])
+    .map(k => k as TypedMotifKey);
+  const usesKeys = Object.keys(summary)
+    .filter(k => k.includes(':USES:'))
+    .sort((a, b) => summary[b as TypedMotifKey] - summary[a as TypedMotifKey])
+    .map(k => k as TypedMotifKey);
+
+  const indicators = [...decoratesKeys, ...usesKeys];
+  const confidence = Math.min(1, total / (STAR_HIGH * 2));
+
+  return {
+    name: 'Cross-Cutting-Concern',
+    confidence,
+    description: `Cross-cutting concerns detected via DECORATES and USES star motifs. ` +
+      `${decoratesEdges} DECORATES edges and ${usesEdges} USES edges spread across ` +
+      `multiple node types suggest concerns not properly modularized.`,
+    indicators: [
+      `DECORATES edges: ${decoratesEdges}`,
+      `USES edges: ${usesEdges}`,
+    ],
+    typedIndicators: indicators.slice(0, 10),
+  };
+}
+
+// ── Main detection ──────────────────────────────────────────────────────────
+
+/**
+ * Detect architectural patterns from typed graphlet profiles.
+ *
+ * Runs type-aware pattern detection for richer results, then falls back to
+ * untyped pattern detection when typed data is sparse. Results are sorted by
+ * confidence descending.
+ *
+ * @param typedProfile - Typed motif summary (e.g. {"Class:CALLS:Function": 12})
+ * @param untypedProfile - Standard graphlet profile for fallback detection
+ * @returns Typed architectural patterns sorted by confidence
+ */
+// #872: Main typed pattern detection entry point
+export function detectTypedPatterns(
+  typedProfile: TypedMotifSummary,
+  untypedProfile: GraphletProfile,
+): TypedArchitecturePattern[] {
+  const patterns: TypedArchitecturePattern[] = [];
+  const hasTypedData = typedTotal(typedProfile) >= TYPED_THRESHOLD;
+
+  // Run typed detectors when we have enough data
+  if (hasTypedData) {
+    const typedDetectors = [
+      detectControllerFat,
+      detectDataClump,
+      detectInheritanceDeep,
+      detectCallbackHell,
+      detectInterfaceSegregation,
+      detectCircularImport,
+      detectCrossCuttingConcern,
+    ];
+
+    for (const detector of typedDetectors) {
+      const result = detector(typedProfile);
+      if (result !== null) {
+        patterns.push(result);
+      }
+    }
+  }
+
+  // Fallback: run untyped pattern detection when typed data is sparse
+  // or to supplement typed results
+  const untypedTotal = untypedProfile.motif3.empty + untypedProfile.motif3.oneEdge
+    + untypedProfile.motif3.twoEdge + untypedProfile.motif3.triangle
+    + untypedProfile.motif4.chain + untypedProfile.motif4.star
+    + untypedProfile.motif4.diamond + untypedProfile.motif4.cycle
+    + untypedProfile.motif4.clique;
+
+  if (!hasTypedData || untypedTotal > 0) {
+    // Import detectPatterns lazily via dynamic pattern matching
+    // to avoid circular dependency issues
+    const untypedPatterns = computeUntypedFallback(untypedProfile);
+    for (const p of untypedPatterns) {
+      // Don't duplicate patterns already detected via typed analysis
+      const alreadyDetected = patterns.some(tp => tp.name === p.name);
+      if (!alreadyDetected) {
+        patterns.push({
+          ...p,
+          typedIndicators: [],
+        });
+      }
+    }
+  }
+
+  // Sort by confidence descending
+  patterns.sort((a, b) => b.confidence - a.confidence);
+
+  // If no pattern matched, return generic
+  if (patterns.length === 0) {
+    patterns.push({
+      name: 'No dominant pattern',
+      confidence: 0.5,
+      description: 'Typed graphlet distribution does not strongly match any known pattern. ' +
+        'The codebase may use a mixed or unconventional structure.',
+      indicators: ['no dominant typed motif class'],
+      typedIndicators: [],
+    });
+  }
+
+  return patterns;
+}
+
+// ── Untyped fallback (inline to avoid circular import) ──────────────────────
+
+/**
+ * Compute untyped architectural patterns from a graphlet profile.
+ *
+ * This is an inline version of the untyped pattern detection logic to avoid
+ * circular imports while providing fallback detection when typed data is sparse.
+ */
+// #872: Inline untyped fallback (mirrors patterns.ts logic)
+function computeUntypedFallback(profile: GraphletProfile): ArchitecturePattern[] {
+  const patterns: ArchitecturePattern[] = [];
+  const total3 = profile.motif3.empty + profile.motif3.oneEdge
+    + profile.motif3.twoEdge + profile.motif3.triangle;
+  const total4 = profile.motif4.chain + profile.motif4.star
+    + profile.motif4.diamond + profile.motif4.cycle + profile.motif4.clique;
+
+  if (total3 === 0 && total4 === 0) {
+    return [{
+      name: 'Insufficient data',
+      confidence: 1,
+      description: 'Not enough graphlet motifs detected to determine architectural pattern.',
+      indicators: ['zero motifs found'],
+    }];
+  }
+
+  const triangleRatio = total3 > 0 ? profile.motif3.triangle / total3 : 0;
+  const chainRatio = total4 > 0 ? profile.motif4.chain / total4 : 0;
+  const starRatio = total4 > 0 ? profile.motif4.star / total4 : 0;
+  const diamondRatio = total4 > 0 ? profile.motif4.diamond / total4 : 0;
+  const cycleRatio = total4 > 0 ? profile.motif4.cycle / total4 : 0;
+  const cliqueRatio = total4 > 0 ? profile.motif4.clique / total4 : 0;
+  const twoEdgeRatio = total3 > 0 ? profile.motif3.twoEdge / total3 : 0;
+
+  if (chainRatio > 0.35 && starRatio < 0.3) {
+    patterns.push({
+      name: 'Layered',
+      confidence: Math.min(1, chainRatio * 1.5),
+      description: 'Layered architecture with sequential dependency chains.',
+      indicators: [
+        `chain ratio: ${(chainRatio * 100).toFixed(1)}% (high)`,
+        `star ratio: ${(starRatio * 100).toFixed(1)}% (low)`,
+      ],
+    });
+  }
+
+  if (starRatio > 0.3) {
+    patterns.push({
+      name: 'Microservices',
+      confidence: Math.min(1, starRatio * 1.5),
+      description: 'Hub-and-spoke dependency topology typical of microservice architectures.',
+      indicators: [`star ratio: ${(starRatio * 100).toFixed(1)}% (high)`],
+    });
+  }
+
+  if (starRatio > 0.2 && diamondRatio > 0.2) {
+    patterns.push({
+      name: 'Event-driven',
+      confidence: Math.min(1, (starRatio + diamondRatio) * 0.8),
+      description: 'Event-driven architecture with fan-out and fan-in patterns.',
+      indicators: [
+        `star ratio: ${(starRatio * 100).toFixed(1)}%`,
+        `diamond ratio: ${(diamondRatio * 100).toFixed(1)}%`,
+      ],
+    });
+  }
+
+  if (diamondRatio > 0.3 && starRatio < 0.25) {
+    patterns.push({
+      name: 'MVC / Layered with diamonds',
+      confidence: Math.min(1, diamondRatio * 1.3),
+      description: 'Diamond-shaped dependencies suggesting MVC or layered architecture.',
+      indicators: [`diamond ratio: ${(diamondRatio * 100).toFixed(1)}% (high)`],
+    });
+  }
+
+  if (triangleRatio > 0.3 || cliqueRatio > 0.2) {
+    patterns.push({
+      name: 'Monolithic',
+      confidence: Math.min(1, Math.max(triangleRatio, cliqueRatio) * 1.5),
+      description: 'Tightly coupled codebase with many inter-module dependencies.',
+      indicators: [
+        `triangle ratio: ${(triangleRatio * 100).toFixed(1)}%`,
+        `clique ratio: ${(cliqueRatio * 100).toFixed(1)}%`,
+      ],
+    });
+  }
+
+  if (total4 > 0 && starRatio > 0.1 && starRatio < 0.35
+    && chainRatio > 0.1 && chainRatio < 0.4
+    && cliqueRatio < 0.15 && cycleRatio < 0.2) {
+    const balance = 1 - Math.abs(starRatio - chainRatio);
+    patterns.push({
+      name: 'Modular',
+      confidence: Math.min(1, balance * 1.2),
+      description: 'Well-structured modular architecture with balanced dependency patterns.',
+      indicators: [
+        `star ratio: ${(starRatio * 100).toFixed(1)}%`,
+        `chain ratio: ${(chainRatio * 100).toFixed(1)}%`,
+        'balanced distribution',
+      ],
+    });
+  }
+
+  if (cycleRatio > 0.2) {
+    patterns.push({
+      name: 'Circular dependencies',
+      confidence: Math.min(1, cycleRatio * 2),
+      description: 'Significant number of 4-node cycles detected.',
+      indicators: [`cycle ratio: ${(cycleRatio * 100).toFixed(1)}% (high)`],
+    });
+  }
+
+  if (twoEdgeRatio > 0.6 && total3 > 10) {
+    patterns.push({
+      name: 'High coupling',
+      confidence: Math.min(1, twoEdgeRatio),
+      description: 'Predominance of 2-edge path motifs suggesting long dependency chains.',
+      indicators: [`2-edge path ratio: ${(twoEdgeRatio * 100).toFixed(1)}% (high)`],
+    });
+  }
+
+  return patterns;
+}

--- a/packages/core/tests/analysis/graphlet/semantic-graphlets.test.ts
+++ b/packages/core/tests/analysis/graphlet/semantic-graphlets.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Tests for semantic (typed) graphlet analysis (#872 Phase 3).
+ *
+ * Tests the typed counter, typed pattern detection, and typed health scoring.
+ * These modules extend the untyped graphlet system with node-label and
+ * relationship-type awareness for richer architectural analysis.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildTypedAdjacencyMap,
+  countTypedGraphlets,
+  emptyTypedProfile,
+} from '../../../src/analysis/graphlet/typed-counter.js';
+import type { TypedAdjacencyMap, TypedMotifKey, TypedGraphletProfile } from '../../../src/analysis/graphlet/typed-counter.js';
+import { detectTypedPatterns } from '../../../src/analysis/graphlet/typed-patterns.js';
+import type { TypedArchitecturePattern, TypedMotifSummary } from '../../../src/analysis/graphlet/typed-patterns.js';
+import { scoreTypedArchitectureHealth } from '../../../src/analysis/graphlet/typed-health.js';
+import type { TypedArchitectureHealth, TypedAntiPattern, LabelHealthBreakdown } from '../../../src/analysis/graphlet/typed-health.js';
+import type { GraphNode, GraphRelationship } from '@astrolabe-dev/shared';
+import { countGraphlets, buildAdjacencyMap } from '../../../src/analysis/graphlet/counter.js';
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+function makeNode(id: string, label: string): GraphNode {
+  return { id, label: label as GraphNode['label'], properties: { name: id } };
+}
+
+function makeRel(id: string, src: string, tgt: string, type: string, confidence = 1): GraphRelationship {
+  return { id, sourceId: src, targetId: tgt, type: type as GraphRelationship['type'], confidence, reason: 'test' };
+}
+
+// ── Typed Counter Tests ──────────────────────────────────────────────────────
+
+describe('Typed Counter', () => {
+  it('builds a typed adjacency map from graph data', () => {
+    const nodes = [
+      makeNode('svc:A', 'Class'),
+      makeNode('svc:B', 'Function'),
+      makeNode('svc:C', 'Interface'),
+    ];
+    const rels = [
+      makeRel('r1', 'svc:A', 'svc:B', 'CALLS'),
+      makeRel('r2', 'svc:C', 'svc:A', 'EXTENDS'),
+    ];
+
+    const { nodeLabels, typedAdj } = buildTypedAdjacencyMap(nodes, rels);
+
+    expect(nodeLabels.get('svc:A')).toBe('Class');
+    expect(nodeLabels.get('svc:B')).toBe('Function');
+    expect(nodeLabels.get('svc:C')).toBe('Interface');
+
+    // Undirected: A→B means A maps to B and B maps to A
+    expect(typedAdj.get('svc:A')?.get('svc:B')).toBeDefined();
+    expect(typedAdj.get('svc:B')?.get('svc:A')).toBeDefined();
+    expect(typedAdj.get('svc:C')?.get('svc:A')).toBeDefined();
+  });
+
+  it('ignores disallowed relationship types', () => {
+    const nodes = [
+      makeNode('n1', 'Function'),
+      makeNode('n2', 'Function'),
+    ];
+    const rels = [
+      makeRel('r1', 'n1', 'n2', 'CONTAINS'), // not in allowed set
+    ];
+
+    const { typedAdj } = buildTypedAdjacencyMap(nodes, rels);
+
+    // n1 should have no neighbors (CONTAINS is not in TYPED_ALLOWED_REL_TYPES)
+    expect(typedAdj.get('n1')?.size ?? 0).toBe(0);
+    expect(typedAdj.get('n2')?.size ?? 0).toBe(0);
+  });
+
+  it('counts typed 3-node motifs', () => {
+    const nodes = [
+      makeNode('A', 'Class'),
+      makeNode('B', 'Function'),
+      makeNode('C', 'Method'),
+    ];
+    const rels = [
+      makeRel('r1', 'A', 'B', 'CALLS'),
+      makeRel('r2', 'A', 'C', 'CALLS'),
+      makeRel('r3', 'B', 'C', 'CALLS'),
+    ];
+
+    const { nodeLabels, typedAdj } = buildTypedAdjacencyMap(nodes, rels);
+    const profile = countTypedGraphlets(nodes, typedAdj, nodeLabels);
+
+    expect(profile.nodeCount).toBe(3);
+    expect(profile.motif3.size).toBeGreaterThan(0);
+    // Should have a triangle motif with Class:Function:Method labels
+    expect(profile.edgeCount).toBeGreaterThanOrEqual(3);
+  });
+
+  it('returns empty profile for graph with fewer than 3 nodes', () => {
+    const nodes = [makeNode('A', 'Class'), makeNode('B', 'Function')];
+    const rels = [makeRel('r1', 'A', 'B', 'CALLS')];
+
+    const { nodeLabels, typedAdj } = buildTypedAdjacencyMap(nodes, rels);
+    const profile = countTypedGraphlets(nodes, typedAdj, nodeLabels);
+
+    expect(profile.nodeCount).toBe(2);
+    expect(profile.motif3.size).toBe(0);
+    expect(profile.motif4.size).toBe(0);
+  });
+
+  it('returns empty profile for empty graph', () => {
+    const profile = emptyTypedProfile(0, 0, false);
+    expect(profile.nodeCount).toBe(0);
+    expect(profile.motif3.size).toBe(0);
+    expect(profile.motif4.size).toBe(0);
+  });
+});
+
+// ── Typed Pattern Detection Tests ────────────────────────────────────────────
+
+describe('Typed Pattern Detection', () => {
+  it('detects Controller-Fat when Class has many CALLS to Functions', () => {
+    // Build a typed motif summary with many Class:CALLS:Function entries
+    const summary: TypedMotifSummary = {
+      'Class:CALLS:Function': 15,
+      'Class:CALLS:Method': 8,
+      'Module:IMPORTS:Module': 3,
+    };
+
+    // Use an untyped profile with high star ratio
+    const untypedProfile = {
+      motif3: { empty: 10, oneEdge: 20, twoEdge: 40, triangle: 30 },
+      motif4: { chain: 5, star: 20, diamond: 3, cycle: 2, clique: 1 },
+      nodeCount: 100,
+      edgeCount: 200,
+      sampled: false,
+    };
+
+    const patterns = detectTypedPatterns(summary, untypedProfile);
+    const ctrlFat = patterns.find((p) => p.name === 'Controller-Fat');
+    expect(ctrlFat).toBeDefined();
+    expect(ctrlFat!.confidence).toBeGreaterThan(0);
+    expect(ctrlFat!.typedIndicators.length).toBeGreaterThan(0);
+  });
+
+  it('detects Circular-Import when Module:IMPORTS:Module is high', () => {
+    const summary: TypedMotifSummary = {
+      'Module:IMPORTS:Module': 12,
+      'Class:CALLS:Function': 2,
+    };
+
+    const untypedProfile = {
+      motif3: { empty: 5, oneEdge: 10, twoEdge: 20, triangle: 5 },
+      motif4: { chain: 2, star: 3, diamond: 2, cycle: 8, clique: 0 },
+      nodeCount: 50,
+      edgeCount: 80,
+      sampled: false,
+    };
+
+    const patterns = detectTypedPatterns(summary, untypedProfile);
+    const circularImport = patterns.find((p) => p.name === 'Circular-Import');
+    expect(circularImport).toBeDefined();
+    expect(circularImport!.typedIndicators).toContain('Module:IMPORTS:Module');
+  });
+
+  it('returns fallback pattern when typed data is sparse', () => {
+    const summary: TypedMotifSummary = {
+      'Class:CALLS:Function': 1,
+    };
+
+    const untypedProfile = {
+      motif3: { empty: 50, oneEdge: 20, twoEdge: 20, triangle: 10 },
+      motif4: { chain: 10, star: 5, diamond: 3, cycle: 1, clique: 0 },
+      nodeCount: 100,
+      edgeCount: 150,
+      sampled: false,
+    };
+
+    const patterns = detectTypedPatterns(summary, untypedProfile);
+    // With sparse typed data, should fall back to untyped pattern detection
+    expect(patterns.length).toBeGreaterThan(0);
+  });
+});
+
+// ── Typed Health Scoring Tests ────────────────────────────────────────────────
+
+describe('Typed Health Scoring', () => {
+  it('computes base health metrics from untyped profile', () => {
+    const profile = {
+      motif3: { empty: 20, oneEdge: 15, twoEdge: 10, triangle: 5 },
+      motif4: { chain: 8, star: 4, diamond: 2, cycle: 1, clique: 0 },
+      nodeCount: 50,
+      edgeCount: 75,
+      sampled: false,
+    };
+    const communities = [
+      { id: 'c1', nodeCount: 20 },
+      { id: 'c2', nodeCount: 30 },
+    ];
+    const typedSummary: Record<string, number> = {
+      'Class:CALLS:Function': 5,
+    };
+    const nodeLabels = new Map<string, string>([
+      ['n1', 'Class'],
+      ['n2', 'Function'],
+    ]);
+    const typedAdj: Map<string, Array<{ target: string; type: string }>> = new Map([
+      ['n1', [{ target: 'n2', type: 'CALLS' }]],
+      ['n2', []],
+    ]);
+
+    // Signature: (profile, typedProfile, communities, adjMap?, nodeLabels?, typedAdjMap?)
+    const result = scoreTypedArchitectureHealth(profile, typedSummary, communities, undefined, nodeLabels, typedAdj);
+
+    expect(result.overallScore).toBeGreaterThanOrEqual(0);
+    expect(result.overallScore).toBeLessThanOrEqual(100);
+    expect(result.cohesion).toBeGreaterThanOrEqual(0);
+    expect(result.modularity).toBeGreaterThanOrEqual(0);
+    expect(result.complexity).toBeGreaterThanOrEqual(0);
+  });
+
+  it('detects God Controller anti-pattern', () => {
+    // 20 Functions calling a single Class → god controller
+    const nodes: GraphNode[] = [
+      makeNode('controller', 'Class'),
+      ...Array.from({ length: 20 }, (_, i) => makeNode(`fn${i}`, 'Function')),
+    ];
+    const rels: GraphRelationship[] = Array.from({ length: 20 }, (_, i) =>
+      makeRel(`r${i}`, `fn${i}`, 'controller', 'CALLS'),
+    );
+
+    const profile = {
+      motif3: { empty: 10, oneEdge: 5, twoEdge: 20, triangle: 5 },
+      motif4: { chain: 3, star: 10, diamond: 2, cycle: 1, clique: 0 },
+      nodeCount: 21,
+      edgeCount: 40,
+      sampled: false,
+    };
+    const communities = [{ id: 'c1', nodeCount: 21 }];
+    const typedSummary: Record<string, number> = {
+      'Class:CALLS:Function': 20,
+    };
+    const { nodeLabels, typedAdj: rawTypedAdj } = buildTypedAdjacencyMap(nodes, rels);
+
+    // Convert to the format expected by scoreTypedArchitectureHealth
+    const typedAdjMap: Map<string, Array<{ target: string; type: string }>> = new Map();
+    for (const [nodeId, neighbors] of rawTypedAdj) {
+      const edges: Array<{ target: string; type: string }> = [];
+      for (const [neighbor, relType] of neighbors) {
+        edges.push({ target: neighbor, type: relType });
+      }
+      typedAdjMap.set(nodeId, edges);
+    }
+
+    // Signature: (profile, typedProfile, communities, adjMap?, nodeLabels?, typedAdjMap?)
+    const result = scoreTypedArchitectureHealth(profile, typedSummary, communities, undefined, nodeLabels, typedAdjMap);
+
+    const godCtrl = result.typedAntiPatterns.find((ap) => ap.name === 'God Controller');
+    expect(godCtrl).toBeDefined();
+    expect(godCtrl!.severity).toBe('warning');
+  });
+
+  it('computes label breakdown for node types', () => {
+    const profile = {
+      motif3: { empty: 10, oneEdge: 5, twoEdge: 10, triangle: 5 },
+      motif4: { chain: 4, star: 2, diamond: 1, cycle: 0, clique: 0 },
+      nodeCount: 10,
+      edgeCount: 15,
+      sampled: false,
+    };
+    const communities = [{ id: 'c1', nodeCount: 10 }];
+    const typedSummary: Record<string, number> = {
+      'Class:CALLS:Function': 3,
+    };
+    const nodeLabels = new Map<string, string>([
+      ['n1', 'Class'],
+      ['n2', 'Class'],
+      ['n3', 'Function'],
+      ['n4', 'Method'],
+    ]);
+    const typedAdj: Map<string, Array<{ target: string; type: string }>> = new Map([
+      ['n1', [{ target: 'n3', type: 'CALLS' }]],
+      ['n2', [{ target: 'n4', type: 'CALLS' }]],
+      ['n3', []],
+      ['n4', []],
+    ]);
+
+    // Signature: (profile, typedProfile, communities, adjMap?, nodeLabels?, typedAdjMap?)
+    const result = scoreTypedArchitectureHealth(profile, typedSummary, communities, undefined, nodeLabels, typedAdj);
+
+    expect(Object.keys(result.labelBreakdown).length).toBeGreaterThan(0);
+    expect(result.labelBreakdown['Class']).toBeDefined();
+    expect(result.labelBreakdown['Class'].nodeCount).toBe(2);
+    expect(result.labelBreakdown['Function'].nodeCount).toBe(1);
+  });
+
+  it('returns empty typed anti-patterns for empty graph', () => {
+    const profile = {
+      motif3: { empty: 0, oneEdge: 0, twoEdge: 0, triangle: 0 },
+      motif4: { chain: 0, star: 0, diamond: 0, cycle: 0, clique: 0 },
+      nodeCount: 0,
+      edgeCount: 0,
+      sampled: false,
+    };
+    const communities: Array<{ id: string; nodeCount: number }> = [];
+    const typedSummary: Record<string, number> = {};
+    const nodeLabels = new Map<string, string>();
+    const typedAdj: Map<string, Array<{ target: string; type: string }>> = new Map();
+
+    const result = scoreTypedArchitectureHealth(profile, typedSummary, communities, undefined, nodeLabels, typedAdj);
+
+    expect(result.typedAntiPatterns).toEqual([]);
+    expect(result.overallScore).toBe(100);
+  });
+});


### PR DESCRIPTION
## Phase 3 — Semantic (Typed) Graphlets

Extends the graphlet analysis system with type-aware motif counting, pattern detection, and health scoring that considers node labels (Class, Function, Method, etc.) and relationship types (CALLS, IMPORTS, EXTENDS, etc.).

### New Files

**`packages/core/src/analysis/graphlet/typed-counter.ts`** (~495 lines)
- `TypedAdjacencyMap` — maps `(nodeId, neighborId) → relationshipType`
- `buildTypedAdjacencyMap()` — builds typed adjacency from `GraphNode[]` / `GraphRelationship[]`
- `countTypedGraphlets()` — counts 3-node and 4-node motifs with label+type keys
- `TypedMotifKey` — branded string key like `Class:Function:Method|CALLS-IMPORTS`
- `TypedGraphletProfile` — motif3/motif4 as `Map<TypedMotifKey, number>`
- Considers 8 relationship types: CALLS, IMPORTS, EXTENDS, IMPLEMENTS, USES, MEMBER_OF, HAS_METHOD, HAS_PROPERTY
- Same sampling strategy as untyped counter (threshold 1000, sample 500)

**`packages/core/src/analysis/graphlet/typed-patterns.ts`** (~499 lines)
- `detectTypedPatterns(typedProfile, untypedProfile)` — 7 type-aware detectors:
  1. **Controller-Fat** — Class with many CALLS to Functions/Methods
  2. **Data-Clump** — diamond motifs on Class:USES:Class
  3. **Inheritance-Deep** — chain motifs on Class:EXTENDS:*
  4. **Callback-Hell** — chain motifs on Function/Method:CALLS:*
  5. **Interface-Segregation-Violation** — Interface with >8 HAS_METHOD
  6. **Circular-Import** — cycle motifs on Module:IMPORTS:*
  7. **Cross-Cutting-Concern** — star motifs on DECORATES/USES edges
- Falls back to untyped pattern detection when typed data is sparse (<5 entries)

**`packages/core/src/analysis/graphlet/typed-health.ts`** (~351 lines)
- `scoreTypedArchitectureHealth()` — delegates base scoring to `scoreArchitectureHealth()`, then enriches:
  - 6 typed anti-patterns: God Controller, Data Class, Interface Bloat, Import Cycle, Deep Inheritance, Shotgun Surgery
  - Per-label health breakdown: `labelBreakdown[Class] = { nodeCount, avgDegree, healthContribution }`
- Delegates to existing `scoreArchitectureHealth()` for base metrics — no duplication

**`packages/core/tests/analysis/graphlet/semantic-graphlets.test.ts`** (312 lines)
- 12 tests: 5 for typed counter, 3 for typed patterns, 4 for typed health

**`packages/core/src/analysis/graphlet/index.ts`** — Updated barrel exports

### Architecture
- Extends (does not replace) existing untyped graphlet system
- Typed modules are standalone — no import from `web-tree-sitter`
- Compatible with existing `countGraphlets()`, `detectPatterns()`, `scoreArchitectureHealth()`

### Test Results
- 12/12 tests passing
- Build: clean across all workspaces

Part of #872