### PR TITLE
feat: add analyze, job_status, cancel_job MCP tools (#944)

### DIFF
--- a/packages/core/src/mcp/backend.ts
+++ b/packages/core/src/mcp/backend.ts
@@ -4,8 +4,10 @@
  * Extracted from server.ts for modularity (#838).
  */
 
-import { execFileSync } from 'node:child_process';
-import { statSync } from 'node:fs';
+import { execFileSync, fork } from 'node:child_process';
+import { statSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { resolve as pathResolve, join as pathJoin, basename } from 'node:path';
 import { createSqliteStore } from '../persist/sqlite.js';
 import { createFtsSearch } from '../search/fts.js';
 import type { SqliteStore } from '../persist/sqlite.js';
@@ -14,6 +16,7 @@ import type { GraphNode } from '../core/types.js';
 import { loadRegistry, findEntryWithSiblingWarning, type RegistryEntry } from './registry.js';
 import { listGroups } from './groups.js';
 import { EDGE_DECAY_FACTORS, applyDecay, noisyOr } from '../analysis/impact-decay.js';
+import { JobManager, type AnalyzeJob } from '../server/analyze-job.js';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -157,6 +160,7 @@ export class LocalBackend {
   private repos = new Map<string, RepoContext>();
   private maxConns = 5;
   private lastAccess = new Map<string, number>();
+  private jobManager = new JobManager();
 
   /**
    * Get the sibling clone warning for a given repo path.
@@ -979,7 +983,78 @@ export class LocalBackend {
     return { columns, rows, total_matched: currentIds.size, returned: rows.length };
   }
 
+  // ── #944: In-process analysis via MCP ────────────────────────────────
+
+  startAnalysis(repoPath: string): AnalyzeJob {
+    const repoName = basename(repoPath);
+    const job = this.jobManager.createJob({ repoPath, repoName });
+
+    if (job.status !== 'queued') return job;
+
+    this.jobManager.updateJob(job.id, {
+      status: 'analyzing',
+      progress: { phase: 'analyzing', percent: 0, message: 'Starting analysis...' },
+    });
+
+    const __filename = fileURLToPath(import.meta.url);
+    const cliDistPath = pathResolve(__filename, '..', '..', '..', 'cli', 'dist', 'index.js');
+    const workerPath = existsSync(cliDistPath) ? cliDistPath : process.argv[1] ?? cliDistPath;
+
+    const args = ['analyze', repoPath, '-o', pathJoin(repoPath, '.astrolabe', 'astrolabe.db')];
+    const child = fork(workerPath, args, { stdio: ['pipe', 'pipe', 'pipe', 'ipc'] });
+
+    this.jobManager.registerChild(job.id, child);
+
+    child.stderr?.on('data', (data: Buffer) => {
+      const text = data.toString('utf-8');
+      const phaseMatch = text.match(/(\w+)\s+(phase|complete)/i);
+      if (phaseMatch) {
+        this.jobManager.updateJob(job.id, {
+          progress: { phase: phaseMatch[1].toLowerCase(), percent: 50, message: text.trim().slice(0, 200) },
+        });
+      }
+    });
+
+    child.on('message', (msg: unknown) => {
+      const m = msg as { type?: string; phase?: string; percent?: number; message?: string };
+      if (m && m.type === 'progress' && m.phase !== undefined && m.percent !== undefined) {
+        this.jobManager.updateJob(job.id, {
+          progress: { phase: m.phase, percent: m.percent, message: m.message ?? '' },
+        });
+      }
+    });
+
+    child.on('exit', (code: number | null) => {
+      if (code === 0) {
+        this.jobManager.updateJob(job.id, {
+          status: 'complete',
+          progress: { phase: 'complete', percent: 100, message: 'Analysis complete' },
+        });
+      } else {
+        this.jobManager.updateJob(job.id, {
+          status: 'failed',
+          error: `Analysis exited with code ${code}`,
+        });
+      }
+    });
+
+    child.on('error', (err: Error) => {
+      this.jobManager.updateJob(job.id, { status: 'failed', error: err.message });
+    });
+
+    return job;
+  }
+
+  getJob(jobId: string): AnalyzeJob | undefined {
+    return this.jobManager.getJob(jobId);
+  }
+
+  cancelAnalysis(jobId: string): boolean {
+    return this.jobManager.cancelJob(jobId);
+  }
+
   shutdown(): void {
+    this.jobManager.dispose();
     for (const ctx of this.repos.values()) {
       ctx.store.close();
       ctx.fts.close();

--- a/packages/core/src/mcp/tools.ts
+++ b/packages/core/src/mcp/tools.ts
@@ -1996,6 +1996,99 @@ Returns snapshots filtered by date range, a trend summary (health direction, slo
       return { content: [{ type: 'text', text: JSON.stringify(output, null, 2) }] };
     },
   },
+
+  'astrolabe.analyze': {
+    name: 'astrolabe.analyze',
+    description: 'Start codebase analysis. Returns immediately with a job ID — use job_status to poll progress. Safe to call while query tools are active (WAL mode handles concurrent read/write).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        repo_path: { type: 'string', description: 'Absolute path to the repository to analyze' },
+      },
+      required: ['repo_path'],
+    },
+    handler: async (params) => {
+      const repoPath = requireString(params, 'repo_path');
+      try {
+        const job = backend.startAnalysis(repoPath);
+        const isDedup = job.status === 'analyzing';
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              job_id: job.id,
+              status: job.status,
+              message: isDedup
+                ? 'Analysis already in progress for this repository.'
+                : 'Analysis started. Use job_status with this job_id to poll progress.',
+            }),
+          }],
+        };
+      } catch (e) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: (e as Error).message }) }],
+          isError: true,
+        };
+      }
+    },
+  },
+
+  'astrolabe.job_status': {
+    name: 'astrolabe.job_status',
+    description: 'Check the status of an analysis job. Non-blocking.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        job_id: { type: 'string', description: 'Job ID from analyze tool' },
+      },
+      required: ['job_id'],
+    },
+    handler: async (params) => {
+      const jobId = requireString(params, 'job_id');
+      const job = backend.getJob(jobId);
+      if (!job) {
+        return { content: [{ type: 'text', text: JSON.stringify({ error: `Job ${jobId} not found` }) }] };
+      }
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            status: job.status,
+            phase: job.progress.phase,
+            percent: job.progress.percent,
+            message: job.progress.message,
+            error: job.error,
+            elapsed_ms: Date.now() - job.startedAt,
+          }),
+        }],
+      };
+    },
+  },
+
+  'astrolabe.cancel_job': {
+    name: 'astrolabe.cancel_job',
+    description: 'Cancel a running analysis job.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        job_id: { type: 'string' },
+      },
+      required: ['job_id'],
+    },
+    handler: async (params) => {
+      const jobId = requireString(params, 'job_id');
+      const cancelled = backend.cancelAnalysis(jobId);
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            cancelled,
+            message: cancelled ? `Job ${jobId} cancelled.` : `Job ${jobId} not found or already complete.`,
+          }),
+        }],
+      };
+    },
+  },
 };
 
 return TOOLS;

--- a/packages/core/tests/mcp/mcp-server.test.ts
+++ b/packages/core/tests/mcp/mcp-server.test.ts
@@ -172,7 +172,7 @@ describe('MCP Server E2E (#536)', () => {
       expect(toolNames).toContain('astrolabe.query');
       expect(toolNames).toContain('astrolabe.context');
       expect(toolNames).toContain('astrolabe.impact');
-      expect(toolNames.length).toBeGreaterThanOrEqual(7);
+      expect(toolNames.length).toBeGreaterThanOrEqual(10);
     });
 
     it('returns error for unknown method', async () => {


### PR DESCRIPTION
# Add analyze, job_status, cancel_job MCP tools (#944)

Closes #944

## Summary

Add 3 new MCP tools for in-process codebase indexing via the MCP server:

- **`astrolabe.analyze`** — Start analysis job (forks CLI, returns immediately)
- **`astrolabe.job_status`** — Poll analysis progress (non-blocking)
- **`astrolabe.cancel_job`** — Cancel running analysis

## Changes

| File | Change |
|------|--------|
| `packages/core/src/mcp/backend.ts` | Add `JobManager` instance, `startAnalysis()`, `getJob()`, `cancelAnalysis()`, `shutdown()` calls `jobManager.dispose()` |
| `packages/core/src/mcp/tools.ts` | Add 3 tool definitions |
| `packages/core/tests/mcp/mcp-server.test.ts` | Update tool count assertion |

## Implementation

Reuses existing `JobManager` from `server/analyze-job.ts` — the same infrastructure used by the HTTP server. Forks the CLI process for analysis (same pattern as `http-server.ts` lines 489-520).

Key properties:
- **Non-blocking**: Returns immediately with job ID
- **Same-repo dedup**: Returns existing running job for same repo path
- **Single-slot concurrency**: Rejects if another repo's analysis is running
- **Read tools work during analysis**: WAL mode + advisory lock only in CLI process
- **30-minute timeout**: Auto-cancel via `JobManager`
- **SIGTERM cancellation**: Via forked child process
