### PR TITLE
fix: increase Node heap to prevent integration test OOM (#851)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
       - run: npm run build --workspace packages/shared
       - run: npm run build --workspace packages/core
       - run: npm test -- --coverage
+        env:
+          NODE_OPTIONS: '--max-old-space-size=8192'
       - name: Upload coverage
         if: matrix.os == 'ubuntu-latest' && matrix.node-version == '20'
         uses: actions/upload-artifact@v4
@@ -87,6 +89,7 @@ jobs:
       - run: npm test
         env:
           ASTROLABE_INTEGRATION: '1'
+          NODE_OPTIONS: '--max-old-space-size=8192'
 
   coverage-report:
     name: Coverage Report

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -63,9 +63,12 @@ jobs:
       - run: npm run build --workspace packages/shared
       - run: npm run build --workspace packages/core
       - run: npm test
+        env:
+          NODE_OPTIONS: '--max-old-space-size=8192'
       - run: npm test
         env:
           ASTROLABE_INTEGRATION: '1'
+          NODE_OPTIONS: '--max-old-space-size=8192'
 
   # ── Build RC ────────────────────────────────────────────────────────────
   release-candidate:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,9 +86,12 @@ jobs:
       - run: npm run build --workspace packages/shared
       - run: npm run build --workspace packages/core
       - run: npm test
+        env:
+          NODE_OPTIONS: '--max-old-space-size=8192'
       - run: npm test
         env:
           ASTROLABE_INTEGRATION: '1'
+          NODE_OPTIONS: '--max-old-space-size=8192'
 
   # ── Publish stable release ─────────────────────────────────────────────
   release:


### PR DESCRIPTION
## Problem
Integration tests in CI/release pipelines OOM at ~4GB heap (default Node limit). The OOM'd release run (27304611588) crashed after 2+ hours with \FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory\ at 4052 MB.

## Fix
Add \NODE_OPTIONS: --max-old-space-size=8192\ to all \
pm test\ steps across:
- \elease.yml\ — integration test gate (the OOM crash site)
- \ci.yml\ — unit tests and integration tests
- \c.yml\ — integration tests

## Why 8GB
GitHub Actions \ubuntu-latest\ runners have 7GB RAM. Setting 8GB gives Node a generous ceiling while staying within runner limits — the OS will page if needed rather than hard-crashing. Actual test execution is only ~30s; the 2+ hour accumulation is vitest worker overhead that slowly leaks.

Refs #851