### PR TITLE
feat: add BigQuery (GoogleSQL) language support (#940)

### DIFF
--- a/packages/core/src/analysis/languages/bigquery.ts
+++ b/packages/core/src/analysis/languages/bigquery.ts
@@ -1,0 +1,171 @@
+/**
+ * Astrolabe — BigQuery (GoogleSQL) language definition.
+ *
+ * Provides tree-sitter query patterns for extracting symbols and references
+ * from BigQuery SQL source files (.sql, .bqsql).
+ *
+ * Grammar: tree-sitter-sql-bigquery v0.8.0
+ *   Repository: github.com/takegue/tree-sitter-sql-bigquery
+ *   Status: 121/121 grammar tests pass, 115+ node types, MIT license
+ *   WASM: Compiled natively via emsdk 3.1.64 (emcc) from v0.8.0 sources
+ *
+ * Key grammar nodes used:
+ *   - create_table_statement.table_name     → Class (tables, views, mat. views)
+ *   - create_function_statement.routine_name → Function
+ *   - create_procedure_statement.routine_name → Function
+ *   - create_schema_statement.schema_name    → Namespace
+ *   - create_model_statement.model_name      → Class (ML models)
+ *   - function_call.function                 → CALLS edge
+ *   - from_item.table_name                   → Import edge (cross-file ref)
+ */
+
+import type { LanguageDefinition, QueryPattern } from '../language-definition.js';
+import { Language as WtsLanguage } from 'web-tree-sitter';
+import { resolve } from 'node:path';
+
+// ── Symbol query patterns ──────────────────────────────────────────────────
+
+const symbolPatterns: QueryPattern[] = [
+  // CREATE TABLE / VIEW / MATERIALIZED VIEW —
+  // all share create_table_statement node with kw('TABLE')|kw('VIEW')|kw('MATERIALIZED VIEW')
+  {
+    query: '(create_table_statement table_name: (identifier) @name) @definition.class',
+    captureLabels: { 'definition.class': 'Class' },
+    nameCapture: 'name',
+    outerCapture: 'definition.class',
+  },
+  // CREATE TABLE … LIKE …
+  {
+    query: '(create_table_like_statement table_name: (identifier) @name) @definition.class',
+    captureLabels: { 'definition.class': 'Class' },
+    nameCapture: 'name',
+    outerCapture: 'definition.class',
+  },
+  // CREATE TABLE … CLONE …
+  {
+    query: '(create_table_clone_statement table_name: (identifier) @name) @definition.class',
+    captureLabels: { 'definition.class': 'Class' },
+    nameCapture: 'name',
+    outerCapture: 'definition.class',
+  },
+  // CREATE TABLE … COPY …
+  {
+    query: '(create_table_copy_statement table_name: (identifier) @name) @definition.class',
+    captureLabels: { 'definition.class': 'Class' },
+    nameCapture: 'name',
+    outerCapture: 'definition.class',
+  },
+  // CREATE SNAPSHOT TABLE …
+  {
+    query: '(create_snapshot_table_statement table_name: (identifier) @name) @definition.class',
+    captureLabels: { 'definition.class': 'Class' },
+    nameCapture: 'name',
+    outerCapture: 'definition.class',
+  },
+  // CREATE EXTERNAL TABLE …
+  {
+    query: '(create_external_table_statement table_name: (identifier) @name) @definition.class',
+    captureLabels: { 'definition.class': 'Class' },
+    nameCapture: 'name',
+    outerCapture: 'definition.class',
+  },
+  // CREATE FUNCTION …
+  {
+    query: '(create_function_statement routine_name: (identifier) @name) @definition.function',
+    captureLabels: { 'definition.function': 'Function' },
+    nameCapture: 'name',
+    outerCapture: 'definition.function',
+  },
+  // CREATE REMOTE FUNCTION …
+  {
+    query: '(create_remote_function_statement routine_name: (identifier) @name) @definition.function',
+    captureLabels: { 'definition.function': 'Function' },
+    nameCapture: 'name',
+    outerCapture: 'definition.function',
+  },
+  // CREATE TABLE FUNCTION …
+  {
+    query: '(create_table_function_statement routine_name: (identifier) @name) @definition.function',
+    captureLabels: { 'definition.function': 'Function' },
+    nameCapture: 'name',
+    outerCapture: 'definition.function',
+  },
+  // CREATE PROCEDURE …
+  {
+    query: '(create_procedure_statement routine_name: (identifier) @name) @definition.function',
+    captureLabels: { 'definition.function': 'Function' },
+    nameCapture: 'name',
+    outerCapture: 'definition.function',
+  },
+  // CREATE SCHEMA …
+  {
+    query: '(create_schema_statement schema_name: (identifier) @name) @definition.namespace',
+    captureLabels: { 'definition.namespace': 'Namespace' },
+    nameCapture: 'name',
+    outerCapture: 'definition.namespace',
+  },
+  // CREATE MODEL …
+  {
+    query: '(create_model_statement model_name: (identifier) @name) @definition.class',
+    captureLabels: { 'definition.class': 'Class' },
+    nameCapture: 'name',
+    outerCapture: 'definition.class',
+  },
+];
+
+// ── Import / reference patterns ────────────────────────────────────────────
+
+const importPatterns: QueryPattern[] = [
+  // FROM clause table references — treat as cross-file references
+  // (from_item table_name: (identifier) @source)
+  {
+    query: '(from_item table_name: (identifier) @source) @import',
+    captureLabels: { 'import': 'Import' },
+    nameCapture: 'source',
+    outerCapture: 'import',
+    isImport: true,
+  },
+];
+
+// ── Call-site patterns ─────────────────────────────────────────────────────
+
+const callPatterns: QueryPattern[] = [
+  // function_call function: (identifier) @call_name
+  {
+    query: '(function_call function: (identifier) @call_name) @call_site',
+    captureLabels: {},
+    nameCapture: 'call_name',
+    outerCapture: 'call_site',
+  },
+];
+
+// ── Language definition ────────────────────────────────────────────────────
+
+export const bigqueryLanguage: LanguageDefinition = {
+  name: 'bigquery',
+  // .sql also maps to BigQuery as the first SQL dialect; future multi-dialect
+  // support will need heuristics or a --sql-dialect CLI flag (#940).
+  extensions: ['.sql', '.bqsql'],
+  wasmFile: 'tree-sitter-bigquery.wasm',
+
+  get symbolPatterns(): QueryPattern[] {
+    return symbolPatterns;
+  },
+
+  get importPatterns(): QueryPattern[] {
+    return importPatterns;
+  },
+
+  get callPatterns(): QueryPattern[] {
+    return callPatterns;
+  },
+
+  importSemantics: 'named',
+  // SQL has no method resolution order (no class inheritance)
+  mroStrategy: 'none',
+
+  async load(wasmDir: string): Promise<WtsLanguage> {
+    const wasmPath = resolve(wasmDir, this.wasmFile);
+    return WtsLanguage.load(wasmPath);
+  },
+};

--- a/packages/core/src/analysis/languages/index.ts
+++ b/packages/core/src/analysis/languages/index.ts
@@ -21,6 +21,7 @@ import { swiftLanguage } from './swift.js';
 import { cLanguage } from './c.js';
 import { cppLanguage } from './cpp.js';
 import { protobufLanguage } from './protobuf.js';
+import { bigqueryLanguage } from './bigquery.js';
 
 /**
  * All registered language definitions.
@@ -42,6 +43,7 @@ const allLanguages: LanguageDefinition[] = [
   cLanguage,
   cppLanguage,
   protobufLanguage,
+  bigqueryLanguage,
 ];
 
 /**

--- a/packages/core/tests/analysis/bigquery.test.ts
+++ b/packages/core/tests/analysis/bigquery.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for BigQuery (GoogleSQL) language parsing and symbol extraction.
+ *
+ * Verifies tree-sitter-sql-bigquery v0.8.0 WASM grammar integration:
+ * - DDL symbol extraction (CREATE TABLE / VIEW / FUNCTION / PROCEDURE / SCHEMA)
+ * - Function call extraction (CALLS edges)
+ * - FROM clause table reference extraction (Import edges)
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { initParser, resetParser, parseFile } from '../../src/analysis/parser.js';
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import type { FileParseResult } from '../../src/analysis/language-definition.js';
+
+// ── Test helpers ────────────────────────────────────────────────────────────
+
+const wasmDir = resolve(process.cwd(), 'wasm');
+let tmpDir: string;
+
+function hasWasm(file: string): boolean {
+  return existsSync(join(wasmDir, file));
+}
+
+function writeFixture(relativePath: string, content: string): string {
+  const fullPath = join(tmpDir, relativePath);
+  writeFileSync(fullPath, content, 'utf-8');
+  return fullPath;
+}
+
+function nl(...lines: string[]): string {
+  return lines.join('\n') + '\n';
+}
+
+/** Shorthand: parseFile with wasmDir baked in. */
+async function parse(path: string): Promise<FileParseResult> {
+  return parseFile(path, wasmDir);
+}
+
+// ── Setup / Teardown ────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'astrolabe-bigquery-test-'));
+  await initParser();
+}, 15000);
+
+afterAll(() => {
+  resetParser();
+  if (tmpDir && existsSync(tmpDir)) {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// ── Helper: extract symbol names from parse result ─────────────────────────
+
+function symbolNames(result: FileParseResult, label?: string): string[] {
+  return result.symbols
+    .filter((s) => !label || s.label === label)
+    .map((s) => s.name);
+}
+
+function importSources(result: FileParseResult): string[] {
+  return result.imports.map((i) => i.source);
+}
+
+function callSiteNames(result: FileParseResult): string[] {
+  return (result.callSites ?? []).map((c) => c.name);
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('BigQuery language support', () => {
+  it('WASM grammar file exists', () => {
+    expect(hasWasm('tree-sitter-bigquery.wasm')).toBe(true);
+  });
+
+  describe('file extension detection', () => {
+    it('parses .sql files as bigquery', async () => {
+      writeFixture('test.sql', nl('SELECT 1'));
+      const result = await parse(join(tmpDir, 'test.sql'));
+      expect(result.language).toBe('bigquery');
+      expect(result.error).toBeUndefined();
+    });
+
+    it('parses .bqsql files as bigquery', async () => {
+      writeFixture('test.bqsql', nl('SELECT 1'));
+      const result = await parse(join(tmpDir, 'test.bqsql'));
+      expect(result.language).toBe('bigquery');
+      expect(result.error).toBeUndefined();
+    });
+  });
+
+  describe('DDL symbol extraction', () => {
+    it('extracts CREATE TABLE as Class', async () => {
+      const path = writeFixture('ddl.sql', nl(
+        'CREATE TABLE users (',
+        '  id INT64,',
+        '  name STRING',
+        ');',
+      ));
+      const result = await parse(path);
+      expect(symbolNames(result, 'Class')).toContain('users');
+    });
+
+    it('extracts CREATE TABLE IF NOT EXISTS as Class', async () => {
+      const path = writeFixture('ddl.sql', nl(
+        'CREATE TABLE IF NOT EXISTS orders (',
+        '  id INT64,',
+        '  total NUMERIC',
+        ');',
+      ));
+      const result = await parse(path);
+      expect(symbolNames(result, 'Class')).toContain('orders');
+    });
+
+    it('extracts CREATE VIEW as Class', async () => {
+      const path = writeFixture('ddl.sql', nl(
+        'CREATE VIEW active_users AS',
+        'SELECT * FROM users WHERE active = true',
+      ));
+      const result = await parse(path);
+      // VIEW shares create_table_statement node → Class label
+      expect(symbolNames(result, 'Class')).toContain('active_users');
+    });
+
+    it('extracts CREATE FUNCTION as Function', async () => {
+      const path = writeFixture('ddl.sql', nl(
+        'CREATE FUNCTION add_one(x INT64) AS (x + 1)',
+      ));
+      const result = await parse(path);
+      expect(symbolNames(result, 'Function')).toContain('add_one');
+    });
+
+    it('extracts CREATE PROCEDURE as Function', async () => {
+      const path = writeFixture('ddl.sql', nl(
+        'CREATE PROCEDURE refresh_data()',
+        'BEGIN',
+        '  SELECT 1;',
+        'END;',
+      ));
+      const result = await parse(path);
+      expect(symbolNames(result, 'Function')).toContain('refresh_data');
+    });
+
+    it('extracts CREATE SCHEMA as Namespace', async () => {
+      const path = writeFixture('ddl.sql', nl(
+        'CREATE SCHEMA analytics',
+      ));
+      const result = await parse(path);
+      expect(symbolNames(result, 'Namespace')).toContain('analytics');
+    });
+
+    it('extracts multiple DDL statements in one file', async () => {
+      const path = writeFixture('ddl.sql', nl(
+        'CREATE TABLE customers (id INT64);',
+        'CREATE FUNCTION get_name(cid INT64) AS (',
+        '  SELECT name FROM customers WHERE id = cid',
+        ');',
+        'CREATE PROCEDURE cleanup() BEGIN END;',
+      ));
+      const result = await parse(path);
+      const classes = symbolNames(result, 'Class');
+      const functions = symbolNames(result, 'Function');
+      expect(classes).toContain('customers');
+      expect(functions).toContain('get_name');
+      expect(functions).toContain('cleanup');
+    });
+  });
+
+  describe('function call extraction', () => {
+    it('extracts function_call as call site', async () => {
+      const path = writeFixture('query.sql', nl(
+        'SELECT COUNT(*), SUM(amount) FROM orders',
+      ));
+      const result = await parse(path);
+      const calls = callSiteNames(result);
+      expect(calls).toContain('COUNT');
+      expect(calls).toContain('SUM');
+    });
+  });
+
+  describe('FROM clause references', () => {
+    it('extracts FROM clause tables as imports', async () => {
+      const path = writeFixture('query.sql', nl(
+        'SELECT * FROM orders',
+        'JOIN customers ON orders.cust_id = customers.id',
+      ));
+      const result = await parse(path);
+      const imports = importSources(result);
+      expect(imports).toContain('orders');
+      expect(imports).toContain('customers');
+    });
+  });
+
+  describe('error tolerance', () => {
+    it('handles invalid SQL gracefully', async () => {
+      const path = writeFixture('bad.sql', nl(
+        'CREATE TABLE;',
+      ));
+      const result = await parse(path);
+      // Tree-sitter may produce ERROR nodes but shouldn't crash
+      expect(result.language).toBe('bigquery');
+    });
+  });
+});

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -26,6 +26,7 @@ export const SUPPORTED_LANGUAGES = [
   'kotlin',
   'vue',
   'protobuf',
+  'bigquery',
 ] as const;
 
 export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];


### PR DESCRIPTION
Closes #940

## Summary
First SQL dialect support in Astrolabe via tree-sitter-sql-bigquery v0.8.0 grammar.

## Changes
- **WASM grammar**: \	ree-sitter-bigquery.wasm\ (7.4MB) compiled from upstream tree-sitter-sql-bigquery v0.8.0
- **Language definition** (\igquery.ts\): DDL symbol patterns (CREATE TABLE/VIEW/FUNCTION/PROCEDURE/SCHEMA/MODEL), function call patterns (CALLS edges), FROM clause table references
- **Registration**: \.sql\ and \.bqsql\ extensions mapped to BigQuery; registered in barrel export
- **Types**: \'bigquery'\ added to \SUPPORTED_LANGUAGES\

## Design decisions
- \.sql\ extension maps to BigQuery as first SQL dialect; future multi-dialect support needs heuristics or \--sql-dialect\ flag
- CREATE TABLE/VIEW/MATERIALIZED VIEW all share \create_table_statement\ node → all mapped to Class label
- Functions and procedures both mapped to Function label
- \rom_item\ table references treated as Import edges for cross-file linking
- \mroStrategy: 'none'\ — no method resolution order in SQL

## Grammar assessment
- 121/121 tests passing, 13 test corpora
- 115+ node types with comprehensive DDL/DML/DCL support
- Missing \locals.scm\ and \	ags.scm\ (not required for symbol extraction)