### PR TITLE
fix: increase Node heap to 8GB for integration tests (cherry-pick #894)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
       - run: npm run build --workspace packages/shared
       - run: npm run build --workspace packages/core
       - run: npm test -- --coverage
+        env:
+          NODE_OPTIONS: '--max-old-space-size=8192'
       - name: Upload coverage
         if: matrix.os == 'ubuntu-latest' && matrix.node-version == '20'
         uses: actions/upload-artifact@v4
@@ -87,6 +89,7 @@ jobs:
       - run: npm test
         env:
           ASTROLABE_INTEGRATION: '1'
+          NODE_OPTIONS: '--max-old-space-size=8192'
 
   coverage-report:
     name: Coverage Report

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -63,9 +63,12 @@ jobs:
       - run: npm run build --workspace packages/shared
       - run: npm run build --workspace packages/core
       - run: npm test
+        env:
+          NODE_OPTIONS: '--max-old-space-size=8192'
       - run: npm test
         env:
           ASTROLABE_INTEGRATION: '1'
+          NODE_OPTIONS: '--max-old-space-size=8192'
 
   # ── Build RC ────────────────────────────────────────────────────────────
   release-candidate:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,9 +86,12 @@ jobs:
       - run: npm run build --workspace packages/shared
       - run: npm run build --workspace packages/core
       - run: npm test
+        env:
+          NODE_OPTIONS: '--max-old-space-size=8192'
       - run: npm test
         env:
           ASTROLABE_INTEGRATION: '1'
+          NODE_OPTIONS: '--max-old-space-size=8192'
 
   # ── Publish stable release ─────────────────────────────────────────────
   release:


### PR DESCRIPTION
Cherry-pick of the OOM fix from #894 to main. The release pipeline (release.yml) integration tests OOM at ~4GB. This adds \NODE_OPTIONS: --max-old-space-size=8192\ to prevent the crash and unblock the v1.0.19 release.