### PR TITLE
fix: analyze hangs indefinitely due to Map mutation during iteration (#951)

### DIFF
--- a/packages/core/src/analysis/phases/pattern-detection.ts
+++ b/packages/core/src/analysis/phases/pattern-detection.ts
@@ -151,10 +151,13 @@ export const patternDetectionPhase: PhaseDefinition<PatternDetectionOutput> = {
     const patternsByCategory: Record<string, number> = {};
     const filesWithPatternsSet = new Set<string>();
 
-    // Iterate over all cached trees using internal Map access
+    // Iterate over all cached trees using internal Map access.
+    // Snapshot keys into an array first — AstCache.get() triggers LRU refresh
+    // which reorders the Map, causing infinite iteration if we iterate keys() live.
     const cacheMap = (astCache as unknown as { cache: Map<string, unknown> }).cache;
+    const cachedPaths = Array.from(cacheMap.keys());
 
-    for (const absPath of cacheMap.keys()) {
+    for (const absPath of cachedPaths) {
       // Incremental filtering
       if (changedPaths && !changedPaths.has(absPath)) continue;
 

--- a/packages/core/tests/analysis/phases/pattern-detection.test.ts
+++ b/packages/core/tests/analysis/phases/pattern-detection.test.ts
@@ -86,7 +86,15 @@ function mockTsLangDef() {
     mroStrategy: 'c3' as const,
     symbolPatterns: [],
     importPatterns: [],
-    load: vi.fn(() => Promise.resolve({})),
+    load: vi.fn(() => Promise.resolve({
+      query: (pattern: string) => {
+        const qr = queryResults.get(pattern) ?? [];
+        return {
+          matches: () => qr,
+          delete: () => {},
+        };
+      },
+    })),
   };
 }
 


### PR DESCRIPTION
# Fix: analyze hangs indefinitely (#951)

Closes #951

## Root Cause

The `pattern-detection` phase iterated `AstCache.cache.keys()` while calling `astCache.get(absPath)` inside the loop body. `AstCache.get()` performs **LRU refresh** — it deletes and re-inserts the key in the internal `Map`, which causes the JavaScript `Map` iterator to re-visit the moved key **indefinitely**.

This is a classic JavaScript Map mutation-during-iteration bug. The iterator never advances past the first entry because the `get()` call moves it back to the end of the Map.

## Fix

Snapshot the keys into an array **before** iterating:

```typescript
// Before (BUG: infinite loop):
for (const absPath of cacheMap.keys()) {
  const entry = astCache.get(absPath); // ← mutates Map order!
  ...
}

// After (FIXED):
const cachedPaths = Array.from(cacheMap.keys());
for (const absPath of cachedPaths) {
  const entry = astCache.get(absPath); // ← Map order changed, but we already have our keys
  ...
}
```

## Verification

- Minimal 2-file test repo: analysis completes in <1 second (was: infinite hang)
- All 19 pipeline phases execute and complete successfully
